### PR TITLE
Modify apt::source to update only new/modified source

### DIFF
--- a/manifests/ppa.pp
+++ b/manifests/ppa.pp
@@ -12,23 +12,34 @@ define apt::ppa(
     fail('lsbdistcodename fact not available: release parameter required')
   }
 
-  exec { "apt-update-${name}":
-    command     => '/usr/bin/aptitude update',
+  $filename_without_slashes = regsubst($name,'/','-','G')
+  $filename_without_ppa     = regsubst($filename_without_slashes, '^ppa:','','G')
+  $sources_list_d_filename  = "${filename_without_ppa}-${release}.list"
+  $sourcelist_path = "${apt::params::sources_list_d}/${sources_list_d_filename}"
+  $update_options  = join([
+    "-o Dir::Etc::SourceList=${sourcelist_path}",
+    '-o Dir::Etc::SourceParts=/dev/null',
+    '--no-list-cleanup',
+    ], ' ')
+
+  exec { "apt::ppa ${name} apt_update":
+    command     => "${apt::params::provider} update ${update_options}",
     refreshonly => true,
   }
 
-  $filename_without_slashes = regsubst($name,'/','-','G')
-  $filename_without_ppa = regsubst($filename_without_slashes, '^ppa:','','G')
-  $sources_list_d_filename = "${filename_without_ppa}-${release}.list"
-
   exec { "add-apt-repository-${name}":
     command => "/usr/bin/add-apt-repository ${name}",
-    notify  => Exec["apt-update-${name}"],
+    notify  => Exec["apt::ppa ${name} apt_update"],
     creates => "${apt::params::sources_list_d}/${sources_list_d_filename}",
   }
 
   file { "${apt::params::sources_list_d}/${sources_list_d_filename}":
     ensure  => file,
+    require => Exec["add-apt-repository-${name}"];
+  }
+
+  file { "${apt::params::sources_list_d}/${sources_list_d_filename}.save":
+    ensure  => absent,
     require => Exec["add-apt-repository-${name}"];
   }
 

--- a/spec/defines/ppa_spec.rb
+++ b/spec/defines/ppa_spec.rb
@@ -17,16 +17,23 @@ describe 'apt::ppa', :type => :define do
       let :filename do
         t.sub(/^ppa:/,'').gsub('/','-') << "-" << "#{release}.list"
       end
+      let :update_options do
+        [
+          "-o Dir::Etc::SourceList=/etc/apt/sources.list.d/#{filename}",
+          '-o Dir::Etc::SourceParts=/dev/null',
+          '--no-list-cleanup',
+        ].join(' ')
+      end
 
-      it { should contain_exec("apt-update-#{t}").with(
-        'command'     => '/usr/bin/aptitude update',
+      it { should contain_exec("apt::ppa #{t} apt_update").with(
+        'command'     => "/usr/bin/apt-get update #{update_options}",
         'refreshonly' => true
         )
       }
 
       it { should contain_exec("add-apt-repository-#{t}").with(
         'command' => "/usr/bin/add-apt-repository #{t}",
-        'notify'  => "Exec[apt-update-#{t}]",
+        'notify'  => "Exec[apt::ppa #{t} apt_update]",
         'creates' => "/etc/apt/sources.list.d/#{filename}"
         )
       }

--- a/spec/defines/source_spec.rb
+++ b/spec/defines/source_spec.rb
@@ -54,6 +54,14 @@ describe 'apt::source', :type => :define do
         "/etc/apt/sources.list.d/#{title}.list"
       end
 
+      let :update_options do
+        [
+          "-o Dir::Etc::SourceList=#{filename}",
+          '-o Dir::Etc::SourceParts=/dev/null',
+          '--no-list-cleanup',
+        ].join(' ')
+      end
+
       let :content do
         content = "# #{title}"
         content << "\ndeb #{param_hash[:location]} #{param_hash[:release]} #{param_hash[:repos]}\n"
@@ -66,12 +74,12 @@ describe 'apt::source', :type => :define do
       it { should contain_apt__params }
 
       it { should contain_file("#{title}.list").with({
-          'ensure'    => 'file',
-          'path'      => filename,
-          'owner'     => 'root',
-          'group'     => 'root',
-          'mode'      => '0644',
-          'content'   => content,
+          'ensure'  => 'file',
+          'path'    => filename,
+          'owner'   => 'root',
+          'group'   => 'root',
+          'mode'    => '0644',
+          'content' => content,
         })
       }
 
@@ -91,7 +99,7 @@ describe 'apt::source', :type => :define do
 
       it {
         should contain_exec("#{title} apt update").with({
-          "command"     => "/usr/bin/apt-get update",
+          "command"     => "/usr/bin/apt-get update #{update_options}",
           "subscribe"   => "File[#{title}.list]",
           "refreshonly" => true
         })


### PR DESCRIPTION
Previously, apt::source would run a full `apt-get update` for every resource defined. This commit modifies the `apt-get update` exec created by each apt::source to run an update against not all sources, but only the specific source that the apt::source resource has defined. It achieves this by setting the Dir::Etc::sourcelist and Dir::Etc::SourceParts options when invoking apt-get, along with --no-list-cleanup.

This mitigates the problem of every apt::source running a full `apt-get update` against all sources, but it may not be the "best" solution. Bigger picture might merit re-opening discussion about the points brought up in [puppetlabs/puppet-apt/pull/13](https://github.com/puppetlabs/puppet-apt/pull/13) "Only call apt-get update once per puppet run" and making a decision one way or the other.

This pull request does not yet modify apt::ppa with the same options to `apt-get update`. I might add another commit later.

**Edit**: apt::ppa commit added.
