### PR TITLE
(#16070) Allow optional order parameter to apt::pin

### DIFF
--- a/manifests/pin.pp
+++ b/manifests/pin.pp
@@ -3,6 +3,7 @@
 
 define apt::pin(
   $ensure     = present,
+  $order      = '',
   $packages   = '*',
   $priority   = 0,
   $release    = '',
@@ -14,6 +15,10 @@ define apt::pin(
 
   $preferences_d = $apt::params::preferences_d
 
+  if $order != '' and !is_integer($order) {
+    fail('Only integers are allowed in the apt::pin order param')
+  }
+
   if $release != '' {
     $pin = "release a=${release}"
   } elsif $origin != '' {
@@ -24,9 +29,13 @@ define apt::pin(
     $pin = "release a=${name}"
   }
 
+  $path = $order ? {
+    ''      => "${preferences_d}/${name}.pref",
+    default => "${preferences_d}/${order}-${name}.pref",
+  }
   file { "${name}.pref":
     ensure  => $ensure,
-    path    => "${preferences_d}/${name}.pref",
+    path    => $path,
     owner   => root,
     group   => root,
     mode    => '0644',

--- a/spec/defines/pin_spec.rb
+++ b/spec/defines/pin_spec.rb
@@ -5,6 +5,7 @@ describe 'apt::pin', :type => :define do
   let :default_params do
     {
       :ensure   => 'present',
+      :order    => '',
       :packages => '*',
       :priority => '0',
       :release  => nil
@@ -13,6 +14,11 @@ describe 'apt::pin', :type => :define do
 
   [ {},
     {
+      :packages  => 'apache',
+      :priority  => '1'
+    },
+    {
+      :order     => 50,
       :packages  => 'apache',
       :priority  => '1'
     },
@@ -40,7 +46,7 @@ describe 'apt::pin', :type => :define do
 
       it { should contain_file("#{title}.pref").with({
           'ensure'  => param_hash[:ensure],
-          'path'    => "/etc/apt/preferences.d/#{title}.pref",
+          'path'    => "/etc/apt/preferences.d/#{param_hash[:order] == '' ? "" : "#{param_hash[:order]}-"}#{title}.pref",
           'owner'   => 'root',
           'group'   => 'root',
           'mode'    => '0644',


### PR DESCRIPTION
As the apt pinnings are parsed in ascending alphabetical order with
first match wins within a given scope it is useful to be able to specify
a ordering parameter. Then the name parameter can be kept to something
meaningful.
