### PR TITLE
add facts showing available updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,13 @@ If you would like to configure your system so the source is the Puppet Labs APT 
       key_server => 'pgp.mit.edu',
     }
 
+### Facts
+
+There are a few facts included within the apt module describing the state of the apt system:
+
+* `apt_updates` - the number of updates available on the system
+* `apt_security_updates` - the number of updates which are security updates
+* `apt_package_updates` - the package names that are available for update. On Facter 2.0 and newer this will be a list type, in earlier versions it is a comma delimitered string.
 
 #### Hiera example
 <pre>

--- a/lib/facter/apt_package_updates.rb
+++ b/lib/facter/apt_package_updates.rb
@@ -1,0 +1,13 @@
+Facter.add("apt_package_updates") do
+  confine :osfamily => 'Debian'
+  setcode do
+    if File.executable?("/usr/lib/update-notifier/apt-check")
+      packages = Facter::Util::Resolution.exec('/usr/lib/update-notifier/apt-check -p 2>&1')
+      packages = packages.split("\n")
+      if Facter.version < '2.0.0'
+        packages = packages.join(',')
+      end
+      packages
+    end
+  end
+end

--- a/lib/facter/apt_security_updates.rb
+++ b/lib/facter/apt_security_updates.rb
@@ -1,0 +1,9 @@
+Facter.add("apt_security_updates") do
+  confine :osfamily => 'Debian'
+  setcode do
+    if File.executable?("/usr/lib/update-notifier/apt-check")
+      updates = Facter::Util::Resolution.exec('/usr/lib/update-notifier/apt-check 2>&1')
+      Integer(updates.strip.split(';')[1])
+    end
+  end
+end

--- a/lib/facter/apt_updates.rb
+++ b/lib/facter/apt_updates.rb
@@ -1,0 +1,9 @@
+Facter.add("apt_updates") do
+  confine :osfamily => 'Debian'
+  setcode do
+    if File.executable?("/usr/lib/update-notifier/apt-check")
+      updates = Facter::Util::Resolution.exec('/usr/lib/update-notifier/apt-check 2>&1')
+      Integer(updates.strip.split(';')[0])
+    end
+  end
+end

--- a/spec/unit/facter/apt_package_updates_spec.rb
+++ b/spec/unit/facter/apt_package_updates_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe 'apt_package_updates fact' do
+  subject { Facter.fact(:apt_package_updates).value }
+  after(:each) { Facter.clear }
+
+  describe 'on Debian based distro missing update-notifier-common' do
+    before { 
+    Facter.fact(:osfamily).stubs(:value).returns 'Debian'
+    File.stubs(:executable?).returns false
+  }
+  it { should == nil }
+  end
+
+  describe 'on Debian based distro' do
+    before { 
+    Facter.fact(:osfamily).stubs(:value).returns 'Debian'
+    File.stubs(:executable?).returns true
+    Facter::Util::Resolution.stubs(:exec).returns "puppet-common\nlinux-generic\nlinux-image-generic"
+  }
+  it {
+    if Facter.version < '2.0.0'
+      should == 'puppet-common,linux-generic,linux-image-generic'
+    else
+      should == ['puppet-common', 'linux-generic', 'linux-image-generic']
+    end
+  }
+  end
+end

--- a/spec/unit/facter/apt_security_updates_spec.rb
+++ b/spec/unit/facter/apt_security_updates_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe 'apt_security_updates fact' do
+  subject { Facter.fact(:apt_security_updates).value }
+  after(:each) { Facter.clear }
+
+  describe 'on Debian based distro missing update-notifier-common' do
+    before { 
+    Facter.fact(:osfamily).stubs(:value).returns 'Debian'
+    File.stubs(:executable?).returns false
+  }
+  it { should == nil }
+  end
+
+  describe 'on Debian based distro' do
+    before { 
+    Facter.fact(:osfamily).stubs(:value).returns 'Debian'
+    File.stubs(:executable?).returns true
+    Facter::Util::Resolution.stubs(:exec).returns '14;7'
+  }
+  it { should == 7 }
+  end
+
+end

--- a/spec/unit/facter/apt_updates_spec.rb
+++ b/spec/unit/facter/apt_updates_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe 'apt_updates fact' do
+  subject { Facter.fact(:apt_updates).value }
+  after(:each) { Facter.clear }
+
+  describe 'on Debian based distro missing update-notifier-common' do
+    before { 
+    Facter.fact(:osfamily).stubs(:value).returns 'Debian'
+    File.stubs(:executable?).returns false
+  }
+  it { should == nil }
+  end
+
+  describe 'on Debian based distro' do
+    before { 
+    Facter.fact(:osfamily).stubs(:value).returns 'Debian'
+    File.stubs(:executable?).returns true
+    Facter::Util::Resolution.stubs(:exec).returns '14;7'
+  }
+  it { should == 14 }
+  end
+
+end


### PR DESCRIPTION
Making use of the apt-check command from the 'update-notifier-common'
package (if available) display the number of available updates, number of
security updates as well as the update package names.
