### PR TITLE
Make sure we configure the proxy before doing apt-get update.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -87,10 +87,11 @@ class apt(
     default: { fail('Valid values for disable_keys are true or false') }
   }
 
-  if($proxy_host) {
+  if ($proxy_host) {
     file { 'configure-apt-proxy':
       path    => '/etc/apt/apt.conf.d/proxy',
       content => "Acquire::http::Proxy \"http://${proxy_host}:${proxy_port}\";",
+      notify  => Exec['apt_update'],
     }
   }
 }

--- a/spec/classes/apt_spec.rb
+++ b/spec/classes/apt_spec.rb
@@ -117,7 +117,8 @@ describe 'apt', :type => :class do
           if param_hash[:proxy_host]
             should contain_file('configure-apt-proxy').with(
               'path'    => '/etc/apt/apt.conf.d/proxy',
-              'content' => "Acquire::http::Proxy \"http://#{param_hash[:proxy_host]}:#{param_hash[:proxy_port]}\";"
+              'content' => "Acquire::http::Proxy \"http://#{param_hash[:proxy_host]}:#{param_hash[:proxy_port]}\";",
+              'notify'  => "Exec[apt_update]"
             )
           else
             should_not contain_file('configure_apt_proxy')


### PR DESCRIPTION
In the case your machine can't access the internet except through a proxy, you want it to be set before you do the apt-get update!

I used a `notify` dependency just in case you forgot to set the proxy in the first place (or mistyped it) and thus had the apt-get update failing. Without the `notify`, the apt-get update wouldn't get executed after you fix the proxy issue, as the sources.list and sources.list.d would have been set in the first (failing) run (I mean, unless you use `always_apt_update`, but that's another story).

I didn't set a dependency on the python-software-properties package because:
1. I believe it should be moved to `apt::ppa` (see #40)
2. you'll probably have something like this defined: `Class['apt'] -> Package <| |>` which would then guarantee the apt-get update will be executed before you install any package
