### PR TITLE
Install required_packages before 'apt-get update'

### DIFF
--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -61,6 +61,7 @@ define apt::source(
       logoutput   => 'on_failure',
       refreshonly => true,
       subscribe   => File["${name}.list"],
+      before      => Exec['apt_update'],
     }
   }
 

--- a/spec/defines/source_spec.rb
+++ b/spec/defines/source_spec.rb
@@ -114,7 +114,8 @@ describe 'apt::source', :type => :define do
           should contain_exec("Required packages: '#{param_hash[:required_packages]}' for #{title}").with({
             "command" => "/usr/bin/apt-get -y install #{param_hash[:required_packages]}",
             "subscribe"   => "File[#{title}.list]",
-            "refreshonly" => true
+            "refreshonly" => true,
+            "before"      => 'Exec[apt_update]',
           })
         else
           should_not contain_exec("Required packages: '#{param_hash[:required_packages]}' for #{title}").with({


### PR DESCRIPTION
This is necessary when required_packages contains GPG keys that are used for
authenticating other packages. Tested with package ubuntu-cloud-keyring which
is included in Ubuntu main and used by the Ubuntu Cloud Archive.

I think the same problem applies to other *-keyring packages as well.
