### PR TITLE
Ensure Exec['apt_update'] runs prior to package installation

### DIFF
--- a/manifests/update.pp
+++ b/manifests/update.pp
@@ -6,4 +6,6 @@ class apt::update {
     logoutput   => 'on_failure',
     refreshonly => true,
   }
+  
+  Exec['apt_update'] -> Package <| title != ["python-software-properties", "software-properties-common"] |>
 }


### PR DESCRIPTION
Added a dependency chain to Exec['apt_update'] to ensure it get's executed prior to to other packages barring "python-software-properties" and "software-properties-common" which are installed by apt::ppa which notifies Exec['apt_update']
