### PR TITLE
Make apt.conf.d/proxy world readable and add a newline

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -128,8 +128,11 @@ Package: bogus-package\n",
   file { 'configure-apt-proxy':
     ensure  => $proxy_set,
     path    => "${apt_conf_d}/proxy",
-    content => "Acquire::http::Proxy \"http://${proxy_host}:${proxy_port}\";",
+    content => "Acquire::http::Proxy \"http://${proxy_host}:${proxy_port}\";\n",
     notify  => Exec['apt_update'],
+    mode    => '0644',
+    owner   => root,
+    group   => root,
   }
 
   # Need anchor to provide containment for dependencies.

--- a/spec/classes/apt_spec.rb
+++ b/spec/classes/apt_spec.rb
@@ -164,7 +164,7 @@ describe 'apt', :type => :class do
           if param_hash[:proxy_host]
             should contain_file('configure-apt-proxy').with(
               'path'    => '/etc/apt/apt.conf.d/proxy',
-              'content' => "Acquire::http::Proxy \"http://#{param_hash[:proxy_host]}:#{param_hash[:proxy_port]}\";",
+              'content' => "Acquire::http::Proxy \"http://#{param_hash[:proxy_host]}:#{param_hash[:proxy_port]}\";\n",
               'notify'  => "Exec[apt_update]"
             )
           else


### PR DESCRIPTION
At least on some systems the proxy configuration file is created with 700 permissions, making commands like "apt-cache policy somepackage" fail when run without root permissions.

Configuration files should generally end with a newline.
