### PR TITLE
Remove testing for Puppet 2.7 compatibility.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,15 +11,9 @@ rvm:
   - 2.0.0
 env:
   matrix:
-    - PUPPET_GEM_VERSION="~> 2.7.0"
     - PUPPET_GEM_VERSION="~> 3.3.0"
     - PUPPET_GEM_VERSION="~> 3.4.0"
 matrix:
   fast_finish: true
-  exclude:
-    - rvm: 1.9.3
-      env: PUPPET_GEM_VERSION="~> 2.7.0"
-    - rvm: 2.0.0
-      env: PUPPET_GEM_VERSION="~> 2.7.0"
 notifications:
   email: false


### PR DESCRIPTION
With official supported modules now being a thing and having a version
of the APT module to which we will backport fixes until the next major
release it is time to say goodbye to Puppet 2.7.

So long and thanks for all the fish.
