### PR TITLE
(#11966) apt module containment for apt_update.

### DIFF
--- a/manifests/builddep.pp
+++ b/manifests/builddep.pp
@@ -9,4 +9,9 @@ define apt::builddep() {
     command => "/usr/bin/apt-get -y --force-yes build-dep ${name}",
     notify  => Exec['apt_update'],
   }
+
+  # Need anchor to provide containment for dependencies.
+  anchor { "apt::builddep::${name}":
+    require => Class['apt::update'],
+  }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -94,4 +94,9 @@ class apt(
       notify  => Exec['apt_update'],
     }
   }
+
+  # Need anchor to provide containment for dependencies.
+  anchor { "apt::update":
+    require => Class['apt::update'],
+  }
 }

--- a/manifests/ppa.pp
+++ b/manifests/ppa.pp
@@ -35,5 +35,10 @@ define apt::ppa(
     ensure  => file,
     require => Exec["add-apt-repository-${name}"];
   }
+
+  # Need anchor to provide containment for dependencies.
+  anchor { "apt::ppa::${name}":
+    require => Class['apt::update'],
+  }
 }
 

--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -61,4 +61,9 @@ define apt::source(
       before      => File["${name}.list"],
     }
   }
+
+  # Need anchor to provide containment for dependencies.
+  anchor { "apt::source::${name}":
+    require => Class['apt::update'],
+  }
 }


### PR DESCRIPTION
The update to separate Exec["apt-get update ${name}"] to single exec in
apt::update class resulted in apt-get update command to be dangled.
Previously if user specified Package['package_a'] <-
Apt::Resource['source_a'], the original refactor would no longer
guarantee apt-get update is executed before the package is installed.
This patch fixes the problem using the anchor resource and ensuring the
old behaviour is maintained and user can depend on apt-get update
command being invoked if they specify dependency on any apt::*
define resource type as well as the apt class.
