### PR TITLE
Fix broken acceptance tests.

### DIFF
--- a/spec/acceptance/apt_spec.rb
+++ b/spec/acceptance/apt_spec.rb
@@ -15,7 +15,7 @@ describe 'apt class', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily')
       EOS
 
       apply_manifest(pp, :catch_failures => true) do |r|
-        expect(r.stdout).to match(/apt_update/)
+        expect(r.stdout).to match(/Exec\[apt_update\]/)
       end
     end
   end
@@ -26,7 +26,7 @@ describe 'apt class', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily')
       EOS
 
       apply_manifest(pp, :catch_failures => true) do |r|
-        expect(r.stdout).to_not match(/apt_update/)
+        expect(r.stdout).to_not match(/Exec\[apt_update\]/)
       end
     end
   end


### PR DESCRIPTION
New fact was added that matched a regex breaking the always_apt_update
tests.  Updated the tests to check for the apt_update exec, not just the
string apt_update.
