### PR TITLE
Add ability to specify hash of apt sources in hiera

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,27 @@ If you would like to configure your system so the source is the Puppet Labs APT 
       key_server => 'pgp.mit.edu',
     }
 
+
+#### Hiera example
+<pre>
+apt::sources:
+  'debian_unstable':
+      location: 'http://debian.mirror.iweb.ca/debian/'
+      release: 'unstable'
+      repos: 'main contrib non-free'
+      required_packages: 'debian-keyring debian-archive-keyring'
+      key: '55BE302B'
+      key_server: 'subkeys.pgp.net'
+      pin: '-10'
+      include_src: 'true'
+
+  'puppetlabs':
+      location: 'http://apt.puppetlabs.com'
+      repos: 'main'
+      key: '4BD6EC30'
+      key_server: 'pgp.mit.edu'
+</pre>
+
 ### Testing
 
 The APT module is mostly a collection of defined resource types, which provide reusable logic that can be leveraged to manage APT. It does provide smoke tests for testing functionality on a target system, as well as spec tests for checking a compiled catalog against an expected set of resources.
@@ -224,6 +245,7 @@ A lot of great people have contributed to this module. A somewhat current list f
 * Branan Purvine-Riley <branan@puppetlabs.com>
 * Christian G. Warden <cwarden@xerus.org>
 * Dan Bode <bodepd@gmail.com> <dan@puppetlabs.com>
+* Daniel Tremblay <github@danieltremblay.ca>
 * Garrett Honeycutt <github@garretthoneycutt.com>
 * Jeff Wallace <jeff@evolvingweb.ca> <jeff@tjwallace.ca>
 * Ken Barber <ken@bob.sh>

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -31,7 +31,8 @@ class apt(
   $purge_sources_list_d = false,
   $purge_preferences    = false,
   $purge_preferences_d  = false,
-  $update_timeout       = undef
+  $update_timeout       = undef,
+  $sources              = undef
 ) {
 
   include apt::params
@@ -135,5 +136,11 @@ Package: bogus-package\n",
   # Need anchor to provide containment for dependencies.
   anchor { 'apt::update':
     require => Class['apt::update'],
+  }
+
+  # manage sources if present
+  if $sources != undef {
+   validate_hash($sources)
+   create_resources('apt::source', $sources)
   }
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+describe 'apt' do
+  context 'with sources defined on valid osfamily' do
+    let :facts do
+      { :osfamily        => 'Debian',
+        :lsbdistcodename => 'precise',
+        :lsbdistid       => 'Debian',
+      }
+    end
+    let(:params) { { :sources => {
+      'debian_unstable' => {
+        'location'          => 'http://debian.mirror.iweb.ca/debian/',
+        'release'           => 'unstable',
+        'repos'             => 'main contrib non-free',
+        'required_packages' => 'debian-keyring debian-archive-keyring',
+        'key'               => '55BE302B',
+        'key_server'        => 'subkeys.pgp.net',
+        'pin'               => '-10',
+        'include_src'       => true
+      },
+      'puppetlabs' => {
+        'location'   => 'http://apt.puppetlabs.com',
+        'repos'      => 'main',
+        'key'        => '4BD6EC30',
+        'key_server' => 'pgp.mit.edu',
+      }
+    } } }
+
+    it {
+      should contain_file('debian_unstable.list').with({
+        'ensure'  => 'present',
+        'path'    => '/etc/apt/sources.list.d/debian_unstable.list',
+        'owner'   => 'root',
+        'group'   => 'root',
+        'mode'    => '0644',
+        'notify'  => 'Exec[apt_update]',
+      })
+    }
+
+    it { should contain_file('debian_unstable.list').with_content(/^deb http:\/\/debian.mirror.iweb.ca\/debian\/ unstable main contrib non-free$/) }
+    it { should contain_file('debian_unstable.list').with_content(/^deb-src http:\/\/debian.mirror.iweb.ca\/debian\/ unstable main contrib non-free$/) }
+
+    it {
+      should contain_file('puppetlabs.list').with({
+        'ensure'  => 'present',
+        'path'    => '/etc/apt/sources.list.d/puppetlabs.list',
+        'owner'   => 'root',
+        'group'   => 'root',
+        'mode'    => '0644',
+        'notify'  => 'Exec[apt_update]',
+      })
+    }
+
+    it { should contain_file('puppetlabs.list').with_content(/^deb http:\/\/apt.puppetlabs.com precise main$/) }
+    it { should contain_file('puppetlabs.list').with_content(/^deb-src http:\/\/apt.puppetlabs.com precise main$/) }
+  end
+end


### PR DESCRIPTION
This patch uses create_resources() to call apt::source which lets you
specify your sources in hiera.
