### PR TITLE
(#14138) Modify apt::ppa's update-apt exec to use the ${apt::params::provider} parameter.

### DIFF
--- a/manifests/ppa.pp
+++ b/manifests/ppa.pp
@@ -13,7 +13,7 @@ define apt::ppa(
   }
 
   exec { "apt-update-${name}":
-    command     => '/usr/bin/aptitude update',
+    command     => "${apt::params::provider} update",
     refreshonly => true,
   }
 


### PR DESCRIPTION
Previously the update-apt exec would always use /usr/bin/aptitude, which is not necessarily present. This change makes it use ${apt::params::provider} which defaults to /usr/bin/apt-get. This also adds some consistency so that ${apt::params::provider} is used everywhere.
