### PR TITLE
Ensuring that the resource exists for sources_lists_d

### DIFF
--- a/manifests/ppa.pp
+++ b/manifests/ppa.pp
@@ -51,6 +51,10 @@ define apt::ppa(
     ],
   }
 
+  file { $sources_list_d:
+    ensure => directory
+  }
+
   file { "${sources_list_d}/${sources_list_d_filename}":
     ensure  => file,
     require => Exec["add-apt-repository-${name}"],


### PR DESCRIPTION
I would get the following error without ensuring the resource existed.

```
Info: Retrieving plugin
Info: Loading facts in /var/lib/puppet/lib/facter/facter_dot_d.rb
Info: Loading facts in /var/lib/puppet/lib/facter/pe_version.rb
Info: Loading facts in /var/lib/puppet/lib/facter/root_home.rb
Info: Loading facts in /var/lib/puppet/lib/facter/puppi_projects.rb
Info: Loading facts in /var/lib/puppet/lib/facter/puppet_vardir.rb
Info: Caching catalog for ip-10-122-45-189.ap-northeast-1.compute.internal
Error: Failed to apply catalog: Could not find dependency File[/etc/apt/sources.list.d] for Exec[add-apt-repository-ppa:webupd8team/java]
```
