### PR TITLE
Added support for a builddep command

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@ Provides helpful definitions for dealing with Apt.
 
 ## Usage
 
+### apt:builddep
+Install the build depends of a specified package.
+<pre>
+apt::builddep { "glusterfs-server": }
+</pre>
+
 ### apt::force
 Force a package to be installed from a specific release.  Useful when using repositoires like Debian unstable in Ubuntu.
 <pre>

--- a/manifests/builddep.pp
+++ b/manifests/builddep.pp
@@ -1,0 +1,16 @@
+# builddep.pp
+
+define apt::builddep() {
+
+  Class['apt'] -> Apt::Ppa[$title]
+
+  exec { "apt-update-${name}":
+    command     => "/usr/bin/apt-get update",
+    refreshonly => true,
+  }
+
+  exec { "apt-builddep-${name}":
+    command     => "/usr/bin/apt-get -y --force-yes build-dep $name",
+    notify  => Exec["apt-update-${name}"],
+  }
+}

--- a/tests/builddep.pp
+++ b/tests/builddep.pp
@@ -1,0 +1,2 @@
+class { 'apt': }
+apt::builddep{ 'foo': }


### PR DESCRIPTION
Hi!

I'm using puppet to manage a bunch of elastic build hosts - so I frequently need to make sure all of the build depends for a package are installed. This adds the ability to do that.
