### PR TITLE
proxy support for apt::ppa

### DIFF
--- a/manifests/ppa.pp
+++ b/manifests/ppa.pp
@@ -26,7 +26,20 @@ define apt::ppa(
     package { $package: }
   }
 
+  if defined(Class[apt]) {
+    $proxy_host = getparam(Class[apt], "proxy_host")
+    $proxy_port = getparam(Class[apt], "proxy_port")
+    case  $proxy_host {
+      false: {
+        $proxy_env = ""
+      }
+      default: {$proxy_env = ["http_proxy=http://${proxy_host}:${proxy_port}", "https_proxy=http://${proxy_host}:${proxy_port}"]}
+    }
+  } else {
+    $proxy_env = ""
+  }
   exec { "add-apt-repository-${name}":
+    environment  => $proxy_env,
     command   => "/usr/bin/add-apt-repository ${name}",
     creates   => "${sources_list_d}/${sources_list_d_filename}",
     logoutput => 'on_failure',


### PR DESCRIPTION
If the node is behind a proxy, the apt class has two parameters to describe the proxy configuration (`proxy_host` and `proxy_port`).

Due to a bug in add-apt-repository, the settings is ignored, and you must define the environment variable `https_proxy`. See [launchpad bug](https://bugs.launchpad.net/ubuntu/+source/software-properties/+bug/516032) for more details.

The code I propose modifies the environment of the exec resource if the apt class is defined with a `proxy_host` value different from the default (false).
