### PR TITLE
Specify release name in apt::source pins

### DIFF
--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -55,6 +55,7 @@ define apt::source(
       priority => $pin,
       before   => File["${name}.list"],
       origin   => $host,
+      release  => $release,
     }
   }
 


### PR DESCRIPTION
At the moment pins created for new sources only specify the origin. This means pins created by apt::backports affect the main repo too (for debian at least).

This should fix this.
