### PR TITLE
Add Mint 17.1 (rebecca) support

### DIFF
--- a/manifests/backports.pp
+++ b/manifests/backports.pp
@@ -45,11 +45,12 @@ class apt::backports(
     } else {
       $distid = 'ubuntu'
       $release_real = $::lsbdistcodename ? {
-        'qiana'  => 'trusty',
-        'petra'  => 'saucy',
-        'olivia' => 'raring',
-        'nadia'  => 'quantal',
-        'maya'   => 'precise',
+        'rebecca' => 'trusty',
+        'qiana'   => 'trusty',
+        'petra'   => 'saucy',
+        'olivia'  => 'raring',
+        'nadia'   => 'quantal',
+        'maya'    => 'precise',
       }
     }
   } else {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,11 +17,12 @@ class apt::params {
       } else {
         $distid = 'ubuntu'
         $distcodename = $::lsbdistcodename ? {
-          'qiana'  => 'trusty',
-          'petra'  => 'saucy',
-          'olivia' => 'raring',
-          'nadia'  => 'quantal',
-          'maya'   => 'precise',
+          'rebecca' => 'trusty',
+          'qiana'   => 'trusty',
+          'petra'   => 'saucy',
+          'olivia'  => 'raring',
+          'nadia'   => 'quantal',
+          'maya'    => 'precise',
         }
       }
     }

--- a/spec/classes/backports_spec.rb
+++ b/spec/classes/backports_spec.rb
@@ -141,6 +141,32 @@ describe 'apt::backports', :type => :class do
     }
   end
 
+  describe "when turning on backports for linux mint 17.1 (ubuntu-based)" do
+
+    let :facts do
+      {
+        'lsbdistcodename' => 'rebecca',
+        'lsbdistid'       => 'LinuxMint',
+        'osfamily'        => 'Debian'
+      }
+    end
+
+    it { should contain_apt__source('backports').with({
+        'location'   => 'http://us.archive.ubuntu.com/ubuntu',
+        'release'    => 'trusty-backports',
+        'repos'      => 'main universe multiverse restricted',
+        'key'        => '437D05B5',
+        'key_server' => 'pgp.mit.edu',
+      })
+    }
+
+    it { should contain_apt__pin('backports').with({
+        'release'  => 'trusty-backports',
+        'priority' => 200,
+      })
+    }
+  end
+
   describe "when turning on backports for debian squeeze but using your own mirror" do
 
     let :facts do

--- a/spec/defines/ppa_spec.rb
+++ b/spec/defines/ppa_spec.rb
@@ -156,7 +156,7 @@ describe 'apt::ppa', :type => :define do
       it do
         expect {
           should compile
-        }.to raise_error(Puppet::Error, /apt::ppa is currently supported on Ubuntu only./)
+        }.to raise_error(Puppet::Error, /apt::ppa is currently supported on Ubuntu and LinuxMint only./)
       end
     end
   end


### PR DESCRIPTION
Added the Mint 17.1 codename to the release lists.  Also adds LinuxMint support to apt::ppa (an updated version of my #361 pull request that resolves the add-apt-repository path problem)