### PR TITLE
Handling of release parameter and apt provider in force manifest

### DIFF
--- a/manifests/force.pp
+++ b/manifests/force.pp
@@ -7,6 +7,8 @@ define apt::force(
   $timeout = 300
 ) {
 
+  $provider = $apt::params::provider
+
   $version_string = $version ? {
     false   => undef,
     default => "=${version}",
@@ -32,7 +34,7 @@ define apt::force(
     }
   }
 
-  exec { "/usr/bin/aptitude -y ${release_string} install ${name}${version_string}":
+  exec { "${provider} -y ${release_string} install ${name}${version_string}":
     unless    => $install_check,
     logoutput => 'on_failure',
     timeout   => $timeout,


### PR DESCRIPTION
I improved the handling of the release parameter in the force manifest.

Now packages are upgraded to the release given via the release parameter. Previously packages were not upgraded if an older version from another release was installed. It was only possible to install packages from a specific release if the package has been deinstalled before.

I also changed the force manifest to use $apt::params:provider instead of aptitude.
