### PR TITLE
backports: Allow setting a custom priority.

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,10 @@ Implementation
 
 Adds the necessary components to get backports for Ubuntu and Debian. The release name defaults to `$lsbdistcodename`. Setting this manually can cause undefined behavior (read: universe exploding).
 
+By default this class drops a Pin-file for Backports pinning it to a priority of 200, lower than the normal Debian archive which gets a priority of 500 to ensure your packages with `ensure => latest` don't get magically upgraded from Backports without your explicit say-so.
+
+If you raise the priority through the `pin_priority` parameter to *500*, identical to the rest of the Debian mirrors, normal policy goes into effect and the newest version wins/becomes the candidate apt will want to install or upgrade to. This means that if a package is available from Backports it and its dependencies will be pulled in from Backports unless you explicitly set the `ensure` attribute of the `package` resource to `installed`/`present` or a specific version.
+
 Limitations
 -----------
 

--- a/manifests/backports.pp
+++ b/manifests/backports.pp
@@ -6,6 +6,12 @@
 #   The ubuntu/debian release name. Defaults to $lsbdistcodename. Setting this
 #   manually can cause undefined behavior. (Read: universe exploding)
 #
+# [*pin_priority*]
+#   _default_: 200
+#
+#   The priority that should be awarded by default to all packages coming from
+#   the Debian Backports project.
+#
 # == Examples
 #
 #   include apt::backports
@@ -23,9 +29,14 @@
 #
 # Copyright 2011 Puppet Labs Inc, unless otherwise noted.
 class apt::backports(
-  $release  = $::lsbdistcodename,
-  $location = $apt::params::backports_location
+  $release      = $::lsbdistcodename,
+  $location     = $::apt::params::backports_location,
+  $pin_priority = 200,
 ) inherits apt::params {
+
+  if ! is_integer($pin_priority) {
+    fail('$pin_priority must be an integer')
+  }
 
   $release_real = downcase($release)
   $key = $::lsbdistid ? {
@@ -43,6 +54,6 @@ class apt::backports(
     repos      => $repos,
     key        => $key,
     key_server => 'pgp.mit.edu',
-    pin        => '200',
+    pin        => $pin_priority,
   }
 }

--- a/spec/acceptance/backports_spec.rb
+++ b/spec/acceptance/backports_spec.rb
@@ -49,6 +49,20 @@ describe 'apt::backports class', :unless => UNSUPPORTED_PLATFORMS.include?(fact(
     end
   end
 
+  context 'pin_priority' do
+    it 'should work with no errors' do
+      pp = <<-EOS
+      class { 'apt::backports': pin_priority => 500, }
+      EOS
+
+      apply_manifest(pp, :catch_failures => true)
+    end
+    describe file('/etc/apt/preferences.d/backports.pref') do
+      it { should be_file }
+      it { should contain "Pin-Priority: 500" }
+    end
+  end
+
   context 'reset' do
     it 'deletes backport files' do
       shell('rm -rf /etc/apt/sources.list.d/backports.list')

--- a/spec/classes/backports_spec.rb
+++ b/spec/classes/backports_spec.rb
@@ -1,6 +1,36 @@
 require 'spec_helper'
 describe 'apt::backports', :type => :class do
 
+  describe 'when asigning a custom priority to backports' do
+    let :facts do
+      {
+        'lsbdistcodename' => 'Karmic',
+        'lsbdistid'       => 'Ubuntu'
+      }
+    end
+
+    context 'integer priority' do
+      let :params do { :pin_priority => 500 } end
+
+      it { should contain_apt__source('backports').with({
+          'location'   => 'http://old-releases.ubuntu.com/ubuntu',
+          'release'    => 'karmic-backports',
+          'repos'      => 'main universe multiverse restricted',
+          'key'        => '437D05B5',
+          'key_server' => 'pgp.mit.edu',
+          'pin'        => 500,
+        })
+      }
+    end
+
+    context 'invalid priority' do
+      let :params do { :pin_priority => 'banana' } end
+      it 'should fail' do
+        expect { subject }.to raise_error(/must be an integer/)
+      end
+    end
+  end
+
   describe 'when turning on backports for ubuntu karmic' do
 
     let :facts do
@@ -16,7 +46,7 @@ describe 'apt::backports', :type => :class do
         'repos'      => 'main universe multiverse restricted',
         'key'        => '437D05B5',
         'key_server' => 'pgp.mit.edu',
-        'pin'        => '200',
+        'pin'        => 200,
       })
     }
   end
@@ -36,7 +66,7 @@ describe 'apt::backports', :type => :class do
         'repos'      => 'main contrib non-free',
         'key'        => '46925553',
         'key_server' => 'pgp.mit.edu',
-        'pin'        => '200',
+        'pin'        => 200,
       })
     }
   end
@@ -64,7 +94,7 @@ describe 'apt::backports', :type => :class do
         'repos'      => 'main contrib non-free',
         'key'        => '46925553',
         'key_server' => 'pgp.mit.edu',
-        'pin'        => '200',
+        'pin'        => 200,
       })
     }
   end


### PR DESCRIPTION
The module used to always pin backports to a priority of 200. This
default is still retained but is now configurable.

Additionally the default is now an Integer, not a 'quoted Integer' and
the tests have been updated to reflect this. This matters for future
parser as it will now kick people if they pass in a stringified integer
as priority.
