### PR TITLE
apt_key: Support fetching keys over FTP.

### DIFF
--- a/lib/puppet/provider/apt_key/apt_key.rb
+++ b/lib/puppet/provider/apt_key/apt_key.rb
@@ -1,6 +1,14 @@
 require 'date'
 require 'open-uri'
+require 'net/ftp'
 require 'tempfile'
+
+if RUBY_VERSION == '1.8.7'
+  # Mothers cry, puppies die and Ruby 1.8.7's open-uri needs to be
+  # monkeypatched to support passing in :ftp_passive_mode.
+  require 'puppet_x/apt_key/patch_openuri'
+  OpenURI::Options.merge!({:ftp_active_mode => false,})
+end
 
 Puppet::Type.type(:apt_key).provide(:apt_key) do
 
@@ -99,8 +107,8 @@ Puppet::Type.type(:apt_key).provide(:apt_key) do
       value
     else
       begin
-        key = open(value).read
-      rescue OpenURI::HTTPError => e
+        key = open(value, :ftp_active_mode => false).read
+      rescue OpenURI::HTTPError, Net::FTPPermError => e
         fail("#{e.message} for #{resource[:source]}")
       rescue SocketError
         fail("could not resolve #{resource[:source]}")

--- a/lib/puppet/type/apt_key.rb
+++ b/lib/puppet/type/apt_key.rb
@@ -49,8 +49,8 @@ Puppet::Type.newtype(:apt_key) do
   end
 
   newparam(:source) do
-    desc 'Location of a GPG key file, /path/to/file, http:// or https://'
-    newvalues(/\Ahttps?:\/\//, /\A\/\w+/)
+    desc 'Location of a GPG key file, /path/to/file, ftp://, http:// or https://'
+    newvalues(/\Ahttps?:\/\//, /\Aftp:\/\//, /\A\/\w+/)
   end
 
   autorequire(:file) do

--- a/lib/puppet_x/apt_key/patch_openuri.rb
+++ b/lib/puppet_x/apt_key/patch_openuri.rb
@@ -1,0 +1,63 @@
+require 'uri'
+require 'stringio'
+require 'time'
+
+module URI
+  class FTP
+    def buffer_open(buf, proxy, options) # :nodoc:
+      if proxy
+        OpenURI.open_http(buf, self, proxy, options)
+        return
+      end
+      require 'net/ftp'
+
+      directories = self.path.split(%r{/}, -1)
+      directories.shift if directories[0] == '' # strip a field before leading slash
+      directories.each {|d|
+        d.gsub!(/%([0-9A-Fa-f][0-9A-Fa-f])/) { [$1].pack("H2") }
+      }
+      unless filename = directories.pop
+        raise ArgumentError, "no filename: #{self.inspect}"
+      end
+      directories.each {|d|
+        if /[\r\n]/ =~ d
+          raise ArgumentError, "invalid directory: #{d.inspect}"
+        end
+      }
+      if /[\r\n]/ =~ filename
+        raise ArgumentError, "invalid filename: #{filename.inspect}"
+      end
+      typecode = self.typecode
+      if typecode && /\A[aid]\z/ !~ typecode
+        raise ArgumentError, "invalid typecode: #{typecode.inspect}"
+      end
+
+      # The access sequence is defined by RFC 1738
+      ftp = Net::FTP.open(self.host)
+      ftp.passive = true if !options[:ftp_active_mode]
+      # todo: extract user/passwd from .netrc.
+      user = 'anonymous'
+      passwd = nil
+      user, passwd = self.userinfo.split(/:/) if self.userinfo
+      ftp.login(user, passwd)
+      directories.each {|cwd|
+        ftp.voidcmd("CWD #{cwd}")
+      }
+      if typecode
+        # xxx: typecode D is not handled.
+        ftp.voidcmd("TYPE #{typecode.upcase}")
+      end
+      if options[:content_length_proc]
+        options[:content_length_proc].call(ftp.size(filename))
+      end
+      ftp.retrbinary("RETR #{filename}", 4096) { |str|
+        buf << str
+        options[:progress_proc].call(buf.size) if options[:progress_proc]
+      }
+      ftp.close
+      buf.io.rewind
+    end
+
+    include OpenURI::OpenRead
+  end
+end

--- a/spec/unit/puppet/type/apt_key_spec.rb
+++ b/spec/unit/puppet/type/apt_key_spec.rb
@@ -143,6 +143,13 @@ describe Puppet::Type::type(:apt_key) do
       )}.to_not raise_error
     end
 
+    it 'allows the ftp URI scheme in source' do
+      expect { Puppet::Type.type(:apt_key).new(
+        :id      => '4BD6EC30',
+        :source  => 'ftp://pgp.mit.edu'
+      )}.to_not raise_error
+    end
+
     it 'allows an absolute path in source' do
       expect { Puppet::Type.type(:apt_key).new(
         :id      => '4BD6EC30',


### PR DESCRIPTION
The current `apt::key` type also supports fetching key's from FTP, this commit adds it to our `apt_key` provider so we don't lose that functionality.

I am extremely sorry for the `patch-openuri` hack this commit introduces, please try and not hold it against me for the rest of my life.

The problem is that in Ruby 1.8.7 net/ftp defaults to using active mode for FTP which breaks just about everywhere a firewall is involved. Unfortunately it is only since Ruby 1.9.3 that net/ftp defaults to passive mode and it is only since 1.9.3 that open-uri's `open()` method accepts the `:ftp_active_mode` option.

So, in case this happens to be running on 1.8.7 we forcefully merge `:ftp_active_mode => false` into OpenURI's `Options` hash and then overload the the `buffer_open()` method. I couldn't find any other way to do this. The only thing that's changed with the original implementation of this in Ruby 1.8.7 is the extra `ftp.passive = true if !options[:ftp_active_mode]` in the body (which I stole from the 1.9.3 implementation).
