### PR TITLE
Force owner and mode on ppa files

### DIFF
--- a/manifests/ppa.pp
+++ b/manifests/ppa.pp
@@ -67,6 +67,9 @@ define apt::ppa(
 
     file { "${sources_list_d}/${sources_list_d_filename}":
         ensure => 'absent',
+        mode   => '0644',
+        owner  => 'root',
+        gruop  => 'root',
         notify => Exec['apt_update'],
     }
   }


### PR DESCRIPTION
This will make sure the generated files in ${sources_list_d} are a standard ownership and file mode.

I reached a problem with a module was forcing ownership of all files generated by the mode to be owned by the application that also include adding an apt::ppa resource.

eg.

``` puppet
File {
  mode => '0600',
  owner => 'applicationname',
  group => 'applicationname',
}
apt::ppa { 'ppa:extra-packages/ppa': }
```

Would cause the following permissions

``` sh
ls -l /etc/apt/sources.list.d/extra-packages
-rw------- 1 applicationname applicationname  69 2014-02-04 10:46 extra-packages.list
```

Then the knock-on was `apt-check` was not able to read the new ppa configuration.

``` sh
/usr/lib/update-notifier/apt-check
E: Error: Opening the cache (E:Opening /etc/apt/sources.list.d/extra-packages.list - ifstream::ifstream (13: Permission denied), E:The list of sources could not be read.)
```
