### PR TITLE
Remove stderr from stdout

### DIFF
--- a/lib/facter/apt_package_updates.rb
+++ b/lib/facter/apt_package_updates.rb
@@ -2,7 +2,7 @@ Facter.add("apt_package_updates") do
   confine :osfamily => 'Debian'
   setcode do
     if File.executable?("/usr/lib/update-notifier/apt-check")
-      packages = Facter::Util::Resolution.exec('/usr/lib/update-notifier/apt-check -p 2>&1')
+      packages = Facter::Util::Resolution.exec('/usr/lib/update-notifier/apt-check -p 2>/dev/null')
       packages = packages.split("\n")
       if Facter.version < '2.0.0'
         packages = packages.join(',')

--- a/lib/facter/apt_security_updates.rb
+++ b/lib/facter/apt_security_updates.rb
@@ -2,7 +2,7 @@ Facter.add("apt_security_updates") do
   confine :osfamily => 'Debian'
   setcode do
     if File.executable?("/usr/lib/update-notifier/apt-check")
-      updates = Facter::Util::Resolution.exec('/usr/lib/update-notifier/apt-check 2>&1')
+      updates = Facter::Util::Resolution.exec('/usr/lib/update-notifier/apt-check 2>/dev/null')
       Integer(updates.strip.split(';')[1])
     end
   end

--- a/lib/facter/apt_updates.rb
+++ b/lib/facter/apt_updates.rb
@@ -2,7 +2,7 @@ Facter.add("apt_updates") do
   confine :osfamily => 'Debian'
   setcode do
     if File.executable?("/usr/lib/update-notifier/apt-check")
-      updates = Facter::Util::Resolution.exec('/usr/lib/update-notifier/apt-check 2>&1')
+      updates = Facter::Util::Resolution.exec('/usr/lib/update-notifier/apt-check 2>/dev/null')
       Integer(updates.strip.split(';')[0])
     end
   end


### PR DESCRIPTION
Sometimes there are lib errors on platforms with malformed packages.
This shouldn't cause the facts to completely fail.
