### PR TITLE
Add wheezy backports support

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,6 +11,9 @@ class apt::params {
         'squeeze': {
           $backports_location = 'http://backports.debian.org/debian-backports'
         }
+        'wheezy': {
+          $backports_location = 'http://ftp.debian.org/debian/'
+        }
         default: {
           $backports_location = 'http://ftp.debian.org/debian/'
         }


### PR DESCRIPTION
Hello,

I added the right parameters for Debian Wheezy support.

Regards,

Markus R.

Signed-off-by: Markus Rekkenbeil markus@bionix-it.de
