### PR TITLE
(#14657) Fix filename when there is a period in the PPA

### DIFF
--- a/manifests/ppa.pp
+++ b/manifests/ppa.pp
@@ -12,8 +12,9 @@ define apt::ppa(
     fail('lsbdistcodename fact not available: release parameter required')
   }
 
-  $filename_without_slashes = regsubst($name,'/','-','G')
-  $filename_without_ppa     = regsubst($filename_without_slashes, '^ppa:','','G')
+  $filename_without_slashes = regsubst($name, '/', '-', G)
+  $filename_without_dots    = regsubst($filename_without_slashes, '\.', '_', G)
+  $filename_without_ppa     = regsubst($filename_without_dots, '^ppa:', '', G)
   $sources_list_d_filename  = "${filename_without_ppa}-${release}.list"
 
   if ! defined(Package['python-software-properties']) {


### PR DESCRIPTION
When adding a ppa with a period in the filename, the apt module does not properly determine the filename for the File resource.

As an example, consider `ppa:chris-lea/node.js`

The apt module creates a filename `chris-lea-node.js-precise.list`

The add-apt-repository script stores this repository in `chris-lea-node_js-precise.list`

I know this needs a test, but I wanted to get the fix out where it can be looked at sooner than later.
