### PR TITLE
(#13125) Apt keys should be case insensitive

### DIFF
--- a/spec/defines/key_spec.rb
+++ b/spec/defines/key_spec.rb
@@ -30,7 +30,9 @@ describe 'apt::key', :type => :define do
   ].each do |param_set|
 
     let :param_hash do
-      default_params.merge(param_set)
+      param_hash = default_params.merge(param_set)
+      param_hash[:key].upcase! if param_hash[:key]
+      param_hash
     end
 
     let :params do


### PR DESCRIPTION
Previously lowercase keys would be installed every
puppet run because apt-key list returns an uppercase
key. This commit makes the comparison case insensitive.
