### PR TITLE
Adds check to params.pp if lab-release is not installed

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -49,6 +49,9 @@ class apt::params {
         }
       }
     }
+    '': {
+      fail('Unable to determine lsbdistid, is lsb-release installed?')
+    }
     default: {
       fail("Unsupported lsbdistid (${::lsbdistid})")
     }

--- a/spec/classes/params_spec.rb
+++ b/spec/classes/params_spec.rb
@@ -24,4 +24,16 @@ describe 'apt::params', :type => :class do
     end
 
   end
+
+  describe "With lsb-release not installed" do
+    let(:facts) { { :lsbdistid => '' } }
+    let (:title) { 'my_package' }
+
+    it do
+      expect {
+        should compile
+      }.to raise_error(Puppet::Error, /Unable to determine lsbdistid, is lsb-release installed/)
+    end
+  end
+
 end


### PR DESCRIPTION
Adds spec test

If lsb-release is not installed, then the end user sees a confusing/ vague message

```
Error: Unsupported lsbdistid () at /modules/apt/manifests/params.pp:52
```

It is common for docker containers to not include this package by default

After fix, the user sees a friendlier message if lab-release is not installed

```
Error: Unable to determine lsbdistid, is lsb-release installed? at /modules/apt/manifests/params.pp:52
```
