### PR TITLE
add an 'ensure' parameter to apt::ppa

### DIFF
--- a/manifests/ppa.pp
+++ b/manifests/ppa.pp
@@ -1,6 +1,7 @@
 # ppa.pp
 
 define apt::ppa(
+  $ensure  = 'present',
   $release = $::lsbdistcodename,
   $options = '-y'
 ) {
@@ -18,42 +19,51 @@ define apt::ppa(
   $filename_without_ppa     = regsubst($filename_without_dots, '^ppa:', '', 'G')
   $sources_list_d_filename  = "${filename_without_ppa}-${release}.list"
 
-  $package = $::lsbdistrelease ? {
-    /^[1-9]\..*|1[01]\..*|12.04$/ => 'python-software-properties',
-    default  => 'software-properties-common',
-  }
-
-  if ! defined(Package[$package]) {
-    package { $package: }
-  }
-
-  if defined(Class[apt]) {
-    $proxy_host = $apt::proxy_host
-    $proxy_port = $apt::proxy_port
-    case  $proxy_host {
-      false, '': {
-        $proxy_env = []
-      }
-      default: {$proxy_env = ["http_proxy=http://${proxy_host}:${proxy_port}", "https_proxy=http://${proxy_host}:${proxy_port}"]}
+  if $ensure == 'present' {
+    $package = $::lsbdistrelease ? {
+        /^[1-9]\..*|1[01]\..*|12.04$/ => 'python-software-properties',
+        default  => 'software-properties-common',
     }
-  } else {
-    $proxy_env = []
-  }
-  exec { "add-apt-repository-${name}":
-    environment  => $proxy_env,
-    command      => "/usr/bin/add-apt-repository ${options} ${name}",
-    unless       => "/usr/bin/test -s ${sources_list_d}/${sources_list_d_filename}",
-    logoutput    => 'on_failure',
-    notify       => Exec['apt_update'],
-    require      => [
-      File[$sources_list_d],
-      Package[$package],
-    ],
-  }
 
-  file { "${sources_list_d}/${sources_list_d_filename}":
-    ensure  => file,
-    require => Exec["add-apt-repository-${name}"],
+    if ! defined(Package[$package]) {
+        package { $package: }
+    }
+
+    if defined(Class[apt]) {
+        $proxy_host = $apt::proxy_host
+        $proxy_port = $apt::proxy_port
+        case  $proxy_host {
+        false, '': {
+            $proxy_env = []
+        }
+        default: {$proxy_env = ["http_proxy=http://${proxy_host}:${proxy_port}", "https_proxy=http://${proxy_host}:${proxy_port}"]}
+        }
+    } else {
+        $proxy_env = []
+    }
+    exec { "add-apt-repository-${name}":
+        environment  => $proxy_env,
+        command      => "/usr/bin/add-apt-repository ${options} ${name}",
+        unless       => "/usr/bin/test -s ${sources_list_d}/${sources_list_d_filename}",
+        logoutput    => 'on_failure',
+        notify       => Exec['apt_update'],
+        require      => [
+        File[$sources_list_d],
+        Package[$package],
+        ],
+    }
+
+    file { "${sources_list_d}/${sources_list_d_filename}":
+        ensure  => file,
+        require => Exec["add-apt-repository-${name}"],
+    }
+  }
+  else {
+
+    file { "${sources_list_d}/${sources_list_d_filename}":
+        ensure => 'absent',
+        notify => Exec['apt_update'],
+    }
   }
 
   # Need anchor to provide containment for dependencies.


### PR DESCRIPTION
...as sometimes we want to get rid of them. :)

We leave this a little loose; rather than simply requiring a boolean for
$ensure, we set the stage for doing an easy switch to also allowing 'purge' at
some point in the future.
