### PR TITLE
unattended_upgrades: Fix matching security archive

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,28 +10,40 @@ class apt::params {
       case $::lsbdistcodename {
         'squeeze': {
           $backports_location = 'http://backports.debian.org/debian-backports'
+          $legacy_origin       = true
+          $origins             = ['${distro_id} ${distro_codename}-security']
         }
         'wheezy': {
           $backports_location = 'http://ftp.debian.org/debian/'
+          $legacy_origin      = false
+          $origins            = ['origin=Debian,archive=stable,label=Debian-Security']
         }
         default: {
           $backports_location = 'http://http.debian.net/debian/'
+          $legacy_origin      = false
+          $origins            = ['origin=Debian,archive=stable,label=Debian-Security']
         }
       }
     }
     'ubuntu': {
       case $::lsbdistcodename {
-        'precise','trusty': {
-          $backports_location = 'http://us.archive.ubuntu.com/ubuntu'
-          $ppa_options = '-y'
-        }
         'lucid': {
           $backports_location = 'http://us.archive.ubuntu.com/ubuntu'
-          $ppa_options = undef
+          $ppa_options        = undef
+          $legacy_origin      = true
+          $origins            = ['${distro_id} ${distro_codename}-security']
+        }
+        'precise', 'trusty': {
+          $backports_location = 'http://us.archive.ubuntu.com/ubuntu'
+          $ppa_options        = '-y'
+          $legacy_origin      = true
+          $origins            = ['${distro_id}:${distro_codename}-security']
         }
         default: {
           $backports_location = 'http://old-releases.ubuntu.com/ubuntu'
-          $ppa_options = '-y'
+          $ppa_options        = '-y'
+          $legacy_origin      = true
+          $origins            = ['${distro_id}:${distro_codename}-security']
         }
       }
     }

