### PR TITLE
apt::ppa failed on ${sources_list_d} (Ubuntu 12.04)

### DIFF
--- a/manifests/ppa.pp
+++ b/manifests/ppa.pp
@@ -37,9 +37,16 @@ define apt::ppa(
     notify    => Exec['apt_update'],
   }
 
+  file { "${sources_list_d}":
+    ensure  => directory,
+  }
+
   file { "${sources_list_d}/${sources_list_d_filename}":
     ensure  => file,
-    require => Exec["add-apt-repository-${name}"],
+    require => [
+      File["${sources_list_d}"],
+      Exec["add-apt-repository-${name}"]
+    ],
   }
 
   # Need anchor to provide containment for dependencies.


### PR DESCRIPTION
On Ubuntu 12.04 the apt::ppa call failed. Ensuring that ${sources_list_d} is a directory fixed the issue.
