### PR TITLE
Builddep notifies apt-get update instead of requiring it

### DIFF
--- a/manifests/builddep.pp
+++ b/manifests/builddep.pp
@@ -6,7 +6,7 @@ define apt::builddep() {
   exec { "apt-builddep-${name}":
     command   => "/usr/bin/apt-get -y --force-yes build-dep ${name}",
     logoutput => 'on_failure',
-    notify    => Exec['apt_update'],
+    require    => Exec['apt_update'],
   }
 
   # Need anchor to provide containment for dependencies.


### PR DESCRIPTION
as the title says, builddep notifies apt-get update instead of requiring it, which doesn't make much sense. In almost every case, you want apt-get update to be executed before builddep.

The problem I ran into is a huge dependency cycle because of apt-get update. Builddep had to be executed after sources being added which after a lot of trying I concluded to not be possible. ([serverfault here](http://serverfault.com/questions/610356/puppet-class-node-dependencies))

Changing `notify` to `require` solves this dependency cycle for me.

Any thoughts on this? 
