### PR TITLE
(#14299) Resolve Modulefile name mismatch.

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,9 +1,9 @@
-name    'puppet-apt'
+name    'puppetlabs-apt'
 version '0.0.2'
-source 'https://github.com/puppetlabs/puppet-apt'
-author 'Evolving Web / Puppet Labs'
+source  'https://github.com/puppetlabs/puppet-apt'
+author  'Evolving Web / Puppet Labs'
 license 'Apache License 2.0'
-summary 'Apt Module for Puppet'
+summary 'Puppet Labs Apt Module'
 description 'APT Module for Puppet'
 project_page 'https://github.com/puppetlabs/puppet-apt'
 


### PR DESCRIPTION
The modulefile name is puppet-apt, but the module is released to forge
under puppetlabs. This causes a dependency confusion for puppet module
tool, which has been fixed by this patch.

Previous:

```
$ puppet module list
~/.puppet/modules
├── puppet-apt (v0.0.2)
├── puppetlabs-mongrodb (v0.0.1)
└── puppetlabs-stdlib (v2.3.1)
```

Now:

```
$ puppet module list
~/.puppet/modules
├── puppetlabs-apt (v0.0.2)
├── puppetlabs-mongrodb (v0.0.1)
└── puppetlabs-stdlib (v2.3.1)
```
