### PR TITLE
(#12529) Add parameter to support setting a proxy for apt

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,7 +16,9 @@
 #  class { 'apt': }
 class apt(
   $disable_keys = false,
-  $always_apt_update = false
+  $always_apt_update = false,
+  $proxy_host = false,
+  $proxy_port = '8080'
 ) {
 
   include apt::params
@@ -52,6 +54,13 @@ class apt(
     exec { 'make-apt-insecure':
       command => '/bin/echo "APT::Get::AllowUnauthenticated 1;" >> /etc/apt/apt.conf.d/99unauth',
       creates => '/etc/apt/apt.conf.d/99unauth'
+    }
+  }
+
+  if($proxy_host) {
+    file { 'configure-apt-proxy':
+      path    => '/etc/apt/apt.conf.d/proxy',
+      content => "Acquire::http::Proxy \"http://${proxy_host}:${proxy_port}\";",
     }
   }
 }

--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -15,7 +15,6 @@ define apt::source(
 
   include apt::params
 
-
   file { "${name}.list":
     path => "${apt::params::root}/sources.list.d/${name}.list",
     ensure => file,
@@ -23,6 +22,7 @@ define apt::source(
     group => root,
     mode => 644,
     content => template("apt/source.list.erb"),
+
   }
 
   if $pin != false {


### PR DESCRIPTION
This commit adds two class parameter to apt that can be used to
specify a proxy to use with apt.
- proxy_host
- proxy_port
