### PR TITLE
Support APT pinning by codename

### DIFF
--- a/manifests/pin.pp
+++ b/manifests/pin.pp
@@ -8,6 +8,7 @@ define apt::pin(
   $packages   = '*',
   $priority   = 0,
   $release    = '',
+  $codename   = '',
   $origin     = '',
   $originator = '',
   $version    = ''
@@ -23,6 +24,8 @@ define apt::pin(
 
   if $release != '' {
     $pin = "release a=${release}"
+  } elsif $codename != '' {
+    $pin = "release n=${codename}"
   } elsif $origin != '' {
     $pin = "origin \"${origin}\""
   } elsif $originator != '' {


### PR DESCRIPTION
Following simple patch allows pinning by codename.

man apt_preferences:
       the Codename: line
           names the codename to which all the packages in the directory tree
           belong. For example, the line "Codename: wheezy" specifies that all
           of the packages in the directory tree below the parent of the
           Release file belong to a version named wheezy. Specifying this
           value in the APT preferences file would require the line:

```
           Pin: release n=wheezy
```
