### PR TITLE
Modified the PPA code for changes in Quantal

### DIFF
--- a/manifests/ppa.pp
+++ b/manifests/ppa.pp
@@ -16,9 +16,14 @@ define apt::ppa(
   $filename_without_dots    = regsubst($filename_without_slashes, '\.', '_', G)
   $filename_without_ppa     = regsubst($filename_without_dots, '^ppa:', '', G)
   $sources_list_d_filename  = "${filename_without_ppa}-${release}.list"
-
-  if ! defined(Package['python-software-properties']) {
-    package { 'python-software-properties': }
+  
+  $package = $::lsbdistrelease ? {
+	  /^[1-9]\..*|1[01]\..*|12.04$/ => 'python-software-properties',
+	  default  => 'software-properties-common',
+  }
+  
+  if ! defined(Package[$package]) {
+    package { $package: }
   }
 
   exec { "add-apt-repository-${name}":
@@ -27,7 +32,7 @@ define apt::ppa(
     logoutput => 'on_failure',
     require   => [
       File[$sources_list_d],
-      Package['python-software-properties'],
+      Package["${package}"],
     ],
     notify    => Exec['apt_update'],
   }
@@ -42,4 +47,3 @@ define apt::ppa(
     require => Class['apt::update'],
   }
 }
-

--- a/spec/defines/ppa_spec.rb
+++ b/spec/defines/ppa_spec.rb
@@ -1,58 +1,82 @@
 require 'spec_helper'
 describe 'apt::ppa', :type => :define do
-  ['ppa:dans_ppa', 'dans_ppa','ppa:dans-daily/ubuntu'].each do |t|
-    describe "with title #{t}" do
-      let :pre_condition do
-        'class { "apt": }'
-      end
+  [ { :lsbdistrelease => '11.04',
+      :lsbdistcodename => 'natty',
+      :package => 'python-software-properties'},
+    { :lsbdistrelease => '12.10',
+      :lsbdistcodename => 'quantal',
+      :package => 'software-properties-common'},
+  ].each do |platform|
+    context "on #{platform[:lsbdistcodename]}" do
       let :facts do
-        {:lsbdistcodename => 'natty'}
-      end
-      let :title do
-        t
+        {
+          :lsbdistrelease => platform[:lsbdistrelease],
+          :lsbdistcodename => platform[:lsbdistcodename],
+        }
       end
       let :release do
-        "natty"
+        "#{platform[:lsbdistcodename]}"
       end
-      let :filename do
-        t.sub(/^ppa:/,'').gsub('/','-') << "-" << "#{release}.list"
+      let :package do
+        "#{platform[:package]}"
       end
+      ['ppa:dans_ppa', 'dans_ppa','ppa:dans-daily/ubuntu'].each do |t|
+        describe "with title #{t}" do
+          let :pre_condition do
+            'class { "apt": }'
+          end
+          let :title do
+            t
+          end
+          let :filename do
+            t.sub(/^ppa:/,'').gsub('/','-') << "-" << "#{release}.list"
+          end
 
-      it { should contain_package("python-software-properties") }
+          it { should contain_package("#{package}") }
 
-      it { should contain_exec("apt_update").with(
-        'command'     => '/usr/bin/apt-get update',
-        'refreshonly' => true
-        )
-      }
+          it { should contain_exec("apt_update").with(
+            'command'     => '/usr/bin/apt-get update',
+            'refreshonly' => true
+            )
+          }
 
-      it { should contain_exec("add-apt-repository-#{t}").with(
-        'command' => "/usr/bin/add-apt-repository #{t}",
-        'creates' => "/etc/apt/sources.list.d/#{filename}",
-        'require' => ["File[/etc/apt/sources.list.d]", "Package[python-software-properties]"],
-        'notify'  => "Exec[apt_update]"
-        )
-      }
+          it { should contain_exec("add-apt-repository-#{t}").with(
+            'command' => "/usr/bin/add-apt-repository #{t}",
+            'creates' => "/etc/apt/sources.list.d/#{filename}",
+            'require' => ["File[/etc/apt/sources.list.d]", "Package[#{package}]"],
+            'notify'  => "Exec[apt_update]"
+            )
+          }
 
-      it { should create_file("/etc/apt/sources.list.d/#{filename}").with(
-        'ensure'  => 'file',
-        'require' => "Exec[add-apt-repository-#{t}]"
-        )
-      }
+          it { should create_file("/etc/apt/sources.list.d/#{filename}").with(
+            'ensure'  => 'file',
+            'require' => "Exec[add-apt-repository-#{t}]"
+            )
+          }
+        end
+      end
     end
   end
 
-  describe "it should not error if package['python-software-properties'] is already defined" do
-    let :pre_condition do
-       'class {"apt": }' +
-       'package { "python-software-properties": }->Apt::Ppa["ppa"]'
+  [ { :lsbdistcodename => 'natty', 
+      :package => 'python-software-properties' },
+    { :lsbdistcodename => 'quantal',
+      :package => 'software-properties-common'},
+  ].each do |platform|
+    context "on #{platform[:lsbdistcodename]}" do
+      describe "it should not error if package['#{platform[:package]}'] is already defined" do
+        let :pre_condition do
+           'class {"apt": }' +
+           'package { "#{platform[:package]}": }->Apt::Ppa["ppa"]'
+        end
+        let :facts do
+          {:lsbdistcodename => '#{platform[:lsbdistcodename]}'}
+        end
+        let(:title) { "ppa" }
+        let(:release) { "#{platform[:lsbdistcodename]}" }
+        it { should contain_package('#{platform[:package]}') }
+      end
     end
-    let :facts do
-      {:lsbdistcodename => 'natty'}
-    end
-    let(:title) { "ppa" }
-    let(:release) { "natty" }
-    it { should contain_package("python-software-properties") }
   end
 
   describe "without Class[apt] should raise a Puppet::Error" do


### PR DESCRIPTION
In Quantal the add-apt-repository tool is no longer in the python-software-properties package but is in software-properties-common.  This commit adds a check in the manifest for pre-precise and then adds some new tests for quantal.

One of my first attempts at changes to a puppet manifest and my first ever attempt at tests, so forgive my code!
