### PR TITLE
Enable auto-update for Debian squeeze-lts

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,7 +12,8 @@ class apt::params {
           $backports_location = 'http://backports.debian.org/debian-backports'
           $legacy_origin       = true
           $origins             = ['${distro_id} oldstable',
-                                  '${distro_id} ${distro_codename}-security']
+                                  '${distro_id} ${distro_codename}-security',
+                                  '${distro_id} ${distro_codename}-lts']
         }
         'wheezy': {
           $backports_location = 'http://ftp.debian.org/debian/'

--- a/spec/classes/unattended_upgrades_spec.rb
+++ b/spec/classes/unattended_upgrades_spec.rb
@@ -61,6 +61,8 @@ describe 'apt::unattended_upgrades', :type => :class do
           should contain_file(file_unattended).with_content(
             /^Unattended-Upgrade::Allowed-Origins/
           ).with_content(
+            /"\${distro_id} \${distro_codename}-lts";/
+          ).with_content(
             /"\${distro_id} \${distro_codename}-security";/
           ).with_content(
             /"\${distro_id} oldstable";/


### PR DESCRIPTION
Quoting https://wiki.debian.org/LTS

Official security support for Debian GNU/Linux 6.0
(code name "Squeeze") has ended on 31 May 2014.
However long term support for the distribution
is going to be extended until February 2016,
i.e. five years after the initial release.

See https://wiki.debian.org/LTS for more details.
