### PR TITLE
(#16075) Allow pinning on version numbers

### DIFF
--- a/manifests/pin.pp
+++ b/manifests/pin.pp
@@ -7,7 +7,8 @@ define apt::pin(
   $priority   = 0,
   $release    = '',
   $origin     = '',
-  $originator = ''
+  $originator = '',
+  $version    = ''
 ) {
 
   include apt::params
@@ -20,6 +21,8 @@ define apt::pin(
     $pin = "origin \"${origin}\""
   } elsif $originator != '' {
     $pin = "release o=${originator}"
+  } elsif $version != '' {
+    $pin = "version ${version}"
   } else {
     $pin = "release a=${name}"
   }


### PR DESCRIPTION
This is needed to be able to produce the following pinning from
apt_preferences(5):

Package: perl
Pin: version 5.8*
Pin-Priority: 1001
