### PR TITLE
add an updates_timeout option to apt::params (PR fix)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ The parameters for `apt` are not required in general and are predominantly for d
       proxy_port           => '8080',
       purge_sources_list   => false,
       purge_sources_list_d => false,
-      purge_preferences_d  => false
+      purge_preferences_d  => false,
+      update_timeout       => undef
     }
 
 Puppet will manage your system's `sources.list` file and `sources.list.d` directory but will do its best to respect existing content. 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,6 +12,8 @@
 #     true, Puppet will purge all unmanaged entries from sources.list
 #   purge_sources_list_d - Accepts true or false. Defaults to false. If set
 #     to true, Puppet will purge all unmanaged entries from sources.list.d
+#   update_timeout - Overrides the exec timeout in seconds for apt-get update.
+#     If not set defaults to Exec's default (300)
 #
 # Actions:
 #
@@ -27,7 +29,8 @@ class apt(
   $proxy_port           = '8080',
   $purge_sources_list   = false,
   $purge_sources_list_d = false,
-  $purge_preferences_d  = false
+  $purge_preferences_d  = false,
+  $update_timeout       = undef
 ) {
 
   include apt::params

--- a/manifests/update.pp
+++ b/manifests/update.pp
@@ -5,5 +5,6 @@ class apt::update {
     command     => "${apt::params::provider} update",
     logoutput   => 'on_failure',
     refreshonly => true,
+    timeout     => $apt::update_timeout,
   }
 }


### PR DESCRIPTION
Slight modification of PR #159, apt_timeout now option in init.pp defaulting to Exec timeout default, also updated some documentation.
