### PR TITLE
Release 2.0.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,24 @@
+2014-02-13 2.0.0
+Summary:
+This is basically a bugfix release, plus the addition of `ensure` in
+`apt::ppa` and changing the default release in `apt::force` to none. This
+latter change is backwards-incompatible, but very minor.
+
+Backwards-Incompatible:
+- Change default value of `apt::force` from `'testing'` to `false`
+
+Features:
+- Add `ensure` to apt::ppa for absent use case
+
+Bugfixes:
+- Fix apt::force unable to upgrade packages from releases other than its original
+- Removed a few refeneces to aptitude instead of apt-get for portability
+- Removed call to getparam() due to stdlib dependency
+- Correct apt::source template when architecture is provided
+- Retry package installs if apt is locked
+- Use root to exec in apt::ppa
+- Updated tests and converted acceptance tests to beaker
+
 2013-10-08 1.4.0
 
 Summary:

--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name    'puppetlabs-apt'
-version '1.4.0'
+version '2.0.0'
 source  'https://github.com/puppetlabs/puppetlabs-apt'
 author  'Evolving Web / Puppet Labs'
 license 'Apache License 2.0'


### PR DESCRIPTION
Summary:
This is basically a bugfix release, plus the addition of `ensure` in
`apt::ppa` and changing the default release in `apt::force` to none. This
latter change is backwards-incompatible, but very minor.

Backwards-Incompatible:
- Change default value of `apt::force` from `'testing'` to `false`

Features:
- Add `ensure` to apt::ppa for absent use case

Bugfixes:
- Fix apt::force unable to upgrade packages from releases other than its original
- Removed a few refeneces to aptitude instead of apt-get for portability
- Removed call to getparam() due to stdlib dependency
- Correct apt::source template when architecture is provided
- Retry package installs if apt is locked
- Use root to exec in apt::ppa
- Updated tests and converted acceptance tests to beaker
