### PR TITLE
Fix add-apt-repository to not fail for PPA

### DIFF
--- a/manifests/ppa.pp
+++ b/manifests/ppa.pp
@@ -22,11 +22,10 @@ define apt::ppa(
   }
 
   exec { "add-apt-repository-${name}":
-    command   => "/usr/bin/add-apt-repository ${name}",
+    command   => "/usr/bin/add-apt-repository -y ${name}",
     creates   => "${sources_list_d}/${sources_list_d_filename}",
     logoutput => 'on_failure',
     require   => [
-      File[$sources_list_d],
       Package['python-software-properties'],
     ],
     notify    => Exec['apt_update'],


### PR DESCRIPTION
I was not able to install a PPA automatically with this module without these two fixes. This will:
- add `-y` to the `add-apt-repository` so it can complete without user interaction
- remove the requirement for the variable `$sources_list_d`
