### PR TITLE
Fix typo

### DIFF
--- a/manifests/ppa.pp
+++ b/manifests/ppa.pp
@@ -69,7 +69,7 @@ define apt::ppa(
         ensure => 'absent',
         mode   => '0644',
         owner  => 'root',
-        gruop  => 'root',
+        group  => 'root',
         notify => Exec['apt_update'],
     }
   }


### PR DESCRIPTION
This was, luckily, a no-op, due to being ensure => absent,
