### PR TITLE
unattended-upgrades: Fix origins for Squeeze.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,7 +11,8 @@ class apt::params {
         'squeeze': {
           $backports_location = 'http://backports.debian.org/debian-backports'
           $legacy_origin       = true
-          $origins             = ['${distro_id} ${distro_codename}-security']
+          $origins             = ['${distro_id} oldstable',
+                                  '${distro_id} ${distro_codename}-security']
         }
         'wheezy': {
           $backports_location = 'http://ftp.debian.org/debian/'

--- a/spec/classes/unattended_upgrades_spec.rb
+++ b/spec/classes/unattended_upgrades_spec.rb
@@ -62,6 +62,8 @@ describe 'apt::unattended_upgrades', :type => :class do
             /^Unattended-Upgrade::Allowed-Origins/
           ).with_content(
             /"\${distro_id} \${distro_codename}-security";/
+          ).with_content(
+            /"\${distro_id} oldstable";/
           )
         }
       end


### PR DESCRIPTION
Because Squeeze is now oldstable we need to add an oldstable line too
otherwise security updates won't be picked up. This is still because we
can't match on codename.
