### PR TITLE
Use the geoDNS http.debian.net instead of the main debian ftp server

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,7 +12,7 @@ class apt::params {
           $backports_location = 'http://backports.debian.org/debian-backports'
         }
         default: {
-          $backports_location = 'http://ftp.debian.org/debian/'
+          $backports_location = 'http://http.debian.net/debian/'
         }
       }
     }


### PR DESCRIPTION
Hello,

I implemented the geoDNS redirector 'http.debian.net' instead ftp.debian.net - the main debian ftp server).

Signed-off-by: Markus Rekkenbeil markus@bionix-it.de
