### PR TITLE
Retry package installs

### DIFF
--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -61,6 +61,8 @@ define apt::source(
       command     => "${provider} -y install ${required_packages}",
       logoutput   => 'on_failure',
       refreshonly => true,
+      tries       => 3,
+      try_sleep   => 1,
       subscribe   => File["${name}.list"],
       before      => Exec['apt_update'],
     }


### PR DESCRIPTION
Sometimes package installs can fail to aquire the lock file, so retry
the command in that case.

```
Notice: /Stage[main]/Hostbase::Apt/Apt::Source[debian-backports]/Exec[Required packages: 'debian-keyring debian-archive-keyring' for debian-backports]/returns: E: Could not get lock /var/lib/dpkg/lock - open (11: Resource temporarily unavailable)
Notice: /Stage[main]/Hostbase::Apt/Apt::Source[debian-backports]/Exec[Required packages: 'debian-keyring debian-archive-keyring' for debian-backports]/returns: E: Unable to lock the administration directory (/var/lib/dpkg/), is another process using it?
Error: /Stage[main]/Hostbase::Apt/Apt::Source[debian-backports]/Exec[Required packages: 'debian-keyring debian-archive-keyring' for debian-backports]: Failed to call refresh: /usr/bin/apt-get -y install debian-keyring debian-archive-keyring returned 100 instead of one of [0]
Error: /Stage[main]/Hostbase::Apt/Apt::Source[debian-backports]/Exec[Required packages: 'debian-keyring debian-archive-keyring' for debian-backports]: /usr/bin/apt-get -y install debian-keyring debian-archive-keyring returned 100 instead of one of [0]
```
