### PR TITLE
Update Modulefile for 1.0.0 release

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name    'puppetlabs-apt'
-version '0.0.4'
+version '1.0.0'
 source  'https://github.com/puppetlabs/puppetlabs-apt'
 author  'Evolving Web / Puppet Labs'
 license 'Apache License 2.0'
@@ -8,4 +8,4 @@ description 'APT Module for Puppet'
 project_page 'https://github.com/puppetlabs/puppetlabs-apt'
 
 ## Add dependencies, if any:
-dependency 'puppetlabs/stdlib', '>= 2.2.1'
+dependency 'puppetlabs/stdlib', '2.x'


### PR DESCRIPTION
This commit increments the version number to 1.0.0 for a new
Puppet Forge release.

Version 1.0.0 is a backwards incompatible release of puppetlabs-apt.

The major change is to the apt::backports class which had its repos
property modified on Ubuntu systems to include the main repository
in addition to universe, multiverse & restricted.

Additionally, the following bug fixes or minor enhancements were
introduced:
- Cleanup of style, variable scope and bug fixes.
- Exec resources now set the `logoutput` parameter to on_failure.
- Adds a timeout parameter to the apt::force defined resource type
- Allow pinning on version numbers in apt::pin
- Allow optional order parameter to apt::pin
- Allow ability to fill in pin explanation

Contributions were provided by the following fine folk:
Nan Liu
Anton Lindström
ytjohn
Steffen Zieger
Erik Dalén
Jonathan Araña Cruz
sathlan
Branan Purvine-Riley
Alexander Menk
