### PR TITLE
MODULES-1476: Fix fact setting failures if apt-check not present

### DIFF
--- a/lib/facter/apt_updates.rb
+++ b/lib/facter/apt_updates.rb
@@ -1,22 +1,23 @@
-apt_package_updates = nil
 Facter.add("apt_has_updates") do
   confine :osfamily => 'Debian'
   if File.executable?("/usr/lib/update-notifier/apt-check")
     apt_package_updates = Facter::Util::Resolution.exec('/usr/lib/update-notifier/apt-check 2>&1').split(';')
+  else
+    apt_package_updates = ['31337', '31337']
   end
-
   setcode do
-    apt_package_updates != ['0', '0'] unless apt_package_updates.nil?
+    apt_package_updates
   end
 end
 
-packages = nil
 Facter.add("apt_package_updates") do
   confine :apt_has_updates => true
-  setcode do
   if File.executable?("/usr/lib/update-notifier/apt-check")
     packages = Facter::Util::Resolution.exec('/usr/lib/update-notifier/apt-check -p 2>&1').split("\n")
+  else
+    packages = ['update-notifier-common']
   end
+  setcode do
     if Facter.version < '2.0.0'
       packages.join(',')
     else
@@ -25,20 +26,16 @@ Facter.add("apt_package_updates") do
   end
 end
 
-if apt_updates != nil
-  Facter.add("apt_updates") do
-    confine :apt_has_updates => true
-    setcode do
-      Integer(apt_package_updates[0])
-    end
+Facter.add("apt_updates") do
+  confine :apt_has_updates => true
+  setcode do
+    Integer(apt_package_updates[0])
   end
 end
 
-if apt_has_updates != nil
-  Facter.add("apt_security_updates") do
-    confine :apt_has_updates => true
-    setcode do
-      Integer(apt_package_updates[1])
-    end
+Facter.add("apt_security_updates") do
+  confine :apt_has_updates => true
+  setcode do
+    Integer(apt_package_updates[1])
   end
 end

--- a/lib/facter/apt_updates.rb
+++ b/lib/facter/apt_updates.rb
@@ -2,7 +2,7 @@ apt_package_updates = nil
 Facter.add("apt_has_updates") do
   confine :osfamily => 'Debian'
   if File.executable?("/usr/lib/update-notifier/apt-check")
-    apt_package_updates = Facter::Util::Resolution.exec('/usr/lib/update-notifier/apt-check 2>/dev/null').split(';')
+    apt_package_updates = Facter::Util::Resolution.exec('/usr/lib/update-notifier/apt-check 2>&1').split(';')
   end
 
   setcode do
@@ -10,10 +10,13 @@ Facter.add("apt_has_updates") do
   end
 end
 
+packages = nil
 Facter.add("apt_package_updates") do
   confine :apt_has_updates => true
   setcode do
-    packages = Facter::Util::Resolution.exec('/usr/lib/update-notifier/apt-check -p 2>/dev/null').split("\n")
+  if File.executable?("/usr/lib/update-notifier/apt-check")
+    packages = Facter::Util::Resolution.exec('/usr/lib/update-notifier/apt-check -p 2>&1').split("\n")
+  end
     if Facter.version < '2.0.0'
       packages.join(',')
     else
@@ -22,16 +25,20 @@ Facter.add("apt_package_updates") do
   end
 end
 
-Facter.add("apt_updates") do
-  confine :apt_has_updates => true
-  setcode do
-    Integer(apt_package_updates[0])
+if apt_updates != nil
+  Facter.add("apt_updates") do
+    confine :apt_has_updates => true
+    setcode do
+      Integer(apt_package_updates[0])
+    end
   end
 end
 
-Facter.add("apt_security_updates") do
-  confine :apt_has_updates => true
-  setcode do
-    Integer(apt_package_updates[1])
+if apt_has_updates != nil
+  Facter.add("apt_security_updates") do
+    confine :apt_has_updates => true
+    setcode do
+      Integer(apt_package_updates[1])
+    end
   end
 end


### PR DESCRIPTION
Also makes the facts work, I don't think they were before. apt-check writes to stderr, not stdout. We need to process stderr. Should handle both now, in case there is a discrepancy there.

Related: #381 

Bug report: https://tickets.puppetlabs.com/browse/MODULES-1476