### PR TITLE
Remove ancient Puppet versions from matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ rvm:
 env:
   matrix:
     - PUPPET_GEM_VERSION="~> 2.7.0"
-    - PUPPET_GEM_VERSION="~> 3.1.0"
-    - PUPPET_GEM_VERSION="~> 3.2.0"
     - PUPPET_GEM_VERSION="~> 3.3.0"
     - PUPPET_GEM_VERSION="~> 3.4.0"
 matrix:
@@ -23,7 +21,5 @@ matrix:
       env: PUPPET_GEM_VERSION="~> 2.7.0"
     - rvm: 2.0.0
       env: PUPPET_GEM_VERSION="~> 2.7.0"
-    - rvm: 2.0.0
-      env: PUPPET_GEM_VERSION="~> 3.1.0"
 notifications:
   email: false


### PR DESCRIPTION
With PE 3.2 out of the door shipping with 3.4.3 I think it's time to shrink the matrix and get rid of 3.1 and 3.2. PE 3.x customers should just upgrade to 3.2, OS users should really be on 3.3+ by now.
