### PR TITLE
Apt::source should pass release to apt::pin

### DIFF
--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -52,6 +52,7 @@ define apt::source(
       priority => $pin,
       before   => File["${name}.list"],
       origin   => $host,
+      release  => $release_real
     }
   }
 

--- a/spec/defines/source_spec.rb
+++ b/spec/defines/source_spec.rb
@@ -92,7 +92,8 @@ describe 'apt::source', :type => :define do
         if param_hash[:pin]
           should contain_apt__pin(title).with({
             "priority"  => param_hash[:pin],
-            "before"    => "File[#{title}.list]"
+            "before"    => "File[#{title}.list]",
+            "release"   => param_hash[:release]
           })
         else
           should_not contain_apt__pin(title).with({


### PR DESCRIPTION
In case pinning is used in apt::source declaration, the 'release' is not sent as parameter to apt::pin, which cause faulty pinning file like : 

```
# wheezy-backports
Explanation: : wheezy-backports
Package: *
Pin: origin "ftp.fr.debian.org"
Pin-Priority: -10
```

which pin all debian repositories, instead it should be : 

```
# wheezy-backports
Explanation: : wheezy-backports
Package: *
Pin: release a=wheezy-backports
Pin-Priority: -10
```

This pull request fix, I think, this issue, and also update spec to ensure release is correctly passed.
