### PR TITLE
(#13016) Add a CHANGELOG since first commit

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,53 @@
+2012-03-07 Puppet Labs <info@puppetlabs.com> - 0.0.1
+d4fec56 Modify apt::source release parameter test
+1132a07 (#12917) Add contributors to README
+8cdaf85 (#12823) Add apt::key defined type and modify apt::source to use it
+7c0d10b (#12809) $release should use $lsbdistcodename and fall back to manual input
+be2cc3e (#12522) Adjust spec test for splitting purge
+7dc60ae (#12522) Split purge option to spare sources.list
+9059c4e Fix source specs to test all key permutations
+8acb202 Add test for python-software-properties package
+a4af11f Check if python-software-properties is defined before attempting to define it.
+1dcbf3d Add tests for required_packages change
+f3735d2 Allow duplicate $required_packages
+74c8371 (#12430) Add tests for changes to apt module
+97ebb2d Test two sources with the same key
+1160bcd (#12526) Add ability to reverse apt { disable_keys => true }
+2842d73 Add Modulefile to puppet-apt
+c657742 Allow the use of the same key in multiple sources
+8c27963 (#12522) Adding purge option to apt class
+997c9fd (#12529) Add unit test for apt proxy settings
+50f3cca (#12529) Add parameter to support setting a proxy for apt
+d522877 (#12094) Replace chained .with_* with a hash
+8cf1bd0 (#12094) Remove deprecated spec.opts file
+2d688f4 (#12094) Add rspec-puppet tests for apt
+0fb5f78 (#12094) Replace name with path in file resources
+f759bc0 (#11953) Apt::force passes $version to aptitude
+f71db53 (#11413) Add spec test for apt::force to verify changes to unless
+2f5d317 (#11413) Update dpkg query used by apt::force
+cf6caa1 (#10451) Add test coverage to apt::ppa
+0dd697d include_src parameter in example; Whitespace cleanup
+b662eb8 fix typos in "repositories"
+1be7457 Fix (#10451) - apt::ppa fails to "apt-get update" when new PPA source is added
+864302a Set the pin priority before adding the source (Fix #10449)
+1de4e0a Refactored as per mlitteken
+1af9a13 Added some crazy bash madness to check if the ppa is installed already. Otherwise the manifest tries to add it on every run!
+52ca73e (#8720) Replace Apt::Ppa with Apt::Builddep
+5c05fa0 added builddep command.
+a11af50 added the ability to specify the content of a key
+c42db0f Fixes ppa test.
+77d2b0d reformatted whitespace to match recommended style of 2 space indentation.
+27ebdfc ignore swap files.
+377d58a added smoke tests for module.
+18f614b reformatted apt::ppa according to recommended style.
+d8a1e4e Created a params class to hold global data.
+636ae85 Added two params for apt class
+148fc73 Update LICENSE.
+ed2d19e Support ability to add more than one PPA
+420d537 Add call to apt-update after add-apt-repository in apt::ppa
+945be77 Add package definition for python-software-properties
+71fc425 Abs paths for all commands
+9d51cd1 Adding LICENSE
+71796e3 Heading fix in README
+87777d8 Typo in README
+f848bac First commit


### PR DESCRIPTION
In preparation for a Forge release, it's appropriate to include a rudimentary CHANGELOG from git commit logs. 
