### PR TITLE
Release 1.1.0 (Ubuntu 12.10 support)

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name    'puppetlabs-apt'
-version '1.0.1'
+version '1.1.0'
 source  'https://github.com/puppetlabs/puppetlabs-apt'
 author  'Evolving Web / Puppet Labs'
 license 'Apache License 2.0'


### PR DESCRIPTION
Prior to this release, Ubuntu 12.10 (Quantal) was not supported.

This commit marks the Forge release of 1.1.0 which includes this
support, thanks to Jarl Nicolson.
