### PR TITLE
Add `refreshonly` parameter to apt::builddep

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Installs the build depends of a specified package.
 
     apt::builddep { 'glusterfs-server': }
 
+Optionally pass `refreshonly => true` to make the builddep exec only run when triggered; you may want to do this if the builddep operation is time-consuming.
+
 ### apt::force
 
 Forces a package to be installed from a specific release.  This class is particularly useful when using repositories, like Debian, that are unstable in Ubuntu.

--- a/manifests/builddep.pp
+++ b/manifests/builddep.pp
@@ -1,12 +1,17 @@
 # builddep.pp
 
-define apt::builddep() {
+define apt::builddep (
+  $refreshonly = false
+) {
+  validate_bool($refreshonly)
+
   include apt::update
 
   exec { "apt-builddep-${name}":
-    command   => "/usr/bin/apt-get -y --force-yes build-dep ${name}",
-    logoutput => 'on_failure',
-    notify    => Exec['apt_update'],
+    command     => "/usr/bin/apt-get -y --force-yes build-dep ${name}",
+    logoutput   => 'on_failure',
+    notify      => Exec['apt_update'],
+    refreshonly => $refreshonly,
   }
 
   # Need anchor to provide containment for dependencies.

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,9 +1,10 @@
 class apt::params {
-  $root           = '/etc/apt'
-  $provider       = '/usr/bin/apt-get'
-  $sources_list_d = "${root}/sources.list.d"
-  $apt_conf_d     = "${root}/apt.conf.d"
-  $preferences_d  = "${root}/preferences.d"
+  $root                 = '/etc/apt'
+  $provider             = '/usr/bin/apt-get'
+  $sources_list_d       = "${root}/sources.list.d"
+  $apt_conf_d           = "${root}/apt.conf.d"
+  $preferences_d        = "${root}/preferences.d"
+  $builddep_refreshonly = false
 
   case $::lsbdistid {
     'debian': {

--- a/spec/defines/builddep_spec.rb
+++ b/spec/defines/builddep_spec.rb
@@ -16,4 +16,39 @@ describe 'apt::builddep', :type => :define do
     }
   end
 
+  describe "should not refreshonly by default" do
+    it { should contain_exec("apt-builddep-my_package").with({
+      'refreshonly' => false
+    })
+  }
+  end
+
+  describe "should not refreshonly when told not to" do
+    let(:params) { { :refreshonly => false } }
+
+    it { should contain_exec("apt-builddep-my_package").with({
+      'refreshonly' => false
+    })
+  }
+  end
+
+  describe "should refreshonly when told to" do
+    let(:params) { { :refreshonly => true } }
+
+    it { should contain_exec("apt-builddep-my_package").with({
+      'refreshonly' => true
+    })
+  }
+  end
+
+  describe "should fail with an invalid refreshonly param" do
+    let(:params) { { :refreshonly => 'frog blast the vent core' } }
+
+    it do
+      expect {
+        should contain_exec("apt-builddep-my_package")
+      }.to raise_error(Puppet::Error, /is not a boolean/)
+    end
+  end
+
 end


### PR DESCRIPTION
If the builddep process is expensive for a particular system configuration,
you may want to limit it to only running when triggered. Unit tests and
documentation update included.
