### PR TITLE
ppa_options not getting correct default

### DIFF
--- a/manifests/ppa.pp
+++ b/manifests/ppa.pp
@@ -3,10 +3,17 @@
 define apt::ppa(
   $ensure  = 'present',
   $release = $::lsbdistcodename,
-  $options = $apt::params::ppa_options,
+  $options = 'DEFAULTS',
 ) {
   include apt::params
   include apt::update
+
+  if $options == 'DEFAULTS' {
+    $_options = $apt::params::ppa_options
+  }
+  else {
+    $_options = $options
+  }
 
   $sources_list_d = $apt::params::sources_list_d
 
@@ -49,7 +56,7 @@ define apt::ppa(
     }
     exec { "add-apt-repository-${name}":
         environment  => $proxy_env,
-        command      => "/usr/bin/add-apt-repository ${options} ${name}",
+        command      => "/usr/bin/add-apt-repository ${_options} ${name}",
         unless       => "/usr/bin/test -s ${sources_list_d}/${sources_list_d_filename}",
         user         => 'root',
         logoutput    => 'on_failure',
@@ -69,9 +76,6 @@ define apt::ppa(
 
     file { "${sources_list_d}/${sources_list_d_filename}":
         ensure => 'absent',
-        mode   => '0644',
-        owner  => 'root',
-        group  => 'root',
         notify => Exec['apt_update'],
     }
   }

--- a/spec/defines/ppa_spec.rb
+++ b/spec/defines/ppa_spec.rb
@@ -1,158 +1,159 @@
 require 'spec_helper'
 describe 'apt::ppa', :type => :define do
-  [
-    {
-      :lsbdistrelease  => '11.04',
-      :lsbdistcodename => 'natty',
-      :operatingsystem => 'Ubuntu',
-      :lsbdistid       => 'Ubuntu',
-      :package         => 'python-software-properties'
-    },
-    {
-      :lsbdistrelease  => '12.10',
-      :lsbdistcodename => 'quantal',
-      :operatingsystem => 'Ubuntu',
-      :lsbdistid       => 'Ubuntu',
-      :package         => 'software-properties-common'
-    },
-  ].each do |platform|
-    context "on #{platform[:lsbdistcodename]}" do
+
+  describe 'defaults, apt not included' do
+    let :facts do
+      {
+        :lsbdistrelease  => '11.04',
+        :lsbdistcodename => 'natty',
+        :operatingsystem => 'Ubuntu',
+        :lsbdistid       => 'Ubuntu',
+      }
+    end
+
+    let(:title) { 'ppa:needs/such.substitution/wow' }
+    it { is_expected.to contain_package('python-software-properties') }
+    it { is_expected.to contain_exec('add-apt-repository-ppa:needs/such.substitution/wow').that_notifies('Exec[apt_update]').with({
+      'environment' => [],
+      'command'     => '/usr/bin/add-apt-repository -y ppa:needs/such.substitution/wow',
+      'unless'      => '/usr/bin/test -s /etc/apt/sources.list.d/needs-such_substitution-wow-natty.list',
+      'user'        => 'root',
+      'logoutput'   => 'on_failure',
+    })
+    }
+
+    it { is_expected.to contain_file('/etc/apt/sources.list.d/needs-such_substitution-wow-natty.list').that_requires('Exec[add-apt-repository-ppa:needs/such.substitution/wow]').with({
+      'ensure' => 'file',
+    })
+    }
+  end
+
+  describe 'apt included, no proxy' do
+    let :pre_condition do
+      'class { "apt": }'
+    end
+    let :facts do
+      {
+        :lsbdistrelease  => '14.04',
+        :lsbdistcodename => 'trusty',
+        :operatingsystem => 'Ubuntu',
+        :lsbdistid       => 'Ubuntu',
+        :osfamily        => 'Debian',
+      }
+    end
+    let :params do
+      {
+        'options' => '',
+      }
+    end
+    let(:title) { 'ppa:foo' }
+    it { is_expected.to contain_package('software-properties-common') }
+    it { is_expected.to contain_exec('add-apt-repository-ppa:foo').that_notifies('Exec[apt_update]').with({
+      'environment' => [],
+      'command'     => '/usr/bin/add-apt-repository  ppa:foo',
+      'unless'      => '/usr/bin/test -s /etc/apt/sources.list.d/foo-trusty.list',
+      'user'        => 'root',
+      'logoutput'   => 'on_failure',
+    })
+    }
+
+    it { is_expected.to contain_file('/etc/apt/sources.list.d/foo-trusty.list').that_requires('Exec[add-apt-repository-ppa:foo]').with({
+      'ensure' => 'file',
+    })
+    }
+  end
+
+  describe 'apt included, proxy' do
+    let :pre_condition do
+      'class { "apt": proxy_host => "example.com" }'
+    end
+    let :facts do
+      {
+        :lsbdistrelease  => '14.04',
+        :lsbdistcodename => 'trusty',
+        :operatingsystem => 'Ubuntu',
+        :lsbdistid       => 'Ubuntu',
+        :osfamily        => 'Debian',
+      }
+    end
+    let :params do
+      {
+        'release' => 'lucid',
+      }
+    end
+    let(:title) { 'ppa:foo' }
+    it { is_expected.to contain_package('software-properties-common') }
+    it { is_expected.to contain_exec('add-apt-repository-ppa:foo').that_notifies('Exec[apt_update]').with({
+      'environment' => ['http_proxy=http://example.com:8080', 'https_proxy=http://example.com:8080'],
+      'command'     => '/usr/bin/add-apt-repository -y ppa:foo',
+      'unless'      => '/usr/bin/test -s /etc/apt/sources.list.d/foo-lucid.list',
+      'user'        => 'root',
+      'logoutput'   => 'on_failure',
+    })
+    }
+
+    it { is_expected.to contain_file('/etc/apt/sources.list.d/foo-lucid.list').that_requires('Exec[add-apt-repository-ppa:foo]').with({
+      'ensure' => 'file',
+    })
+    }
+  end
+
+  describe 'ensure absent' do
+    let :facts do
+      {
+        :lsbdistrelease  => '14.04',
+        :lsbdistcodename => 'trusty',
+        :operatingsystem => 'Ubuntu',
+        :lsbdistid       => 'Ubuntu',
+        :osfamily        => 'Debian',
+      }
+    end
+    let(:title) { 'ppa:foo' }
+    let :params do
+      {
+        'ensure' => 'absent'
+      }
+    end
+    it { is_expected.to contain_file('/etc/apt/sources.list.d/foo-trusty.list').that_notifies('Exec[apt_update]').with({
+      'ensure' => 'absent',
+    })
+    }
+  end
+
+  context 'validation' do
+    describe 'no release' do
       let :facts do
         {
-          :lsbdistrelease  => platform[:lsbdistrelease],
-          :lsbdistcodename => platform[:lsbdistcodename],
-          :operatingsystem => platform[:operatingsystem],
-          :lsbdistid       => platform[:lsbdistid],
+          :lsbdistrelease  => '14.04',
+          :operatingsystem => 'Ubuntu',
+          :lsbdistid       => 'Ubuntu',
           :osfamily        => 'Debian',
         }
       end
-      let :release do
-        "#{platform[:lsbdistcodename]}"
-      end
-      let :package do
-        "#{platform[:package]}"
-      end
-      let :options do
-        "-y"
-      end
-      ['ppa:dans_ppa', 'dans_ppa','ppa:dans-daily/ubuntu'].each do |t|
-        describe "with title #{t}" do
-          let :pre_condition do
-            'class { "apt": }'
-          end
-          let :title do
-            t
-          end
-          let :filename do
-            t.sub(/^ppa:/,'').gsub('/','-') << "-" << "#{release}.list"
-          end
-
-          it { should contain_package("#{package}") }
-
-          it { should contain_exec("apt_update").with(
-            'command'     => '/usr/bin/apt-get update',
-            'refreshonly' => true
-            )
-          }
-
-          it { should contain_exec("add-apt-repository-#{t}").with(
-            'command' => "/usr/bin/add-apt-repository #{options} #{t}",
-            'unless'  => "/usr/bin/test -s /etc/apt/sources.list.d/#{filename}",
-            'require' => ["File[sources.list.d]", "Package[#{package}]"],
-            'notify'  => "Exec[apt_update]"
-            )
-          }
-
-          it { should create_file("/etc/apt/sources.list.d/#{filename}").with(
-            'ensure'  => 'file',
-            'require' => "Exec[add-apt-repository-#{t}]"
-            )
-          }
-        end
-      end
-      describe 'without a proxy defined' do
-        let :title do
-          'rspec_ppa'
-        end
-        let :pre_condition do
-          'class { "apt":
-             proxy_host => false
-          }'
-        end
-        let :filename do
-          "#{title}-#{release}.list"
-        end
-
-        it { should contain_exec("add-apt-repository-#{title}").with(
-          'environment' => [],
-          'command'     => "/usr/bin/add-apt-repository #{options} #{title}",
-          'unless'      => "/usr/bin/test -s /etc/apt/sources.list.d/#{filename}",
-          'require'     => ["File[sources.list.d]", "Package[#{package}]"],
-          'notify'      => "Exec[apt_update]"
-          )
-        }
-      end
-
-      describe 'behind a proxy' do
-        let :title do
-          'rspec_ppa'
-        end
-        let :pre_condition do
-          'class { "apt":
-            proxy_host => "user:pass@proxy",
-          }'
-        end
-          let :filename do
-            "#{title}-#{release}.list"
-          end
-
-        it { should contain_exec("add-apt-repository-#{title}").with(
-          'environment' => [
-            "http_proxy=http://user:pass@proxy:8080",
-            "https_proxy=http://user:pass@proxy:8080",
-          ],
-          'command'     => "/usr/bin/add-apt-repository #{options} #{title}",
-          'unless'      => "/usr/bin/test -s /etc/apt/sources.list.d/#{filename}",
-          'require'     => ["File[sources.list.d]", "Package[#{package}]"],
-          'notify'      => "Exec[apt_update]"
-          )
-        }
+      let(:title) { 'ppa:foo' }
+      it do
+        expect {
+          should compile
+        }.to raise_error(Puppet::Error, /lsbdistcodename fact not available: release parameter required/)
       end
     end
