### PR TITLE
Don't pass options to ppa on lucid

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,11 +21,17 @@ class apt::params {
     }
     'ubuntu': {
       case $::lsbdistcodename {
-        'hardy','lucid','maverick','natty','oneiric','precise': {
+        'hardy','maverick','natty','oneiric','precise': {
           $backports_location = 'http://us.archive.ubuntu.com/ubuntu'
+          $ppa_options = 'y'
+        }
+        'lucid': {
+          $backports_location = 'http://us.archive.ubuntu.com/ubuntu'
+          $ppa_options = undef
         }
         default: {
           $backports_location = 'http://old-releases.ubuntu.com/ubuntu'
+          $ppa_options = 'y'
         }
       }
     }

--- a/manifests/ppa.pp
+++ b/manifests/ppa.pp
@@ -2,7 +2,7 @@
 
 define apt::ppa(
   $release = $::lsbdistcodename,
-  $options = '-y'
+  $options = $apt::params::ppa_options,
 ) {
   $ensure  = 'present'
   include apt::params

--- a/spec/acceptance/apt_ppa_spec.rb
+++ b/spec/acceptance/apt_ppa_spec.rb
@@ -27,14 +27,13 @@ if fact('operatingsystem') == 'Ubuntu'
       end
     end
 
-    context 'readding a removed ppa.' do
+    context 'reading a removed ppa.' do
       it 'setup' do
-        shell('add-apt-repository -y ppa:raravena80/collectd5')
         # This leaves a blank file
-        shell('add-apt-repository --remove ppa:raravena80/collectd5')
+        shell('echo > /etc/apt/sources.list.d/raravena80-collectd5-$(lsb_release -c -s).list')
       end
 
-      it 'should readd it successfully' do
+      it 'should read it successfully' do
         pp = <<-EOS
         include '::apt'
         apt::ppa { 'ppa:raravena80/collectd5': }
@@ -71,30 +70,31 @@ if fact('operatingsystem') == 'Ubuntu'
       end
     end
 
-    context 'options' do
-      context '-y' do
-        it 'works without failure' do
-          pp = <<-EOS
-          include '::apt'
-          apt::ppa { 'ppa:canonical-kernel-team/ppa':
-            release => precise,
-            options => '-y',
-          }
-          EOS
+    if ! default[:platform].match(/10\.04/)
+      context 'options' do
+        context '-y' do
+          it 'works without failure' do
+            pp = <<-EOS
+            include '::apt'
+            apt::ppa { 'ppa:canonical-kernel-team/ppa':
+              release => precise,
+              options => '-y',
+            }
+            EOS
 
-          shell('rm -rf /etc/apt/sources.list.d/canonical-kernel-team-ppa*', :acceptable_exit_codes => [0,1,2])
-          apply_manifest(pp, :catch_failures => true)
-        end
+            shell('rm -rf /etc/apt/sources.list.d/canonical-kernel-team-ppa*', :acceptable_exit_codes => [0,1,2])
+            apply_manifest(pp, :catch_failures => true)
+          end
 
-        describe file('/etc/apt/sources.list.d/canonical-kernel-team-ppa-precise.list') do
-          it { should be_file }
+          describe file('/etc/apt/sources.list.d/canonical-kernel-team-ppa-precise.list') do
+            it { should be_file }
+          end
         end
       end
-    end
 
-    context 'reset' do
-      it { shell('rm -rf /etc/apt/sources.list.d/canonical-kernel-team-ppa*', :acceptable_exit_codes => [0,1,2]) }
+      context 'reset' do
+        it { shell('rm -rf /etc/apt/sources.list.d/canonical-kernel-team-ppa*', :acceptable_exit_codes => [0,1,2]) }
+      end
     end
-
   end
 end

--- a/spec/acceptance/nodesets/ubuntu-server-10044-x64.yml
+++ b/spec/acceptance/nodesets/ubuntu-server-10044-x64.yml
@@ -1,0 +1,11 @@
+HOSTS:
+  ubuntu-server-10044-x64:
+    roles:
+      - master
+    platform: ubuntu-10.04-amd64
+    box : ubuntu-server-10044-x64-vbox4210-nocm
+    box_url : http://puppet-vagrant-boxes.puppetlabs.com/ubuntu-server-10044-x64-vbox4210-nocm.box
+    hypervisor : vagrant
+CONFIG:
+  log_level: debug
+  type: git

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,17 +1,18 @@
 require 'beaker-rspec'
 
+# Install Puppet
 unless ENV['RS_PROVISION'] == 'no'
   hosts.each do |host|
-    # Install Puppet
     if host.is_pe?
       install_pe
     else
-      install_package host, 'rubygems'
-      on host, 'gem install puppet --no-ri --no-rdoc'
+      install_puppet
       on host, "mkdir -p #{host['distmoduledir']}"
     end
   end
 end
+
+UNSUPPORTED_PLATFORMS = ['windows','aix','solaris',/el-(4|5|6)/]
 
 RSpec.configure do |c|
   # Project root


### PR DESCRIPTION
Lucid (10.04) has `add-apt-repository` but it doesn't accept any options. The define defaulted to `-y` but this changes that on lucid.

This was made 7 months ago, so apparently no one cares about 10.04 any more.
