### PR TITLE
ppa: fix empty environment definition in exec ressource when no proxy

### DIFF
--- a/manifests/ppa.pp
+++ b/manifests/ppa.pp
@@ -30,13 +30,13 @@ define apt::ppa(
     $proxy_host = getparam(Class[apt], "proxy_host")
     $proxy_port = getparam(Class[apt], "proxy_port")
     case  $proxy_host {
-      false: {
-        $proxy_env = ""
+      false, "": {
+        $proxy_env = []
       }
       default: {$proxy_env = ["http_proxy=http://${proxy_host}:${proxy_port}", "https_proxy=http://${proxy_host}:${proxy_port}"]}
     }
   } else {
-    $proxy_env = ""
+    $proxy_env = []
   }
   exec { "add-apt-repository-${name}":
     environment  => $proxy_env,

--- a/spec/defines/ppa_spec.rb
+++ b/spec/defines/ppa_spec.rb
@@ -55,6 +55,29 @@ describe 'apt::ppa', :type => :define do
           }
         end
       end
+      describe 'without a proxy defined' do
+        let :title do
+          'rspec_ppa'
+        end
+        let :pre_condition do
+          'class { "apt":
+             proxy_host => false
+          }'
+        end
+          let :filename do
+            "#{title}-#{release}.list"
+          end
+
+        it { should contain_exec("add-apt-repository-#{title}").with(
+          'environment' => [],
+          'command'     => "/usr/bin/add-apt-repository #{title}",
+          'creates'     => "/etc/apt/sources.list.d/#{filename}",
+          'require'     => ["File[/etc/apt/sources.list.d]", "Package[#{package}]"],
+          'notify'      => "Exec[apt_update]"
+          )
+        }
+      end
+
       describe 'behind a proxy' do
         let :title do
           'rspec_ppa'


### PR DESCRIPTION
The value given for empty environment in the exec resource of ppa definition was false. In the PR I corrected it and also added a spec to cover the case.
