### PR TITLE
Apt::ppa should exec with root

### DIFF
--- a/manifests/ppa.pp
+++ b/manifests/ppa.pp
@@ -45,6 +45,7 @@ define apt::ppa(
         environment  => $proxy_env,
         command      => "/usr/bin/add-apt-repository ${options} ${name}",
         unless       => "/usr/bin/test -s ${sources_list_d}/${sources_list_d_filename}",
+        user         => 'root',
         logoutput    => 'on_failure',
         notify       => Exec['apt_update'],
         require      => [


### PR DESCRIPTION
Sometimes one could define an Exec user globally. This would make add-apt-repository fail because it do not use user root.

User root is needed to execute this command.
