### PR TITLE
(#14287) Fix apt::pin resource for rspec-puppet.

### DIFF
--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -30,7 +30,10 @@ define apt::source(
   }
 
   if $pin != false {
-    apt::pin { $release: priority => $pin } -> File["${name}.list"]
+    apt::pin { $release:
+      priority => $pin,
+      before   => File["${name}.list"]
+    }
   }
 
   exec { "${name} apt update":


### PR DESCRIPTION
The shorthand syntax cause rspec-puppet failure for external modules
depending on the puppet-apt module. This patch uses the require
metaparameter to avoid this issue.
