### PR TITLE
Add a way to specify a timeout for the apt::force define.

### DIFF
--- a/manifests/force.pp
+++ b/manifests/force.pp
@@ -3,7 +3,8 @@
 
 define apt::force(
   $release = 'testing',
-  $version = false
+  $version = false,
+  $timeout = 300
 ) {
 
   $version_string = $version ? {
@@ -18,5 +19,6 @@ define apt::force(
   exec { "/usr/bin/aptitude -y -t ${release} install ${name}${version_string}":
     unless    => $install_check,
     logoutput => 'on_failure',
+    timeout   => $timeout,
   }
 }


### PR DESCRIPTION
Hi,

for some package on slow machine/network (virtual), the installation of a package can be very long (activeMQ from wheezy).

With this parameter it's easy to specify a more than usual (which is 300 seconds in the code) timeout.

Best regards,
