### PR TITLE
Separate apt::pin for apt::backports to allow pin by release instead of ...

### DIFF
--- a/manifests/backports.pp
+++ b/manifests/backports.pp
@@ -66,12 +66,17 @@ class apt::backports(
     'ubuntu' => 'main universe multiverse restricted',
   }
 
+  apt::pin { 'backports':
+    before   => Apt::Source['backports'],
+    release  => "${release_real}-backports",
+    priority => $pin_priority,
+  }
+
   apt::source { 'backports':
     location   => $location,
     release    => "${release_real}-backports",
     repos      => $repos,
     key        => $key,
     key_server => 'pgp.mit.edu',
-    pin        => $pin_priority,
   }
 }

--- a/spec/classes/backports_spec.rb
+++ b/spec/classes/backports_spec.rb
@@ -19,7 +19,12 @@ describe 'apt::backports', :type => :class do
           'repos'      => 'main universe multiverse restricted',
           'key'        => '437D05B5',
           'key_server' => 'pgp.mit.edu',
-          'pin'        => 500,
+        })
+      }
+
+      it { should contain_apt__pin('backports').with({
+          'release'  => 'karmic-backports',
+          'priority' => 500,
         })
       }
     end
@@ -48,7 +53,12 @@ describe 'apt::backports', :type => :class do
         'repos'      => 'main universe multiverse restricted',
         'key'        => '437D05B5',
         'key_server' => 'pgp.mit.edu',
-        'pin'        => 200,
+      })
+    }
+
+    it { should contain_apt__pin('backports').with({
+        'release'  => 'karmic-backports',
+        'priority' => 200,
       })
     }
   end
@@ -69,7 +79,12 @@ describe 'apt::backports', :type => :class do
         'repos'      => 'main contrib non-free',
         'key'        => '46925553',
         'key_server' => 'pgp.mit.edu',
-        'pin'        => 200,
+      })
+    }
+
+    it { should contain_apt__pin('backports').with({
+        'release'  => 'squeeze-backports',
+        'priority' => 200,
       })
     }
   end
@@ -90,7 +105,12 @@ describe 'apt::backports', :type => :class do
         'repos'      => 'main contrib non-free',
         'key'        => '46925553',
         'key_server' => 'pgp.mit.edu',
-        'pin'        => 200,
+      })
+    }
+
+    it { should contain_apt__pin('backports').with({
+        'release'  => 'wheezy-backports',
+        'priority' => 200,
       })
     }
   end
@@ -111,7 +131,12 @@ describe 'apt::backports', :type => :class do
         'repos'      => 'main universe multiverse restricted',
         'key'        => '437D05B5',
         'key_server' => 'pgp.mit.edu',
-        'pin'        => 200,
+      })
+    }
+
+    it { should contain_apt__pin('backports').with({
+        'release'  => 'trusty-backports',
+        'priority' => 200,
       })
     }
   end
@@ -140,7 +165,12 @@ describe 'apt::backports', :type => :class do
         'repos'      => 'main contrib non-free',
         'key'        => '46925553',
         'key_server' => 'pgp.mit.edu',
-        'pin'        => 200,
+      })
+    }
+
+    it { should contain_apt__pin('backports').with({
+        'release'  => 'squeeze-backports',
+        'priority' => 200,
       })
     }
   end


### PR DESCRIPTION
Currently apt::backports creates a ineffective pin when using debian 7 because backports and the main repo share an origin. Pinning by release can, for this reason, be more reliable for backports.