### PR TITLE
Check for an updated key if one has expired (great for the puppetlabs key change!)

### DIFF
--- a/manifests/key.pp
+++ b/manifests/key.pp
@@ -51,7 +51,7 @@ define apt::key (
           unless    => "/usr/bin/apt-key list | /bin/grep -E '${upkey}.*\[expires:'",
           logoutput => 'on_failure',
           before    => Anchor["apt::key ${upkey} present"],
-          notify    => Exec['apt_update',
+          notify    => Exec['apt_update'],
         }
       }
 


### PR DESCRIPTION
If the key came from a keyserver apt::key to check if it has expired and attempt to update it if it has 
