### PR TITLE
Make installation of software-properties optional

### DIFF
--- a/manifests/ppa.pp
+++ b/manifests/ppa.pp
@@ -4,6 +4,7 @@ define apt::ppa(
   $ensure  = 'present',
   $release = $::lsbdistcodename,
   $options = $apt::params::ppa_options,
+  $install_software_properties = true,
 ) {
   include apt::params
   include apt::update
@@ -29,8 +30,12 @@ define apt::ppa(
         default  => 'software-properties-common',
     }
 
-    if ! defined(Package[$package]) {
-        package { $package: }
+    if $install_software_properties {
+      if ! defined(Package[$package]) {
+          package { $package:
+            before => Exec["add-apt-repository-${name}"],
+          }
+      }
     }
 
     if defined(Class[apt]) {
@@ -54,10 +59,7 @@ define apt::ppa(
         user        => 'root',
         logoutput   => 'on_failure',
         notify      => Exec['apt_update'],
-        require     => [
-        File['sources.list.d'],
-        Package[$package],
-        ],
+        require     => File['sources.list.d'],
     }
 
     file { "${sources_list_d}/${sources_list_d_filename}":

--- a/spec/defines/ppa_spec.rb
+++ b/spec/defines/ppa_spec.rb
@@ -124,6 +124,29 @@ describe 'apt::ppa', :type => :define do
     }
   end
 
+  context 'without software properties' do
+    let(:title) { 'ppa:foo' }
+    let :facts do
+      {
+        :lsbdistrelease  => '14.04',
+        :lsbdistcodename => 'trusty',
+        :operatingsystem => 'Ubuntu',
+        :lsbdistid       => 'Ubuntu',
+        :osfamily        => 'Debian',
+      }
+    end
+    let :params do
+      {
+        'ensure' => 'absent',
+        'install_software_properties' => false,
+      }
+    end
+    it 'should not install software-properties' do
+      is_expected.not_to contain_package('python-software-properties')
+      is_expected.not_to contain_package('software-properties-common')
+    end
+  end
+
   context 'validation' do
     describe 'no release' do
       let :facts do


### PR DESCRIPTION
To simplify configuration of package installs on
Ubuntu, I frequently do the following:

    Apt::Source<||> -> Package<||>

To ensure that apt source configuration occurrs before
package installation. Having the ppas install software
properties breaks this pattern because it means that
the apt-get update must be run both before and after
software properties resulting in a dependency cycle.

For my purposes, the value of being able to stage
apt operations before packages is significannt enough
that I just ensure that software properties in installed
as a part of my base image.

According to the following issue, this looks like it has
been resolved as of 14.04 (that this library is installed
by default)

  https://bugs.launchpad.net/ubuntu/+source/ubuntu-meta/+bug/439566