### PR TITLE
Add support to disable/enable installing of recommended packages

### DIFF
--- a/manifests/recommends.pp
+++ b/manifests/recommends.pp
@@ -16,6 +16,6 @@ class apt::recommends (
     owner   => root,
     group   => root,
     mode    => '0644',
-    content => "APT::Install-Recommends \"${install_recommends}\";"
+    content => "APT::Install-Recommends \"${install_recommends}\";\n"
   }
 }


### PR DESCRIPTION
Setting install_recommends to false helps keeping more control
over installed packages
