### PR TITLE
Bug fix for include_src

### DIFF
--- a/templates/source.list.erb
+++ b/templates/source.list.erb
@@ -1,5 +1,5 @@
 # <%= @name %>
 deb <% if @architecture %>[arch=<%= @architecture %>] <% end %><%= @location %> <%= @release_real %> <%= @repos %>
-<%- if @include_src then -%>
+<%- if @include_src == true then -%>
 deb-src <% if @architecture %>[arch=<%= @architecture %>] <% end %><%= @location %> <%= @release_real %> <%= @repos %>
 <%- end -%>


### PR DESCRIPTION
If I was to put the value for `include_src` as "false" or "none" or any other negative sounding value, it was still adding the deb-src line. So I forced it to "`== true`" and now it works

Credit goes to ramindk from #puppet@freenode
