### PR TITLE
(#14321) apt::pin resource support release.

### DIFF
--- a/manifests/pin.pp
+++ b/manifests/pin.pp
@@ -5,7 +5,7 @@ define apt::pin(
   $ensure   = present,
   $packages = '*',
   $priority = 0,
-  $release = "${name}"
+  $release  = $name
 ) {
 
   include apt::params

--- a/spec/defines/pin_spec.rb
+++ b/spec/defines/pin_spec.rb
@@ -6,7 +6,8 @@ describe 'apt::pin', :type => :define do
     {
       :ensure   => 'present',
       :packages => '*',
-      :priority => '0'
+      :priority => '0',
+      :release  => nil
     }
   end
 
@@ -19,6 +20,11 @@ describe 'apt::pin', :type => :define do
       :ensure    => 'absent',
       :packages  => 'apache',
       :priority  => '1'
+    },
+    {
+      :packages  => 'apache',
+      :priority  => '1',
+      :release   => 'my_newpin'
     }
   ].each do |param_set|
     describe "when #{param_set == {} ? "using default" : "specifying"} define parameters" do
@@ -38,7 +44,7 @@ describe 'apt::pin', :type => :define do
           'owner'   => 'root',
           'group'   => 'root',
           'mode'    => '0644',
-          'content' => "# #{title}\nPackage: #{param_hash[:packages]}\nPin: release a=#{title}\nPin-Priority: #{param_hash[:priority]}",
+          'content' => "# #{title}\nPackage: #{param_hash[:packages]}\nPin: release a=#{param_hash[:release] || title}\nPin-Priority: #{param_hash[:priority]}",
         })
       }
     end


### PR DESCRIPTION
When using specific packages is not possible to pin on the same release, adding                                                                                                     release will allow pin specific packages for the same release. This update adds 
release parameter to apt::pin.
