### PR TITLE
Added dependency for packages

### DIFF
--- a/manifests/update.pp
+++ b/manifests/update.pp
@@ -6,4 +6,6 @@ class apt::update {
     logoutput   => 'on_failure',
     refreshonly => true,
   }
+
+  Exec['apt_update'] -> Package <| title != "python-software-properties" and title != "software-properties-common" |>
 }


### PR DESCRIPTION
Exec['apt-update'] will run before other packages except python-software-properties and software-properties-common.
