### PR TITLE
Add support for calling `apt::update` directly

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -74,7 +74,13 @@ class apt(
   $frequency_options = ['always','daily','weekly','reluctantly']
   validate_re($apt_update_frequency, $frequency_options)
   include apt::params
-  include apt::update
+
+  class { 'apt::update':
+    always_apt_update    => $always_apt_update,
+    apt_update_frequency => $apt_update_frequency,
+    update_timeout       => $update_timeout,
+    update_tries         => $update_tries,
+  }
 
   validate_bool($purge_sources_list, $purge_sources_list_d,
                 $purge_preferences, $purge_preferences_d)

--- a/manifests/update.pp
+++ b/manifests/update.pp
@@ -1,14 +1,19 @@
-class apt::update {
+class apt::update(
+  $always_apt_update    = false,
+  $apt_update_frequency = 'reluctantly',
+  $update_timeout       = '300',
+  $update_tries         = '1',
+) {
   include apt::params
   #TODO: to catch if $::apt_update_last_success has the value of -1 here. If we
   #opt to do this, a info/warn would likely be all you'd need likely to happen
   #on the first run, but if it's not run in awhile something is likely borked
   #with apt and we'd want to know about it.
 
-  if $::apt::always_apt_update == false {
+  if $always_apt_update == false {
     #if always_apt_update is true there's no point in parsing this logic.
 
-    case $apt::apt_update_frequency {
+    case $apt_update_frequency {
       'always': {
         $_kick_apt = true
       }
@@ -61,8 +66,8 @@ class apt::update {
     command     => "${apt::params::provider} update",
     logoutput   => 'on_failure',
     refreshonly => $_refresh,
-    timeout     => $apt::update_timeout,
-    tries       => $apt::update_tries,
+    timeout     => $update_timeout,
+    tries       => $update_tries,
     try_sleep   => 1
   }
 }


### PR DESCRIPTION
eliminate the error message of variable look up failure:
- Could not look up qualified variable '::apt::always_apt_update'; class apt has not been evaluated
- Could not look up qualified variable 'apt::update_timeout'; class apt has not been evaluated
- Could not look up qualified variable 'apt::update_tries'; class apt has not been evaluated