### PR TITLE
Update update.pp

### DIFF
--- a/manifests/update.pp
+++ b/manifests/update.pp
@@ -7,6 +7,8 @@ class apt::update {
     refreshonly => true,
   }
   
-  Exec['apt_update'] -> Package <| tags != ['apt'] |>
+  Package <| tags != ['apt'] |> {
+    require += Exec['apt_update'],
+  }
 
 }


### PR DESCRIPTION
Resolve apt::update only running after a module attempts to install a package when using apt::source and apt::ppa
