### PR TITLE
Documentation: Fix typo and syntax for example of apt::unattended_upgrad...

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,16 +72,16 @@ class { 'apt':
   }
   ```  
 
-* `apt::unattended_updates`: This class manages the unattended-upgrades package and related configuration files for Ubuntu and Debian systems. You can configure the class to automatically upgrade all new package releases or just security releases.
+* `apt::unattended_upgrades`: This class manages the unattended-upgrades package and related configuration files for Ubuntu and Debian systems. You can configure the class to automatically upgrade all new package releases or just security releases.
 
   ```
-  apt::unattended_upgrades {
-    origins             = $::apt::params::origins,
-    blacklist           = [],
-    update              = '1',
-    download            = '1',
-    upgrade             = '1',
-    autoclean           = '7',
+  class { 'apt::unattended_upgrades':
+    origins     => $::apt::params::origins,
+    blacklist   => [],
+    update      => '1',
+    download    => '1',
+    upgrade     => '1',
+    autoclean   => '7',
   }
   ```
   


### PR DESCRIPTION
Small documentation improvement: The example on how to configure apt::unattended_upgrades is not proper Puppet syntax. apt::unattended_upgrades is a class should be get resource-like declared.