### PR TITLE
Only call apt-get update once per puppet run

### DIFF
--- a/manifests/builddep.pp
+++ b/manifests/builddep.pp
@@ -1,16 +1,12 @@
 # builddep.pp
 
 define apt::builddep() {
+  include apt::update
 
   Class['apt'] -> Apt::Builddep[$name]
 
-  exec { "apt-update-${name}":
-    command     => "/usr/bin/apt-get update",
-    refreshonly => true,
-  }
-
   exec { "apt-builddep-${name}":
     command     => "/usr/bin/apt-get -y --force-yes build-dep $name",
-    notify      => Exec["apt-update-${name}"],
+    notify      => Exec["apt update"],
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,33 +21,31 @@ class apt(
 
   include apt::params
 
-  $refresh_only_apt_update = $always_apt_update? {
-    true => false,
-    false => true
+  if $always_apt_update == true {
+    include apt::update::always
+  } else {
+    include apt::update
   }
 
   package { "python-software-properties": }
 
   file { "sources.list":
-    name => "${apt::params::root}/sources.list",
+    name   => "${apt::params::root}/sources.list",
     ensure => present,
-    owner => root,
-    group => root,
-    mode => 644,
+    owner  => root,
+    group  => root,
+    mode   => 644,
+    notify => Exec['apt update'],
   }
 
   file { "sources.list.d":
-    name => "${apt::params::root}/sources.list.d",
+    name   => "${apt::params::root}/sources.list.d",
     ensure => directory,
-    owner => root,
-    group => root,
+    owner  => root,
+    group  => root,
+    notify => Exec['apt update'],
   }
 
-  exec { "apt_update":
-    command => "${apt::params::provider} update",
-    subscribe => [ File["sources.list"], File["sources.list.d"] ],
-    refreshonly => $refresh_only_apt_update,
-  }
   if($disable_keys) {
     exec { 'make-apt-insecure':
       command => '/bin/echo "APT::Get::AllowUnauthenticated 1;" >> /etc/apt/apt.conf.d/99unauth',

--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -14,25 +14,20 @@ define apt::source(
 ) {
 
   include apt::params
-
+  include apt::update
 
   file { "${name}.list":
-    name => "${apt::params::root}/sources.list.d/${name}.list",
-    ensure => file,
-    owner => root,
-    group => root,
-    mode => 644,
+    name    => "${apt::params::root}/sources.list.d/${name}.list",
+    ensure  => file,
+    owner   => root,
+    group   => root,
+    mode    => 644,
     content => template("apt/source.list.erb"),
+    notify  => Exec['apt update'],
   }
 
   if $pin != false {
     apt::pin { "${release}": priority => "${pin}" } -> File["${name}.list"]
-  }
-
-  exec { "${name} apt update":
-    command => "${apt::params::provider} update",
-    subscribe => File["${name}.list"],
-    refreshonly => true,
   }
 
   if $required_packages != false {

--- a/manifests/update.pp
+++ b/manifests/update.pp
@@ -1,0 +1,8 @@
+class apt::update {
+  include apt::params
+
+  exec { 'apt update':
+    command     => "${apt::params::provider} update",
+    refreshonly => true,
+  }
+}

--- a/manifests/update/always.pp
+++ b/manifests/update/always.pp
@@ -1,0 +1,5 @@
+class apt::update::always inherits apt::update {
+  Exec['apt update'] {
+    refreshonly => false,
+  }
+}


### PR DESCRIPTION
Change things around so that there's a single Exec[apt update] resource that just gets notified as needed.

https://projects.puppetlabs.com/issues/11966
