### PR TITLE
Fix README.md markdown syntax error

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ apt::source { "debian_unstable":
   key_server        => "subkeys.pgp.net",
   pin               => "-10",
   include_src       => true
+}
+</pre>
 
 ### apt::key
 Add a key to the list of keys used by apt to authenticate packages.
@@ -71,6 +73,3 @@ apt::key { "jenkins":
 </pre>
 
 Note that use of the "key_source" parameter requires wget to be installed and working.
-
-}
-</pre>


### PR DESCRIPTION
I butchered a </pre> inadvertantly when I updated the file to include
reference to apt::key. This commit fixes the butchery.
