### PR TITLE
Release 1.2.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,27 @@
 
 Release notes for the puppetlabs-apt module.
 
+1.2.0
+=====
+
+Features:
+- Add geppetto `.project` natures
+- Add GH auto-release
+- Add `apt::key::key_options` parameter
+- Add complex pin support using distribution properties for `apt::pin` via new properties:
+  - `apt::pin::codename`
+  - `apt::pin::release_version`
+  - `apt::pin::component`
+  - `apt::pin::originator`
+  - `apt::pin::label`
+- Add source architecture support to `apt::source::architecture`
+
+Bugfixes:
+- Use apt-get instead of aptitude in apt::force
+- Update default backports location
+- Add dependency for required packages before apt-get update
+
+
 1.1.1
 =====
 

--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name    'puppetlabs-apt'
-version '1.1.1'
+version '1.2.0'
 source  'https://github.com/puppetlabs/puppetlabs-apt'
 author  'Evolving Web / Puppet Labs'
 license 'Apache License 2.0'


### PR DESCRIPTION
Features:
- Add geppetto `.project` natures
- Add GH auto-release
- Add `apt::key::key_options` parameter
- Add complex pin support using distribution properties for `apt::pin` via new properties:
  - `apt::pin::codename`
  - `apt::pin::release_version`
  - `apt::pin::component`
  - `apt::pin::originator`
  - `apt::pin::label`
- Add source architecture support to `apt::source::architecture`

Bugfixes:
- Use apt-get instead of aptitude in apt::force
- Update default backports location
- Add dependency for required packages before apt-get update
