### PR TITLE
(#14308) Add ensure=>absent for define resource.

### DIFF
--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -1,4 +1,5 @@
 define apt::conf (
+  $ensure   = present,
   $priority = '50',
   $content
 ) {
@@ -8,7 +9,7 @@ define apt::conf (
   $apt_conf_d = $apt::params::apt_conf_d
 
   file { "${apt_conf_d}/${priority}${name}":
-    ensure  => file,
+    ensure  => $ensure,
     content => $content,
     owner   => root,
     group   => root,

--- a/manifests/pin.pp
+++ b/manifests/pin.pp
@@ -2,6 +2,7 @@
 # pin a release in apt, useful for unstable repositories
 
 define apt::pin(
+  $ensure   = present,
   $packages = '*',
   $priority = 0
 ) {
@@ -11,7 +12,7 @@ define apt::pin(
   $preferences_d = $apt::params::preferences_d
 
   file { "${name}.pref":
-    ensure  => file,
+    ensure  => $ensure,
     path    => "${preferences_d}/${name}",
     owner   => root,
     group   => root,

--- a/spec/defines/conf_spec.rb
+++ b/spec/defines/conf_spec.rb
@@ -23,12 +23,35 @@ describe 'apt::conf', :type => :define do
     }
 
     it { should contain_file(filename).with({
-          'ensure'    => 'file',
+          'ensure'    => 'present',
           'content'   => "Apt::Install-Recommends 0;\nApt::AutoRemove::InstallRecommends 1;\n",
           'owner'     => 'root',
           'group'     => 'root',
           'mode'      => '0644',
         })
       }
+  end
+
+  describe "when removing an apt preference" do
+    let :params do
+      {
+        :ensure   => 'absent',
+        :priority => '00',
+        :content  => "Apt::Install-Recommends 0;\nApt::AutoRemove::InstallRecommends 1;\n"
+      }
+    end
+
+    let :filename do
+      "/etc/apt/apt.conf.d/00norecommends"
+    end
+
+    it { should contain_file(filename).with({
+        'ensure'    => 'absent',
+        'content'   => "Apt::Install-Recommends 0;\nApt::AutoRemove::InstallRecommends 1;\n",
+        'owner'     => 'root',
+        'group'     => 'root',
+        'mode'      => '0644',
+      })
+    }
   end
 end

--- a/spec/defines/pin_spec.rb
+++ b/spec/defines/pin_spec.rb
@@ -4,13 +4,19 @@ describe 'apt::pin', :type => :define do
 
   let :default_params do
     {
+      :ensure   => 'present',
       :packages => '*',
       :priority => '0'
     }
   end
 
-  [{},
-   {
+  [ {},
+    {
+      :packages  => 'apache',
+      :priority  => '1'
+    },
+    {
+      :ensure    => 'absent',
       :packages  => 'apache',
       :priority  => '1'
     }
@@ -27,7 +33,7 @@ describe 'apt::pin', :type => :define do
       it { should include_class("apt::params") }
 
       it { should contain_file("#{title}.pref").with({
-          'ensure'  => 'file',
+          'ensure'  => param_hash[:ensure],
           'path'    => "/etc/apt/preferences.d/#{title}",
           'owner'   => 'root',
           'group'   => 'root',

--- a/spec/defines/source_spec.rb
+++ b/spec/defines/source_spec.rb
@@ -6,6 +6,7 @@ describe 'apt::source', :type => :define do
 
   let :default_params do
     {
+      :ensure             => 'present',
       :location           => '',
       :release            => 'karmic',
       :repos              => 'main',
@@ -35,6 +36,12 @@ describe 'apt::source', :type => :define do
       :key                => 'key_name',
       :key_server         => 'keyserver.debian.com',
       :key_content        => false,
+    },
+    {
+      :ensure             => 'absent',
+      :location           => 'somewhere',
+      :release            => 'precise',
+      :repos              => 'security',
     }
   ].each do |param_set|
     describe "when #{param_set == {} ? "using default" : "specifying"} class parameters" do
@@ -66,7 +73,7 @@ describe 'apt::source', :type => :define do
       it { should contain_apt__params }
 
       it { should contain_file("#{title}.list").with({
-          'ensure'    => 'file',
+          'ensure'    => param_hash[:ensure],
           'path'      => filename,
           'owner'     => 'root',
           'group'     => 'root',


### PR DESCRIPTION
Several apt::\* define resource type does not support ensurable. This
update allows ensure=>absent to support the removal of these
configuration files.
- apt::conf
- apt::pin
- apt::source
