### PR TITLE
Allow $apt_ppa_package to be used from params

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,6 +5,15 @@ class apt::params {
   $apt_conf_d     = "${root}/apt.conf.d"
   $preferences_d  = "${root}/preferences.d"
 
+  case $::lsbdistrelease {
+    /^[1-9]\..*|1[01]\..*|12.04$/: {
+      $apt_ppa_package = 'python-software-properties'
+    }
+    default: {
+      $apt_ppa_package = 'software-properties-common'
+    }
+  }
+
   case $::lsbdistid {
     'debian': {
       case $::lsbdistcodename {

--- a/manifests/ppa.pp
+++ b/manifests/ppa.pp
@@ -8,7 +8,8 @@ define apt::ppa(
   include apt::params
   include apt::update
 
-  $sources_list_d = $apt::params::sources_list_d
+  $sources_list_d  = $apt::params::sources_list_d
+  $apt_ppa_package = $apt::params::apt_ppa_package
 
   if ! $release {
     fail('lsbdistcodename fact not available: release parameter required')
@@ -24,13 +25,8 @@ define apt::ppa(
   $sources_list_d_filename  = "${filename_without_ppa}-${release}.list"
 
   if $ensure == 'present' {
-    $package = $::lsbdistrelease ? {
-        /^[1-9]\..*|1[01]\..*|12.04$/ => 'python-software-properties',
-        default  => 'software-properties-common',
-    }
-
-    if ! defined(Package[$package]) {
-        package { $package: }
+    if ! defined(Package[$apt_ppa_package]) {
+        package { $apt_ppa_package: }
     }
 
     if defined(Class[apt]) {
@@ -54,7 +50,7 @@ define apt::ppa(
         notify       => Exec['apt_update'],
         require      => [
         File['sources.list.d'],
-        Package[$package],
+        Package[$apt_ppa_package],
         ],
     }
 


### PR DESCRIPTION
This change moves the apt ppa support package name
logic from ppa.pp to params.pp, so that it can be used
externally from other modules.

Use case:
There seems to be a chicken and egg scenario when using the apt module with
`purge_sources_list` and `purge_sources_list_d` set to `true` while also having an `apt::ppa` defined within the catalog.

Apt module wipes all the sources files, then tries to add the ppa, but first requires
`package { 'python-software-properties' }`.
With the sources files wiped completely, apt now doesn't have a cache of packages, so apt errors with the following:

```
Error: Execution of '/usr/bin/apt-get -q -y -o DPkg::Options::=--force-confold install python-software-properties' returned 100: Reading package lists...
Building dependency tree...
Reading state information...
Package python-software-properties is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

E: Package 'python-software-properties' has no installation candidate
```

This change allows at least the name of the package to be available to read from other modules, so in an apt wrapper we can do the following:

```
    class { '::apt':
        purge_sources_list   => true,
        purge_sources_list_d => true,
        always_apt_update    => true
    }

    $apt_ppa_package = $apt::params::apt_ppa_package

    package { $apt_ppa_package: }

    Package[$apt_ppa_package] -> Class['::apt']
```

This allows people to use the logic of the package naming you have in the module to install it themselves before the Apt module starts managing the Apt sources.
