### PR TITLE
Add PL Repo source to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,17 @@ apt::source { "debian_unstable":
   include_src       => true
 }
 </pre>
+
+This source will configure your system for the Puppet Labs APT repository.
+<pre>
+apt::source { 'puppetlabs':
+  location   => 'http://apt.puppetlabs.com',
+  repos      => 'main',
+  key        => '4BD6EC30',
+  key_server => 'pgp.mit.edu',
+}
+</pre>
+
 ### apt::key
 Add a key to the list of keys used by apt to authenticate packages.
 <pre>


### PR DESCRIPTION
Prior to this commit, the only information about the Puppet Labs
repository source was in the tests folder.

This commit adds example usage for apt::source to the README for
the Puppet Labs APT repository.
