### PR TITLE
(#11953) Apt::force passes $version to aptitude

### DIFF
--- a/manifests/force.pp
+++ b/manifests/force.pp
@@ -6,7 +6,12 @@ define apt::force(
   $version = false
 ) {
 
-  exec { "/usr/bin/aptitude -y -t ${release} install ${name}":
+  $version_string = $version ? {
+    false => undef,
+    default => "=${version}",
+  }
+
+  exec { "/usr/bin/aptitude -y -t ${release} install ${name}${version_string}":
     unless => $version ? {
       false => "/usr/bin/dpkg -s ${name} | grep -q 'Status: install'",
       default => "/usr/bin/dpkg -s ${name} | grep -q 'Version: ${version}'"

--- a/spec/defines/force_spec.rb
+++ b/spec/defines/force_spec.rb
@@ -15,7 +15,8 @@ describe 'apt::force', :type => :define do
         base_command + (version ? "'Version: #{params[:version]}'" : "'Status: install'")
       end
       let :exec_title do
-        "/usr/bin/aptitude -y -t #{params[:release]} install #{title}"
+        base_exec = "/usr/bin/aptitude -y -t #{params[:release]} install #{title}"
+        base_exec + (version ? "=#{version}" : "")
       end
       it { should contain_exec(exec_title).with_unless(unless_query) }
     end


### PR DESCRIPTION
Previously, even if $version were passed to apt::force, aptitude would just
install the default version of the package available. This updates the aptitude
call to use the version string if it exists. If no version is passed, or if it
is false, no version is added to the aptitude call.  This also updates the
rspec-puppet tests for the define, to reflect the changes to the exec.
