### PR TITLE
Fixed regex to follow APT requirements

### DIFF
--- a/manifests/pin.pp
+++ b/manifests/pin.pp
@@ -64,10 +64,6 @@ define apt::pin(
 
   }
 
-  $path = $order ? {
-    ''      => "${preferences_d}/${name}.pref",
-    default => "${preferences_d}/${order}-${name}.pref",
-  }
 
   # According to man 5 apt_preferences:
   # The files have either no or "pref" as filename extension
@@ -78,6 +74,10 @@ define apt::pin(
   # be silently ignored.
   $file_name = regsubst($title, '[^0-9a-z\-_\.]', '_', 'IG')
 
+  $path = $order ? {
+    ''      => "${preferences_d}/${file_name}.pref",
+    default => "${preferences_d}/${order}-${file_name}.pref",
+  }
   file { "${file_name}.pref":
     ensure  => $ensure,
     path    => $path,


### PR DESCRIPTION
Previous implementation would overwrite the file name and potentially include characters that would cause apt to ignore the pref file.

What would happen is that $path would use $name by default.
Then the regex would generate a valid $file_name, then ignore completely by using previously set $path, allowing forbidden characters in the file name.
