### PR TITLE
Skip apt-add even if .list file is empty

### DIFF
--- a/manifests/ppa.pp
+++ b/manifests/ppa.pp
@@ -44,7 +44,7 @@ define apt::ppa(
     exec { "add-apt-repository-${name}":
         environment  => $proxy_env,
         command      => "/usr/bin/add-apt-repository ${options} ${name}",
-        unless       => "/usr/bin/test -s ${sources_list_d}/${sources_list_d_filename}",
+        unless       => "/usr/bin/test -f ${sources_list_d}/${sources_list_d_filename}",
         logoutput    => 'on_failure',
         notify       => Exec['apt_update'],
         require      => [


### PR DESCRIPTION
Change to skip apt-add if .list file is present, even if it's empty.

On Elementary OS Luna, adding e.g. git-core/ppa creates `git-core-ppa-precise.list` containing the actual data, and an empty file called `git-core-ppa-luna.list` as a placeholder. This makes `apt::ppa` execute on every Puppet run. Wouldn't have thought allowing an empty file would break anything, but happy to be corrected.
