### PR TITLE
Making the apt::key regsubst get less chars

### DIFF
--- a/manifests/key.pp
+++ b/manifests/key.pp
@@ -10,8 +10,8 @@ define apt::key (
   include apt::params
 
   $upkey = upcase($key)
-  # trim the key to the last 8 chars so we can match longer keys with apt-key list too
-  $trimmedkey = regsubst($upkey, '^.*(.{8})$', '\1')
+  # trim the key to the last 8 chars (or down to 3) so we can match longer keys with apt-key list too
+  $trimmedkey = regsubst($upkey, '(.{3,8})$', '\1')
 
   if $key_content {
     $method = 'content'


### PR DESCRIPTION
Sometimes keys don't have 8 chars (like 'Google'), but I think 3 the minimum.
Making the regex get the last 3 to 8 chars.
Tested with Rubular to assure the result is the same as the old regex.

One Issue is if the developer put a really generic key, like 'red'. It would match RedHat and Redmine. I don't think this is a great issue anyway.
