### PR TITLE
Add Ubuntu Trusty

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,7 +21,7 @@ class apt::params {
     }
     'ubuntu': {
       case $::lsbdistcodename {
-        'oneiric','precise','trusty': {
+        'precise','trusty': {
           $backports_location = 'http://us.archive.ubuntu.com/ubuntu'
           $ppa_options = '-y'
         }


### PR DESCRIPTION
It's in Beta now and has landed on the main mirrors.
