### PR TITLE
Proxy safe keyserver address

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ You can additionally set the following attributes:
  * `source`: HTTP, HTTPS or FTP location of a GPG key or path to a file on the
              target host;
  * `content`: Instead of pointing to a file, pass the key in as a string;
- * `server`: The GPG key server to use. It defaults to *keyserver.ubuntu.com*;
+ * `server`: The GPG key server to use. It defaults to *hkp://keyserver.ubuntu.com:80*;
  * `keyserver_options`: Additional options to pass to `--keyserver`.
 
 Because it is a native type it can be used in and queried for with MCollective.

--- a/lib/puppet/type/apt_key.rb
+++ b/lib/puppet/type/apt_key.rb
@@ -61,7 +61,7 @@ Puppet::Type.newtype(:apt_key) do
 
   newparam(:server) do
     desc 'The key server to fetch the key from based on the ID.'
-    defaultto :'keyserver.ubuntu.com'
+    defaultto :'hkp://keyserver.ubuntu.com:80'
     # Need to validate this, preferably through stdlib is_fqdn
     # but still working on getting to that.
   end

--- a/manifests/key.pp
+++ b/manifests/key.pp
@@ -41,7 +41,7 @@
 #
 #   The keyserver from where to fetch our GPG key. It defaults to
 #   undef which results in apt_key's default keyserver being used,
-#   currently +keyserver.ubuntu.com+.
+#   currently +hkp://keyserver.ubuntu.com:80+.
 #
 # [*key_options*]
 #   _default_: +undef+

--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -9,7 +9,7 @@ define apt::source(
   $include_src       = true,
   $required_packages = false,
   $key               = undef,
-  $key_server        = 'keyserver.ubuntu.com',
+  $key_server        = 'hkp://keyserver.ubuntu.com:80',
   $key_content       = undef,
   $key_source        = undef,
   $pin               = false,

--- a/spec/acceptance/apt_key_provider_spec.rb
+++ b/spec/acceptance/apt_key_provider_spec.rb
@@ -68,7 +68,7 @@ describe 'apt_key', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily')) 
         EOS
 
         # Install the key first
-        shell("apt-key adv --keyserver keyserver.ubuntu.com \
+        shell("apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 \
               --recv-keys #{PUPPETLABS_GPG_KEY_ID}")
         shell("apt-key list | grep #{PUPPETLABS_GPG_KEY_ID}")
 

--- a/spec/unit/puppet/type/apt_key_spec.rb
+++ b/spec/unit/puppet/type/apt_key_spec.rb
@@ -15,7 +15,7 @@ describe Puppet::Type::type(:apt_key) do
     end
 
     it 'keyserver is default' do
-      resource[:server].should eq :'keyserver.ubuntu.com'
+      resource[:server].should eq :'hkp://keyserver.ubuntu.com:80'
     end
 
     it 'source is not set' do


### PR DESCRIPTION
When I use this great puppet module from behind the very restrictive proxy i fall into the problem, that is described here http://askubuntu.com/questions/134913/cant-add-repo-keys and this little fix solve it ;)
