### PR TITLE
apt: Allow managing of preferences file.

### DIFF
--- a/spec/acceptance/apt_spec.rb
+++ b/spec/acceptance/apt_spec.rb
@@ -175,6 +175,50 @@ describe 'apt class' do
     end
   end
 
+  context 'purge_preferences' do
+    context 'false' do
+      it 'creates a preferences file' do
+        shell("echo 'original' > /etc/apt/preferences")
+      end
+
+      it 'should work with no errors' do
+        pp = <<-EOS
+        class { 'apt': purge_preferences => false }
+        EOS
+
+        apply_manifest(pp, :catch_failures => true)
+      end
+
+      describe file('/etc/apt/preferences') do
+        it { should be_file }
+        it 'is not managed by Puppet' do
+          shell("grep 'original' /etc/apt/preferences", {:acceptable_exit_codes => 0})
+        end
+      end
+    end
+
+    context 'true' do
+      it 'creates a preferences file' do
+        shell('touch /etc/apt/preferences')
+      end
+
+      it 'should work with no errors' do
+        pp = <<-EOS
+        class { 'apt': purge_preferences => true }
+        EOS
+
+        apply_manifest(pp, :catch_failures => true)
+      end
+
+      describe file('/etc/apt/preferences') do
+        it { should be_file }
+        it 'is managed by Puppet' do
+          shell("grep 'Explanation' /etc/apt/preferences", {:acceptable_exit_codes => 0})
+        end
+      end
+    end
+  end
+
   context 'purge_preferences_d' do
     context 'false' do
       it 'creates a preferences file' do

--- a/spec/classes/apt_spec.rb
+++ b/spec/classes/apt_spec.rb
@@ -19,6 +19,10 @@ describe 'apt', :type => :class do
       :purge_sources_list_d => true,
     },
     {
+      :purge_preferences   => true,
+      :purge_preferences_d => true,
+    },
+    {
       :disable_keys => false
     }
   ].each do |param_set|
@@ -82,6 +86,49 @@ describe 'apt', :type => :class do
             'purge'   => false,
             'recurse' => false,
             'notify'  => 'Exec[apt_update]'
+          })
+        end
+      }
+      it {
+        if param_hash[:purge_preferences]
+          should create_file('apt-preferences').with({
+            :ensure  => 'present',
+            :path    => '/etc/apt/preferences',
+            :owner   => 'root',
+            :group   => 'root',
+            :mode    => '0644',
+            :content => /Explanation/,
+          })
+        else
+          should create_file('apt-preferences').with({
+            :ensure  => 'present',
+            :path    => '/etc/apt/preferences',
+            :owner   => 'root',
+            :group   => 'root',
+            :mode    => '0644',
+            :content => nil,
+          })
+        end
+      }
+
+      it {
+        if param_hash[:purge_preferences_d]
+          should create_file("preferences.d").with({
+            'path'    => "/etc/apt/preferences.d",
+            'ensure'  => "directory",
+            'owner'   => "root",
+            'group'   => "root",
+            'purge'   => true,
+            'recurse' => true,
+          })
+        else
+          should create_file("preferences.d").with({
+            'path'    => "/etc/apt/preferences.d",
+            'ensure'  => "directory",
+            'owner'   => "root",
+            'group'   => "root",
+            'purge'   => false,
+            'recurse' => false,
           })
         end
       }


### PR DESCRIPTION
We already had a feature to manage and purge entries in preferences.d
but not the preferences file in /etc/apt. This commit adds that
capability.

Fixes #199
