### PR TITLE
Fix bug with apt key lenght check

### DIFF
--- a/manifests/key.pp
+++ b/manifests/key.pp
@@ -56,7 +56,11 @@ define apt::key (
   $key_options = undef,
 ) {
 
-  validate_re($key, ['\A(0x)?[0-9a-fA-F]{8}\Z', '\A(0x)?[0-9a-fA-F]{16}\Z'])
+  validate_re($key, [
+    '\A(0x)?[0-9a-fA-F]{8}\Z',
+    '\A(0x)?[0-9a-fA-F]{16}\Z',
+    '\A(0x)?[0-9a-fA-F]{40}\Z',
+  ])
   validate_re($ensure, ['\Aabsent|present\Z',])
 
   if $key_content {


### PR DESCRIPTION
The validate_re() at line 59 introduced in v1.5.0 is breaking my current setup.
Actually I don't see any valid reason to use short version of keys names in a Puppet manifest (full name is harder to forge), and by the way, why should not a full GPG key name be valid?
