### PR TITLE
remove check, if $release is empty

### DIFF
--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -4,7 +4,7 @@
 define apt::source(
   $ensure            = present,
   $location          = '',
-  $release           = $::lsbdistcodename,
+  $release           = 'UNDEF',
   $repos             = 'main',
   $include_src       = true,
   $required_packages = false,
@@ -21,8 +21,14 @@ define apt::source(
   $sources_list_d = $apt::params::sources_list_d
   $provider       = $apt::params::provider
 
-  if $release == undef {
-    fail('lsbdistcodename fact not available: release parameter required')
+  if $release == 'UNDEF' {
+    if $::lsbdistcodename == undef {
+      fail('lsbdistcodename fact not available: release parameter required')
+    } else {
+      $release_real = $::lsbdistcodename
+    }
+  } else {
+    $release_real = $release
   }
 
   file { "${name}.list":

--- a/spec/defines/source_spec.rb
+++ b/spec/defines/source_spec.rb
@@ -42,6 +42,12 @@ describe 'apt::source', :type => :define do
       :location           => 'http://example.com',
       :release            => 'precise',
       :repos              => 'security',
+    },
+    {
+      :release            => '',
+    },
+    {
+      :release            => 'custom',
     }
   ].each do |param_set|
     describe "when #{param_set == {} ? "using default" : "specifying"} class parameters" do

--- a/templates/source.list.erb
+++ b/templates/source.list.erb
@@ -1,5 +1,5 @@
 # <%= name %>
-deb <%= location %> <%= release %> <%= repos %>
+deb <%= location %> <%= release_real %> <%= repos %>
 <%- if include_src then -%>
-deb-src <%= location %> <%= release %> <%= repos %>
+deb-src <%= location %> <%= release_real %> <%= repos %>
 <%- end -%>


### PR DESCRIPTION
At the moment, it's not possible to add sources, with an empty release value.

For example: http://pkg.jenkins-ci.org/debian/

This pull request removes the check, if $release is empty.
