### PR TITLE
MODULES-434: handle proxy authentication in apt_key#source_to_file

### DIFF
--- a/lib/puppet/provider/apt_key/apt_key.rb
+++ b/lib/puppet/provider/apt_key/apt_key.rb
@@ -120,7 +120,7 @@ Puppet::Type.type(:apt_key).provide(:apt_key) do
     else
       begin
         proxy = parsedValue.find_proxy
-        if not proxy.nil?
+        unless proxy.nil?
           if proxy.user && proxy.password
             options = {:proxy_http_basic_authentication => [proxy, proxy.user, proxy.password]}
           else

--- a/lib/puppet/provider/apt_key/apt_key.rb
+++ b/lib/puppet/provider/apt_key/apt_key.rb
@@ -119,7 +119,17 @@ Puppet::Type.type(:apt_key).provide(:apt_key) do
       value
     else
       begin
-        key = parsedValue.read
+        proxy = parsedValue.find_proxy
+        if not proxy.nil?
+          if proxy.user && proxy.password
+            options = {:proxy_http_basic_authentication => [proxy, proxy.user, proxy.password]}
+          else
+            options = {:proxy => proxy}
+          end
+        else
+          options = {}
+        end
+        key = parsedValue.read(options)
       rescue OpenURI::HTTPError, Net::FTPPermError => e
         fail("#{e.message} for #{resource[:source]}")
       rescue SocketError


### PR DESCRIPTION
Avoids "407 Proxy Authorization Required" errors while downloading keys.

Bug report: https://tickets.puppetlabs.com/browse/MODULES-434