### PR TITLE
Added linuxmint to the case parameters in params.pp

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -26,7 +26,7 @@ class apt::params {
         }
       }
     }
-    'ubuntu': {
+    'ubuntu', 'linuxmint': {
       case $::lsbdistcodename {
         'lucid': {
           $backports_location = 'http://us.archive.ubuntu.com/ubuntu'


### PR DESCRIPTION
When utilizing the apt repo on my LinuxMint machine, it was an unrecognized OSFamily member.
