### PR TITLE
Fix missing include in PPA manifest

### DIFF
--- a/manifests/ppa.pp
+++ b/manifests/ppa.pp
@@ -3,6 +3,7 @@
 define apt::ppa(
   $release = $::lsbdistcodename
 ) {
+  include ::apt
   include apt::params
   include apt::update
 


### PR DESCRIPTION
This resolves the following error:

```
Could not find dependency File[/etc/apt/sources.list.d] for Exec[add-apt-repository-ppa:joey-imbasciano/collectd5] at /etc/puppet/modules/apt/manifests/ppa.pp:30
```

The File resource is out of scope for the ppa class otherwise.
