### PR TITLE
Ability to remove apt repository from sources.list.d

### DIFF
--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -36,10 +36,6 @@ define apt::source(
       file { "${name}.list":
         ensure  => absent,
         path    => "${apt::params::root}/sources.list.d/${name}.list",
-        owner   => root,
-        group   => root,
-        mode    => '0644',
-        content => template("${module_name}/source.list.erb"),
       }
     }
     default: { fail "Invalid 'ensure' value '${ensure}' for apt::source" }


### PR DESCRIPTION
With this commit apt:source can be removed from server by setting ensure parameter:
apt::source { 'custom_repo':
  ensure => absent,
  ...
}