-  end
 
-  [ { :lsbdistcodename => 'natty',
-      :package => 'python-software-properties' },
-    { :lsbdistcodename => 'quantal',
-      :package => 'software-properties-common'},
-  ].each do |platform|
-    context "on #{platform[:lsbdistcodename]}" do
-      describe "it should not error if package['#{platform[:package]}'] is already defined" do
-        let :pre_condition do
-           'class {"apt": }' +
-           'package { "#{platform[:package]}": }->Apt::Ppa["ppa"]'
-        end
-        let :facts do
-          {:lsbdistcodename => '#{platform[:lsbdistcodename]}',
-           :operatingsystem => 'Ubuntu',
-           :lsbdistid => 'Ubuntu',
-           :osfamily => 'Debian'}
-        end
-        let(:title) { "ppa" }
-        let(:release) { "#{platform[:lsbdistcodename]}" }
-        it { should contain_package('#{platform[:package]}') }
+    describe 'not ubuntu' do
+      let :facts do
+        {
+          :lsbdistrelease  => '14.04',
+          :lsbdistcodename => 'trusty',
+          :operatingsystem => 'Debian',
+          :lsbdistid       => 'Ubuntu',
+          :osfamily        => 'Debian',
+        }
+      end
+      let(:title) { 'ppa:foo' }
+      it do
+        expect {
+          should compile
+        }.to raise_error(Puppet::Error, /apt::ppa is currently supported on Ubuntu only./)
       end
     end
-  end
-
-  describe "without Class[apt] should raise a Puppet::Error" do
-    let(:release) { "natty" }
-    let(:title) { "ppa" }
-    it { expect { should contain_apt__ppa(title) }.to raise_error(Puppet::Error) }
-  end
-
-  describe "without release should raise a Puppet::Error" do
-    let(:title) { "ppa:" }
-    it { expect { should contain_apt__ppa(:release) }.to raise_error(Puppet::Error) }
   end
 end


### PR DESCRIPTION
While working on updating unit tests for apt::ppa, found that if
apt::params hasn't already been included elsewhere, the $options
parameter is not picking up the correct defaults. Updated the code to
set default options after apt::params is included.
