### PR TITLE
Manage apt::holds in hiera, like apt::sources

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -55,6 +55,7 @@ class apt(
   $update_timeout       = undef,
   $update_tries         = undef,
   $sources              = undef,
+  $holds                = undef,
   $fancy_progress       = undef
 ) {
 
@@ -203,5 +204,11 @@ class apt(
   if $sources != undef {
     validate_hash($sources)
     create_resources('apt::source', $sources)
+  }
+
+  # manage holds if present
+  if $holds != undef {
+    validate_hash($holds)
+    create_resources('apt::hold', $holds)
   }
 }


### PR DESCRIPTION
It's nice to be able to manage holds with hiera as well, just like sources.

Usage:

```yaml
apt::holds:
  facter:
    version: 2.3.*
  hiera:
    version: 1.3.*
  puppet:
    version: 3.7.*
  puppet-common:
    version: 3.7.*
```