--- a/manifests/unattended_upgrades.pp
+++ b/manifests/unattended_upgrades.pp
@@ -14,30 +14,29 @@
 # file and in /etc/cron.daily/apt
 #
 class apt::unattended_upgrades (
-  $origins = ['${distro_id}:${distro_codename}-security'],
-  $blacklist = [],
-  $update = "1",
-  $download = "1",
-  $upgrade = "1",
-  $autoclean = "7",
-  $auto_fix = true,
-  $minimal_steps = false,
+  $origins             = $::apt::params::origins,
+  $blacklist           = [],
+  $update              = "1",
+  $download            = "1",
+  $upgrade             = "1",
+  $autoclean           = "7",
+  $auto_fix            = true,
+  $minimal_steps       = false,
   $install_on_shutdown = false,
-  $mail_to = "NONE",
-  $mail_only_on_error = false,
-  $remove_unused = true,
-  $auto_reboot = false,
-  $dl_limit = "NONE",
-  $enable = "1",
-  $backup_interval = "0",
-  $backup_level = "3",
-  $max_age = "0",
-  $min_age = "0",
-  $max_size = "0",
-  $download_delta = "0",
-  $verbose = "0",
-) {
-  include apt::params
+  $mail_to             = "NONE",
+  $mail_only_on_error  = false,
+  $remove_unused       = true,
+  $auto_reboot         = false,
+  $dl_limit            = "NONE",
+  $enable              = "1",
+  $backup_interval     = "0",
+  $backup_level        = "3",
+  $max_age             = "0",
+  $min_age             = "0",
+  $max_size            = "0",
+  $download_delta      = "0",
+  $verbose             = "0",
+) inherits ::apt::params {
 
   validate_bool(
     $auto_fix,
@@ -47,6 +46,7 @@ class apt::unattended_upgrades (
     $remove_unused,
     $auto_reboot
   )
+  validate_array($origins)
 
   package { 'unattended-upgrades':
     ensure => present,

--- a/spec/classes/unattended_upgrades_spec.rb
+++ b/spec/classes/unattended_upgrades_spec.rb
@@ -25,16 +25,100 @@ describe 'apt::unattended_upgrades', :type => :class do
   }
 
   describe "origins" do
-    describe "with param defaults" do
-      let(:params) {{ }}
-      it { should contain_file(file_unattended).with_content(/^Unattended-Upgrade::Allowed-Origins \{\n\t"\$\{distro_id\}:\$\{distro_codename\}-security";\n\};$/) }
+    describe 'on Debian' do
+      default_facts = { :lsbdistid => 'Debian' }
+      context 'defaults' do
+        let :facts do default_facts end
+        it {
+          should contain_file(file_unattended).with_content(
+            /^Unattended-Upgrade::Origins-Pattern/
+          ).with_content(
+            /"origin=Debian,archive=stable,label=Debian-Security";/
+          )
+        }
+      end
+      context 'defaults with custom origin' do
+        let :facts do default_facts end
+        let :params do { :origins => ['bananana']} end
+        it {
+          should contain_file(file_unattended).with_content(
+            /^Unattended-Upgrade::Origins-Pattern/
+          ).with_content(
+            /"bananana";/
+          )
+        }
+      end
+      context 'defaults with invalid origin' do
+        let :facts do default_facts end
+        let :params do { :origins => 'bananana'} end
+        it {
+          expect {subject}.to raise_error(/is not an Array/)
+        }
+      end
+      context 'squeeze' do
+        let :facts do default_facts.merge({:lsbdistcodename => 'squeeze'}) end
+        it {
+          should contain_file(file_unattended).with_content(
+            /^Unattended-Upgrade::Allowed-Origins/
+          ).with_content(
+            /"\${distro_id} \${distro_codename}-security";/
+          )
+        }
+      end
+      context 'wheezy' do
+        let :facts do default_facts.merge({:lsbdistcodename => 'wheezy'}) end
+        it {
+          should contain_file(file_unattended).with_content(
+            /^Unattended-Upgrade::Origins-Pattern/
+          ).with_content(
+            /"origin=Debian,archive=stable,label=Debian-Security";/
+          )
+        }
+      end
     end
 
-    describe "with origins => ['ubuntu:precise-security']" do
-      let :params do
-        { :origins => ['ubuntu:precise-security'] }
+    describe 'on Ubuntu' do
+      default_facts = { :lsbdistid => 'Ubuntu' }
+      context 'default' do
+        let :facts do default_facts end
+        it {
+          should contain_file(file_unattended).with_content(
+            /^Unattended-Upgrade::Allowed-Origins/
+          ).with_content(
+            /"\${distro_id}\:\${distro_codename}-security";/
+          )
+        }
       end
-      it { should contain_file(file_unattended).with_content(/^Unattended-Upgrade::Allowed-Origins \{\n\t"ubuntu:precise-security";\n\};$/) }
+      context 'lucid' do
+        let :facts do default_facts.merge({:lsbdistcodename => 'lucid'}) end
+        it {
+          should contain_file(file_unattended).with_content(
+            /^Unattended-Upgrade::Allowed-Origins/
+          ).with_content(
+            /"\${distro_id} \${distro_codename}-security";/
+          )
+        }
+      end
+      context 'precise' do
+        let :facts do default_facts.merge({:lsbdistcodename => 'precise'}) end
+        it {
+          should contain_file(file_unattended).with_content(
+            /^Unattended-Upgrade::Allowed-Origins/
+          ).with_content(
+            /"\${distro_id}\:\${distro_codename}-security";/
+          )
+        }
+      end
+      context 'trusty' do
+        let :facts do default_facts.merge({:lsbdistcodename => 'trusty'}) end
+        it {
+          should contain_file(file_unattended).with_content(
+            /^Unattended-Upgrade::Allowed-Origins/
+          ).with_content(
+            /"\${distro_id}\:\${distro_codename}-security";/
+          )
+        }
+      end
     end
   end
 

--- a/templates/50unattended-upgrades.erb
+++ b/templates/50unattended-upgrades.erb
@@ -1,5 +1,9 @@
 // Automatically upgrade packages from these (origin:archive) pairs
+<%- if @legacy_origin -%>
 Unattended-Upgrade::Allowed-Origins {
+<%- else -%>
+Unattended-Upgrade::Origins-Pattern {
+<%- end -%>
 <% @origins.each do |origin| -%>
 	"<%= origin %>";
 <% end -%>


### PR DESCRIPTION
The default configuration we were writing for Debian was only working
for Squeeze, from Wheezy and onwards this wasn't working anymore. This
has to do with the fact that we should now be using Origins-Pattern
according to the unattended-upgrades docs. However, Ubuntu didn't
entirely get with the program yet...

This change reflects the defaults that unattended-upgrade installs on
every platform we support. In order to do so the unattended-upgrades
Debian archive for Squeeze, Wheezy, Lucid, Precise and Trusty were
downloaded and the default `/etc/apt/apt.conf.d/50unattended-upgrades`
checked for its content with regard to using `Allowed-Origins` or
`Origins-Pattern`.
