### PR TITLE
Fix spec tests

### DIFF
--- a/spec/classes/backports_spec.rb
+++ b/spec/classes/backports_spec.rb
@@ -10,7 +10,7 @@ describe 'apt::backports', :type => :class do
       }
     end
 
-    it { should contain_apt__source('backports.list').with({
+    it { should contain_apt__source('backports').with({
         'location'   => 'http://old-releases.ubuntu.com/ubuntu',
         'release'    => 'karmic-backports',
         'repos'      => 'universe multiverse restricted',
@@ -30,7 +30,7 @@ describe 'apt::backports', :type => :class do
       }
     end
 
-    it { should contain_apt__source('backports.list').with({
+    it { should contain_apt__source('backports').with({
         'location'   => 'http://backports.debian.org/debian-backports',
         'release'    => 'squeeze-backports',
         'repos'      => 'main contrib non-free',
@@ -58,7 +58,7 @@ describe 'apt::backports', :type => :class do
       { 'location' => location }
     end
 
-    it { should contain_apt__source('backports.list').with({
+    it { should contain_apt__source('backports').with({
         'location'   => location,
         'release'    => 'squeeze-backports',
         'repos'      => 'main contrib non-free',

--- a/spec/defines/pin_spec.rb
+++ b/spec/defines/pin_spec.rb
@@ -40,11 +40,11 @@ describe 'apt::pin', :type => :define do
 
       it { should contain_file("#{title}.pref").with({
           'ensure'  => param_hash[:ensure],
-          'path'    => "/etc/apt/preferences.d/#{title}",
+          'path'    => "/etc/apt/preferences.d/#{title}.pref",
           'owner'   => 'root',
           'group'   => 'root',
           'mode'    => '0644',
-          'content' => "# #{title}\nPackage: #{param_hash[:packages]}\nPin: release a=#{param_hash[:release] || title}\nPin-Priority: #{param_hash[:priority]}",
+          'content' => "# #{title}\nPackage: #{param_hash[:packages]}\nPin: release a=#{param_hash[:release] || title}\nPin-Priority: #{param_hash[:priority]}\n",
         })
       }
     end

--- a/spec/defines/source_spec.rb
+++ b/spec/defines/source_spec.rb
@@ -84,12 +84,12 @@ describe 'apt::source', :type => :define do
 
       it {
         if param_hash[:pin]
-          should contain_apt__pin(param_hash[:release]).with({
+          should contain_apt__pin(title).with({
             "priority"  => param_hash[:pin],
             "before"    => "File[#{title}.list]"
           })
         else
-          should_not contain_apt__pin(param_hash[:release]).with({
+          should_not contain_apt__pin(title).with({
             "priority"  => param_hash[:pin],
             "before"    => "File[#{title}.list]"
           })


### PR DESCRIPTION
A few tests were broken by changes introduced in #61. Mostly they were resource names. This makes the matching adjustments to the spec tests.
