### PR TITLE
Build all branches on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,6 @@ rvm:
 before_script:
 after_script:
 script: "rake spec"
-branches:
-  only:
-    - master
 env:
   - PUPPET_VERSION=3.0.2
   - PUPPET_VERSION=2.7.20


### PR DESCRIPTION
We should build all branches for travis, otherwise users won't be able to test
their own feature branches.

@kbarber has confirmed by suspicion that we want to build all branches in puppetlabs/puppetlabs-apache/pull/143#issuecomment-13038523

So I'm changing apt to do the same.
