### PR TITLE
(MODULES-1231) Fix apt::force locale issues

### DIFF
--- a/manifests/force.pp
+++ b/manifests/force.pp
@@ -52,8 +52,9 @@ define apt::force(
   }
 
   exec { "${provider} -y ${config_files} ${config_missing} ${release_string} install ${name}${version_string}":
-    unless    => $install_check,
-    logoutput => 'on_failure',
-    timeout   => $timeout,
+    unless      => $install_check,
+    environment => ['LC_ALL=C', 'LANG=C'],
+    logoutput   => 'on_failure',
+    timeout     => $timeout,
   }
 }


### PR DESCRIPTION
The current $install_check variable greps for 'Installed' or 'Candidate', which means that it will give the wrong results when a non-English locale is used. This patch ensures that the check will work properly for non-English locales.

I have done basic testing with locales fr_FR.UTF-8 and en_US.utf8.
I'm not sure how to create an acceptance test for this since it might require a re-login for locale changes to take effect.
