### PR TITLE
apt::force: upgrade installed to specified release

### DIFF
--- a/manifests/force.pp
+++ b/manifests/force.pp
@@ -13,7 +13,7 @@ define apt::force(
   }
 
   $install_check = $version ? {
-    false   => "/usr/bin/dpkg -s ${name} | grep -q 'Status: install'",
+    false   => "/usr/bin/aptitude search '?narrow(?narrow(?installed,?archive($release)),?name(^$name$))' | grep -q ^i",
     default => "/usr/bin/dpkg -s ${name} | grep -q 'Version: ${version}'",
   }
   exec { "/usr/bin/aptitude -y -t ${release} install ${name}${version_string}":


### PR DESCRIPTION
Packages that are already installed will not be updated to the release
specified in the apt::force resource. This commit fixes that issue. It
only applies when the version is not specified; if it is, the release
does not matter anyway.
