### PR TITLE
fix scoping of $lsbdistcodename in source.pp

### DIFF
--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -4,7 +4,7 @@
 define apt::source(
   $ensure            = present,
   $location          = '',
-  $release           = $lsbdistcodename,
+  $release           = $::lsbdistcodename,
   $repos             = 'main',
   $include_src       = true,
   $required_packages = false,


### PR DESCRIPTION
Current unscoped variable yields deprecation warning:
warning: Dynamic lookup of $lsbdistcodename at
[..]/apt/manifests/source.pp:7 is deprecated.
