### PR TITLE
Fix the spec test for apt::source

### DIFF
--- a/spec/defines/source_spec.rb
+++ b/spec/defines/source_spec.rb
@@ -22,7 +22,7 @@ describe 'apt::source', :type => :define do
 
   [{},
    {
-      :location           => 'somewhere',
+      :location           => 'http://example.com',
       :release            => 'precise',
       :repos              => 'security',
       :include_src        => false,
@@ -39,7 +39,7 @@ describe 'apt::source', :type => :define do
     },
     {
       :ensure             => 'absent',
-      :location           => 'somewhere',
+      :location           => 'http://example.com',
       :release            => 'precise',
       :repos              => 'security',
     }


### PR DESCRIPTION
the `$location` paramater is meant to be a deb location, so it should be formatted as a URI.
