### PR TITLE
getparam() isn't available in all stdlib versions.

### DIFF
--- a/manifests/ppa.pp
+++ b/manifests/ppa.pp
@@ -28,8 +28,8 @@ define apt::ppa(
   }
 
   if defined(Class[apt]) {
-    $proxy_host = getparam(Class[apt], 'proxy_host')
-    $proxy_port = getparam(Class[apt], 'proxy_port')
+    $proxy_host = $apt::proxy_host
+    $proxy_port = $apt::proxy_port
     case  $proxy_host {
       false, '': {
         $proxy_env = []


### PR DESCRIPTION
There's no need for getparam() here when a regular variable works
just fine.
