### PR TITLE
Unpin puppet-lint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ group :development, :test do
   gem 'rspec-puppet',            :require => false
   gem 'puppetlabs_spec_helper',  :require => false
   gem 'serverspec',              :require => false
-  gem 'puppet-lint', '0.3.2',    :require => false
+  gem 'puppet-lint',             :require => false
   gem 'beaker',                  :require => false
   gem 'beaker-rspec',            :require => false
   gem 'pry',                     :require => false


### PR DESCRIPTION
The issues associated with the 1.0.0 release of puppet-lint have been
resolved.
