### PR TITLE
apt::force: Added 2 parameters for automatic configuration file handling...

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,12 +71,20 @@ Installs the build depends of a specified package.
 ### apt::force
 
 Forces a package to be installed from a specific release. This class is particularly useful when using repositories, like Debian, that are unstable in Ubuntu.
+The cfg_files parameter controls wether newer or older configuration files should be used or only unchanged configuration files should be updated. Cfg_missing forces the provider to install all missing configuration files. Both are optional.
 
     apt::force { 'glusterfs-server':
-      release => 'unstable',
-      version => '3.0.3',
-      require => Apt::Source['debian_unstable'],
+      release     => 'unstable',
+      version     => '3.0.3',
+      cfg_files   => 'unchanged',
+      cfg_missing => true,
+      require     => Apt::Source['debian_unstable'],
     }
+
+You can additionally set the following attributes:
+
+ * `cfg_files`: "new", "old", "unchanged" or "none" (default). "new" will overwrite all existing configuration files with newer ones, "old" will force usage of all old files and "unchanged" only updates unchanged config files whereas setting "none" will don't do anything but providing backward-compatability with existing puppet manifests.
+ * `cfg_missing`: "true" or "false". Setting cfg_missing to false will provide backward compatability whereas setting true will add an aptitude/apt-get parameter which checks and installs missing configuration files for the selected package.
 
 ### apt_key
 

