### PR TITLE
fix deprecation warning with rspec-puppet 1.0.0 (and newer)

### DIFF
--- a/spec/classes/apt_spec.rb
+++ b/spec/classes/apt_spec.rb
@@ -39,7 +39,7 @@ describe 'apt', :type => :class do
         end
       end
 
-      it { should include_class("apt::params") }
+      it { should contain_class("apt::params") }
 
       it {
         if param_hash[:purge_sources_list]

--- a/spec/classes/release_spec.rb
+++ b/spec/classes/release_spec.rb
@@ -8,7 +8,7 @@ describe 'apt::release', :type => :class do
 
   let (:params) { param_set }
 
-  it { should include_class("apt::params") }
+  it { should contain_class("apt::params") }
 
   it {
     should contain_file("/etc/apt/apt.conf.d/01release").with({

--- a/spec/defines/pin_spec.rb
+++ b/spec/defines/pin_spec.rb
@@ -85,7 +85,7 @@ describe 'apt::pin', :type => :define do
         param_set[:params]
       end
 
-      it { should include_class("apt::params") }
+      it { should contain_class("apt::params") }
 
       it { should contain_file("#{title}.pref").with({
           'ensure'  => param_hash[:ensure],


### PR DESCRIPTION
include_class has been deprecated.
