### PR TITLE
Fix Modulefile for puppet-apt to puppetlabs-apt rename

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,11 +1,11 @@
 name    'puppetlabs-apt'
 version '0.0.4'
-source  'https://github.com/puppetlabs/puppet-apt'
+source  'https://github.com/puppetlabs/puppetlabs-apt'
 author  'Evolving Web / Puppet Labs'
 license 'Apache License 2.0'
 summary 'Puppet Labs Apt Module'
 description 'APT Module for Puppet'
-project_page 'https://github.com/puppetlabs/puppet-apt'
+project_page 'https://github.com/puppetlabs/puppetlabs-apt'
 
 ## Add dependencies, if any:
 dependency 'puppetlabs/stdlib', '>= 2.2.1'


### PR DESCRIPTION
This fixes the `source` and `project_page` lines in the Modulefile to match the rename. 0.0.4 has apparently still not been pushed to the forge, so this can be merged without a version bump.
