### PR TITLE
Move Package['python-software-properties'] to apt:ppa

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -37,10 +37,6 @@ class apt(
     false => true,
   }
 
-  if ! defined(Package['python-software-properties']) {
-    package { 'python-software-properties': }
-  }
-
   $sources_list_content = $purge_sources_list ? {
     false =>  undef,
     true  => "# Repos managed by puppet.\n",

--- a/spec/classes/apt_spec.rb
+++ b/spec/classes/apt_spec.rb
@@ -41,8 +41,6 @@ describe 'apt', :type => :class do
 
       it { should include_class("apt::params") }
 
-      it { should contain_package("python-software-properties") }
-
       it {
         if param_hash[:purge_sources_list]
         should contain_file("sources.list").with({
@@ -125,10 +123,5 @@ describe 'apt', :type => :class do
         }
       end
     end
-  end
-
-  describe "it should not error if package['python-software-properties'] is already defined" do
-    let(:pre_condition) { 'package { "python-software-properties": }->Class["Apt"]' }
-    it { should contain_package("python-software-properties") }
   end
 end

--- a/spec/defines/ppa_spec.rb
+++ b/spec/defines/ppa_spec.rb
@@ -18,16 +18,19 @@ describe 'apt::ppa', :type => :define do
         t.sub(/^ppa:/,'').gsub('/','-') << "-" << "#{release}.list"
       end
 
+      it { should contain_package("python-software-properties") }
+
       it { should contain_exec("apt-update-#{t}").with(
-        'command'     => '/usr/bin/aptitude update',
+        'command'     => '/usr/bin/apt-get update',
         'refreshonly' => true
         )
       }
 
       it { should contain_exec("add-apt-repository-#{t}").with(
         'command' => "/usr/bin/add-apt-repository #{t}",
-        'notify'  => "Exec[apt-update-#{t}]",
-        'creates' => "/etc/apt/sources.list.d/#{filename}"
+        'creates' => "/etc/apt/sources.list.d/#{filename}",
+        'require' => "Package[python-software-properties]",
+        'notify'  => "Exec[apt-update-#{t}]"
         )
       }
 
@@ -37,6 +40,19 @@ describe 'apt::ppa', :type => :define do
         )
       }
     end
+  end
+
+  describe "it should not error if package['python-software-properties'] is already defined" do
+    let :pre_condition do
+       'class {"apt": }' +
+       'package { "python-software-properties": }->Apt::Ppa["ppa"]'
+    end
+    let :facts do
+      {:lsbdistcodename => 'natty'}
+    end
+    let(:title) { "ppa" }
+    let(:release) { "natty" }
+    it { should contain_package("python-software-properties") }
   end
 
   describe "without Class[apt] should raise a Puppet::Error" do
@@ -49,5 +65,4 @@ describe 'apt::ppa', :type => :define do
     let(:title) { "ppa:" }
     it { expect { should contain_apt__ppa(:release) }.to raise_error(Puppet::Error) }
   end
-
 end


### PR DESCRIPTION
python-software-properties is only needed by apt::ppa, not any of the other puppet-apt types or classes, so let's move it to apt:ppa, so it only gets installed if needed.

This also allows dependencies like this one, where the apt-proxy, sources.list et al., and the apt-get update, are guaranteed to be set/have run prior to installing the package:

```
class { 'apt':
   # set proxy or whatever other option here
}
apt::ppa { 'ppa:...':
   require => Class['apt']
}
```

Also updates the apt-update in Apt::Ppa to use $apt::params::provider instead of aptitude.