--- a/manifests/force.pp
+++ b/manifests/force.pp
@@ -2,10 +2,15 @@
 # force a package from a specific release
 
 define apt::force(
-  $release = false,
-  $version = false,
-  $timeout = 300
+  $release     = false,
+  $version     = false,
+  $timeout     = 300,
+  $cfg_files   = 'none',
+  $cfg_missing = false,
 ) {
+
+  validate_re($cfg_files, ['^new', '^old', '^unchanged', '^none'])
+  validate_bool($cfg_missing)
 
   $provider = $apt::params::provider
 
@@ -17,6 +22,18 @@ define apt::force(
   $release_string = $release ? {
     false   => undef,
     default => "-t ${release}",
+  }
+
+  case $cfg_files {
+    'new':       { $config_files = '-o Dpkg::Options::="--force-confnew"' }
+    'old':       { $config_files = '-o Dpkg::Options::="--force-confold"' }
+    'unchanged': { $config_files = '-o Dpkg::Options::="--force-confdef"' }
+    'none':      { $config_files = '' }
+  }
+
+  case $cfg_missing {
+    true:    { $config_missing = '-o Dpkg::Options::="--force-confmiss"' }
+    false:   { $config_missing = '' }
   }
 
   if $version == false {
@@ -34,7 +51,7 @@ define apt::force(
     }
   }
 
-  exec { "${provider} -y ${release_string} install ${name}${version_string}":
+  exec { "${provider} -y ${config_files} ${config_missing} ${release_string} install ${name}${version_string}":
     unless    => $install_check,
     logoutput => 'on_failure',
     timeout   => $timeout,

--- a/spec/defines/force_spec.rb
+++ b/spec/defines/force_spec.rb
@@ -11,13 +11,15 @@ describe 'apt::force', :type => :define do
 
   let :default_params do
     {
-      :release => false,
-      :version => false
+      :release     => false,
+      :version     => false,
+      :cfg_files   => 'none',
+      :cfg_missing => false,
     }
   end
 
   describe "when using default parameters" do
-    it { should contain_exec("/usr/bin/apt-get -y  install #{title}").with(
+    it { should contain_exec("/usr/bin/apt-get -y    install #{title}").with(
       :unless    => "/usr/bin/dpkg -s #{title} | grep -q 'Status: install'",
       :logoutput => 'on_failure',
       :timeout   => '300'
@@ -28,7 +30,7 @@ describe 'apt::force', :type => :define do
     let :params do
       default_params.merge(:release => 'testing')
     end
-    it { should contain_exec("/usr/bin/apt-get -y -t #{params[:release]} install #{title}").with(
+    it { should contain_exec("/usr/bin/apt-get -y   -t #{params[:release]} install #{title}").with(
       :unless => "/usr/bin/test \$(/usr/bin/apt-cache policy -t #{params[:release]} #{title} | /bin/grep -E 'Installed|Candidate' | /usr/bin/uniq -s 14 | /usr/bin/wc -l) -eq 1"
     ) }
   end
@@ -37,9 +39,39 @@ describe 'apt::force', :type => :define do
     let :params do
       default_params.merge(:version => '1')
     end
-    it { should contain_exec("/usr/bin/apt-get -y  install #{title}=#{params[:version]}").with(
+    it { should contain_exec("/usr/bin/apt-get -y    install #{title}=#{params[:version]}").with(
       :unless => "/usr/bin/dpkg -s #{title} | grep -q 'Version: #{params[:version]}'"
     ) }
+  end
+
+  describe "when specifying cfg_files parameter" do
+    let :params do
+      default_params.merge(:cfg_files => 'unchanged')
+    end
+    it { should contain_exec('/usr/bin/apt-get -y -o Dpkg::Options::="--force-confdef"   install my_package').with(
+      :unless    => "/usr/bin/dpkg -s #{title} | grep -q 'Status: install'"
+    ) }
+  end
+
+  describe "when specifying cfg_missing parameter" do
+    let :params do
+      default_params.merge(:cfg_missing => true)
+    end
+    it { should contain_exec('/usr/bin/apt-get -y  -o Dpkg::Options::="--force-confmiss"  install my_package').with(
+      :unless    => "/usr/bin/dpkg -s #{title} | grep -q 'Status: install'"
+    ) }
+  end
+
+  describe "when specifying cfg_files and cfg_missing parameter" do
+   let :params do
+     default_params.merge(
+       :cfg_files   => 'unchanged',
+       :cfg_missing => true
+     )
+   end
+   it { should contain_exec('/usr/bin/apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confmiss"  install my_package').with(
+     :unless    => "/usr/bin/dpkg -s #{title} | grep -q 'Status: install'"
+   ) }
   end
 
   describe "when specifying release and version parameters" do
@@ -49,8 +81,22 @@ describe 'apt::force', :type => :define do
         :version => '1'
       )
     end
-    it { should contain_exec("/usr/bin/apt-get -y -t #{params[:release]} install #{title}=1").with(
+    it { should contain_exec("/usr/bin/apt-get -y   -t #{params[:release]} install #{title}=1").with(
       :unless => "/usr/bin/apt-cache policy -t #{params[:release]} #{title} | /bin/grep -q 'Installed: #{params[:version]}'"
     ) }
+  end
+
+  describe "when specifying release, version, cfg_files and cfg_missing parameters" do
+   let :params do
+     default_params.merge(
+       :release     => 'testing',
+       :version     => '1',
+       :cfg_files   => 'unchanged',
+       :cfg_missing => true
+     )
+   end
+   it { should contain_exec('/usr/bin/apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confmiss" -t testing install my_package=1').with(
+     :unless => "/usr/bin/apt-cache policy -t #{params[:release]} #{title} | /bin/grep -q 'Installed: #{params[:version]}'"
+   ) }
   end
 end


### PR DESCRIPTION
...; fixes #modules-1306

when updating or installing newer packages with apt::force and you have changed previous
configuration files aptitude or apt-get will prompt what to do. You can suppress that
by pre-define the action with cfg_files parameter (new, old or unchanged and its backward
compatible if not defined). With a second optional parameter cfg_missing you can force
your provider to install missing configuration files as well.

Signed-off-by: Martin Seener martin@seener.de

apt::force: Changed selectors used in force.pp to case statements; refs #module-1306

Signed-off-by: Martin Seener martin@seener.de

apt::force: rspec: fixed the failing tests and added validate_re for cfg_files and validate_bool for cfg_missing. Also removed default values for both case statements and only allow pre-defined values or true/false. Furthermore enhanced the README refs #module-1306

Was able to fix the failing rspec tests for the patch.
Thanks to Morgan Haskel.

Signed-off-by: Martin Seener martin@seener.de

Despite the puppetlabs-stdlib documentation says validation_re supports 3 arguments the tests failed telling that only 2 are supported. Fixed this by removing the 3 optional argument; refs #modules-1306

Signed-off-by: Martin Seener martin.seener@barzahlen.de

apt::force: updated readme refs #module-1306

Signed-off-by: Martin Seener martin@seener.de
