### PR TITLE
Implement fancy progress bars configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ The parameters for `apt` are not required in general and are predominantly for d
       purge_sources_list   => false,
       purge_sources_list_d => false,
       purge_preferences_d  => false,
-      update_timeout       => undef
+      update_timeout       => undef,
+      fancy_progress       => undef
     }
 
 Puppet will manage your system's `sources.list` file and `sources.list.d` directory but will do its best to respect existing content.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -36,7 +36,8 @@ class apt(
   $purge_preferences_d  = false,
   $update_timeout       = undef,
   $update_tries         = undef,
-  $sources              = undef
+  $sources              = undef,
+  $fancy_progress       = undef
 ) {
 
   if $::osfamily != 'Debian' {
@@ -109,6 +110,24 @@ Package: bogus-package\n",
     group   => root,
     purge   => $purge_preferences_d,
     recurse => $purge_preferences_d,
+  }
+
+  case $fancy_progress {
+    true: {
+      file { '99progressbar':
+        ensure  => present,
+        content => 'Dpkg::Progress-Fancy "1";',
+        path    => "${apt_conf_d}/99progressbar",
+      }
+    }
+    false: {
+      file { '99progressbar':
+        ensure  => absent,
+        path    => "${apt_conf_d}/99progressbar",
+      }
+    }
+    undef: {} # do nothing
+    default: { fail('Valid values for fancy_progress are true or false') }
   }
 
   case $disable_keys {

--- a/spec/acceptance/apt_spec.rb
+++ b/spec/acceptance/apt_spec.rb
@@ -274,6 +274,34 @@ describe 'apt class', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily')
     end
   end
 
+  context 'fancy_progress => true' do
+    it 'should work with no errors' do
+      pp = <<-EOS
+      class { 'apt': fancy_progress => true }
+      EOS
+
+      apply_manifest(pp, :catch_failures => true)
+    end
+
+    describe file('/etc/apt/apt.conf.d/99progressbar') do
+      it { should be_file }
+      it { should contain 'Dpkg::Progress-Fancy "1";' }
+    end
+  end
+  context 'fancy_progress => false' do
+    it 'should work with no errors' do
+      pp = <<-EOS
+      class { 'apt': fancy_progress => false }
+      EOS
+
+      apply_manifest(pp, :catch_failures => true)
+    end
+
+    describe file('/etc/apt/apt.conf.d/99progressbar') do
+      it { should_not be_file }
+    end
+  end
+
   context 'reset' do
     it 'fixes the sources.list' do
       shell('cp /tmp/sources.list /etc/apt')


### PR DESCRIPTION
Ubuntu 14.04 ships with apt 0.9.15, has a ``fancy progress bar'', which
is a green bar that shows at the bottom of the terminal showing progress
throughout install.

This patch enables the progress bar, which is usually done by running
echo 'Dpkg::Progress-Fancy "1";' > /etc/apt/apt.conf.d/99progressbar
