### PR TITLE
Remove proxy file if proxy is set and then later set to false

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -99,18 +99,16 @@ class apt(
     default: { fail('Valid values for disable_keys are true or false') }
   }
 
-  if ($proxy_host) {
-    file { 'configure-apt-proxy':
-      path    => "${apt_conf_d}/proxy",
-      content => "Acquire::http::Proxy \"http://${proxy_host}:${proxy_port}\";",
-      notify  => Exec['apt_update'],
-    }
-  } else {
-    file { 'configure-apt-proxy':
-      path    => "${apt_conf_d}/proxy",
-      ensure  => absent,
-      notify  => Exec['apt_update'],
-    }
+  $proxy_set = $proxy_host ? {
+    false   => absent,
+    default => present
+  }
+
+  file { 'configure-apt-proxy':
+    path    => "${apt_conf_d}/proxy",
+    content => "Acquire::http::Proxy \"http://${proxy_host}:${proxy_port}\";",
+    notify  => Exec['apt_update'],
+    ensure  => $proxy_set,
   }
 
   # Need anchor to provide containment for dependencies.


### PR DESCRIPTION
If a proxy is set and then later unset we need to remove the proxy file. As it currently sits the file will be ignored, but apt will still pick it up and use the proxy.
