### PR TITLE
key id's longer than 8 characters are always downloaded/retreived from key servers/sources

### DIFF
--- a/manifests/key.pp
+++ b/manifests/key.pp
@@ -9,6 +9,7 @@ define apt::key (
   include apt::params
 
   $upkey = upcase($key)
+  $upkeytrimmed = regsubst($upkey, '.*([A-Z0-9]{8})$', '\1')
 
   if $key_content {
     $method = 'content'
@@ -48,7 +49,7 @@ define apt::key (
         exec { $digest:
           command   => $digest_command,
           path      => '/bin:/usr/bin',
-          unless    => "/usr/bin/apt-key list | /bin/grep '${upkey}'",
+          unless    => "/usr/bin/apt-key list | /bin/grep '${upkeytrimmed}'",
           logoutput => 'on_failure',
           before    => Anchor["apt::key ${upkey} present"],
         }


### PR DESCRIPTION
some repos (like percona apt repo) have key id's longer than 8 characters and if given key id is longer than 8 characters, it won't be matched on "apt-key list | grep KEY" and marked unlisted which will force puppet to download/retreive it on each run.

``` ruby
  apt::source {
    "percona":
      location          => "http://repo.percona.com/apt",
      release           => $::lsbdistcodename,
      repos             => "main",
      include_src       => false,
      key               => "1C4CBDCDCD2EFD2A",
      key_server        => "keys.gnupg.net",
  }
```
