### PR TITLE
Use File.expand_path with require.

### DIFF
--- a/lib/puppet/provider/apt_key/apt_key.rb
+++ b/lib/puppet/provider/apt_key/apt_key.rb
@@ -6,7 +6,8 @@ require 'tempfile'
 if RUBY_VERSION == '1.8.7'
   # Mothers cry, puppies die and Ruby 1.8.7's open-uri needs to be
   # monkeypatched to support passing in :ftp_passive_mode.
-  require 'puppet_x/apt_key/patch_openuri'
+  require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..',
+                                    'puppet_x', 'apt_key', 'patch_openuri.rb'))
   OpenURI::Options.merge!({:ftp_active_mode => false,})
 end
 


### PR DESCRIPTION
For some reason, even though our own tests pass with `require puppet_x/apt_key/patch_openuri` every other module that depends on puppetlabs-apt is now breaking in tests claiming it can't load that module.

Somewhere along the way something is probably messing with `LOADPATH` causing this to trip up. This should fix the issues for everyone.

This commit affects:
- puppetlabs/puppetlabs-apt#229
- puppetlabs/puppetlabs-postgresql#391
