### PR TITLE
fixed include, contained dash instead of underline.

### DIFF
--- a/tests/unattended-upgrades.pp
+++ b/tests/unattended-upgrades.pp
@@ -1,1 +1,0 @@
-include apt::unattended-upgrades

--- a/tests/unattended_upgrades.pp
+++ b/tests/unattended_upgrades.pp
@@ -1,0 +1,1 @@
+include apt::unattended_upgrades


### PR DESCRIPTION
I did it to please my syntax validator, but I'm assuming it wasn't functioning as expected either.
