### PR TITLE
Force owner and mode on ppa file creation

### DIFF
--- a/manifests/ppa.pp
+++ b/manifests/ppa.pp
@@ -60,6 +60,9 @@ define apt::ppa(
 
     file { "${sources_list_d}/${sources_list_d_filename}":
         ensure  => file,
+        mode   => '0644',
+        owner  => 'root',
+        gruop  => 'root',
         require => Exec["add-apt-repository-${name}"],
     }
   }


### PR DESCRIPTION
Pull #227 set the owner and group when the file is `ensure => absent`. This change sets the owner, group and permissions when creating the file.
