### PR TITLE
(#12522) Apt module should have a purge option

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,11 +15,18 @@
 # Sample Usage:
 #  class { 'apt': }
 class apt(
+  $always_apt_update = false,
   $disable_keys = false,
-  $always_apt_update = false
+  $purge = false
 ) {
 
   include apt::params
+
+  # Validate parameters
+  case $purge {
+    true, false: { }                                     # valid
+    default: { fail("purge parameter must be Boolean") } # invalid
+  }
 
   $refresh_only_apt_update = $always_apt_update? {
     true => false,
@@ -34,6 +41,10 @@ class apt(
     owner => root,
     group => root,
     mode => 644,
+    content => $purge ? {
+      false =>  undef,
+      true  => "# Repos managed by puppet.\n",
+    },
   }
 
   file { "sources.list.d":
@@ -41,6 +52,8 @@ class apt(
     ensure => directory,
     owner => root,
     group => root,
+    purge => $purge,
+    recurse => $purge,
   }
 
   exec { "apt_update":

--- a/spec/classes/apt_spec.rb
+++ b/spec/classes/apt_spec.rb
@@ -3,14 +3,16 @@ describe 'apt', :type => :class do
   let :default_params do
     {
       :disable_keys => false,
-      :always_apt_update => false
+      :always_apt_update => false,
+      :purge => false
     }
   end
 
   [{},
    {
       :disable_keys => true,
-      :always_apt_update => true
+      :always_apt_update => true,
+      :purge => true 
     }
   ].each do |param_set|
     describe "when #{param_set == {} ? "using default" : "specifying"} class parameters" do
@@ -35,22 +37,46 @@ describe 'apt', :type => :class do
       it { should contain_package("python-software-properties") }
 
       it {
+        if param_hash[:purge]
         should contain_file("sources.list").with({
-          'path'    => "/etc/apt/sources.list",
-          'ensure'  => "present",
-          'owner'   => "root",
-          'group'   => "root",
-          'mode'    => 644
-        })
+            'path'    => "/etc/apt/sources.list",
+            'ensure'  => "present",
+            'owner'   => "root",
+            'group'   => "root",
+            'mode'    => 644,
+            "content" => "# Repos managed by puppet.\n" 
+          })
+        else
+        should contain_file("sources.list").with({
+            'path'    => "/etc/apt/sources.list",
+            'ensure'  => "present",
+            'owner'   => "root",
+            'group'   => "root",
+            'mode'    => 644,
+            'content' => nil
+          })
+        end
       }
-
       it {
-        should create_file("sources.list.d").with({
-          "path"    => "/etc/apt/sources.list.d",
-          "ensure"  => "directory",
-          "owner"   => "root",
-          "group"   => "root"
-        })
+        if param_hash[:purge]
+          should create_file("sources.list.d").with({
+            'path'    => "/etc/apt/sources.list.d",
+            'ensure'  => "directory",
+            'owner'   => "root",
+            'group'   => "root",
+            'purge'   => true,
+            'recurse' => true
+          })
+        else
+          should create_file("sources.list.d").with({
+            'path'    => "/etc/apt/sources.list.d",
+            'ensure'  => "directory",
+            'owner'   => "root",
+            'group'   => "root",
+            'purge'   => false,
+            'recurse' => false
+          })
+        end
       }
 
       it {


### PR DESCRIPTION
This commit introduces a purge option for the apt class. When purge is true, the contents of /etc/apt/sources.list are removed and unmanaged repos are removed from /etc/apt/sources.list.d.
