### PR TITLE
Add optional architecture qualifier to apt-sources

### DIFF
--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -12,7 +12,8 @@ define apt::source(
   $key_server        = 'keyserver.ubuntu.com',
   $key_content       = false,
   $key_source        = false,
-  $pin               = false
+  $pin               = false,
+  $architecture      = undef
 ) {
 
   include apt::params

--- a/spec/defines/source_spec.rb
+++ b/spec/defines/source_spec.rb
@@ -48,6 +48,9 @@ describe 'apt::source', :type => :define do
     },
     {
       :release            => 'custom',
+    },
+    {
+      :architecture       => 'amd64',
     }
   ].each do |param_set|
     describe "when #{param_set == {} ? "using default" : "specifying"} class parameters" do
@@ -69,9 +72,13 @@ describe 'apt::source', :type => :define do
 
       let :content do
         content = "# #{title}"
-        content << "\ndeb #{param_hash[:location]} #{param_hash[:release]} #{param_hash[:repos]}\n"
+        if param_hash[:architecture]
+          arch = "[arch=#{param_hash[:architecture]}]"
+        end
+        content << "\ndeb #{arch} #{param_hash[:location]} #{param_hash[:release]} #{param_hash[:repos]}\n"
+
         if param_hash[:include_src]
-          content << "deb-src #{param_hash[:location]} #{param_hash[:release]} #{param_hash[:repos]}\n"
+          content << "deb-src #{arch} #{param_hash[:location]} #{param_hash[:release]} #{param_hash[:repos]}\n"
         end
         content
       end

--- a/templates/source.list.erb
+++ b/templates/source.list.erb
@@ -1,5 +1,5 @@
 # <%= @name %>
-deb <%= @location %> <%= @release_real %> <%= @repos %>
+deb <% if @architecture %>[arch=<%= @architecture %>]<% end %> <%= @location %> <%= @release_real %> <%= @repos %>
 <%- if @include_src then -%>
-deb-src <%= @location %> <%= @release_real %> <%= @repos %>
+deb-src <% if @architecture %>[arch=<%= @architecture %>]<% end %> <%= @location %> <%= @release_real %> <%= @repos %>
 <%- end -%>


### PR DESCRIPTION
For your consideration; saw [this](https://github.com/puppetlabs/puppetlabs-apt/pull/110) PR hanging out there for ~ 3 months and had a need for this.
