### PR TITLE
Check if python-software-properties is defined before attempting to define it.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,7 +26,9 @@ class apt(
     false => true
   }
 
-  package { "python-software-properties": }
+  if ! defined(Package["python-software-properties"]) {
+    package { "python-software-properties": }
+  }
 
   file { "sources.list":
     name => "${apt::params::root}/sources.list",


### PR DESCRIPTION
python-software-properties may be defined by other modules, causing Puppet to fail.  This adds a check to ensure we are not defining a package which was previously defined by another module.
