### PR TITLE
Modify apt::source release verification to work correctly with puppet-rspec

### DIFF
--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -16,7 +16,7 @@ define apt::source(
 
   include apt::params
 
-  if ! $release {
+  if $release == undef {
     fail("lsbdistcodename fact not available: release parameter required")
   }
 
@@ -27,7 +27,6 @@ define apt::source(
     group => root,
     mode => 644,
     content => template("apt/source.list.erb"),
-
   }
 
   if $pin != false {

--- a/spec/defines/source_spec.rb
+++ b/spec/defines/source_spec.rb
@@ -136,8 +136,11 @@ describe 'apt::source', :type => :define do
       }
     end
   end
-    describe "without release should raise a Puppet::Error" do
-      it { expect { should contain_apt__source(:release) }.to raise_error(Puppet::Error) }
-    end
+  describe "without release should raise a Puppet::Error" do
+    let(:default_params) { Hash.new }
+    let(:facts) { Hash.new }
+    it { expect { should raise_error(Puppet::Error) } }
+    let(:facts) { { :lsbdistcodename => 'lucid' } }
+    it { should contain_apt__source(title) }
+  end
 end
-


### PR DESCRIPTION
This pull request modifies the release parameter test in apt::source to work correctly within puppet-rspec for edge-case resource definitions. Previously, the test for the $release parameter was written as

``` puppet
if ! $release { fail() }
```

This pull request updates the test to be written as

``` puppet
if $release == undef { fail() }
```

Additionally, the tests for correct behavior in the presence or absence of a $release parameter have been beefed up.

The reason for making this change relates to examples such as the following resource definition:

``` puppet
apt::source { "jenkins":
  location    => "http://pkg.jenkins-ci.org/debian",
  release     => "",
  repos       => "binary/",
  key         => "D50582E6",
  key_source  => "http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key",
  include_src => false,
}
```

Note that the $release parameter is given as the empty string. In practice, this is perfectly valid and everything will work great. However, it seems that the empty string gets interpreted by something in puppet-rspec as something equivalent to "False", and thus when testing, the above resource definition would fail with "Puppet::Error: lsbdistcodename fact not available: release parameter required" even though the $release parameter has been explicitly specified (as the empty string).

See also: [rtyler/puppet-jenkins/issues/9](https://github.com/rtyler/puppet-jenkins/issues/9)
