### PR TITLE
WIP - rspec-puppet 2.0 updates and future parser fixes

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,7 @@
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-lint/tasks/puppet-lint'
 
-PuppetLint.configuration.fail_on_warnings
+PuppetLint.configuration.fail_on_warnings = true
 PuppetLint.configuration.send('relative')
 PuppetLint.configuration.send('disable_80chars')
 PuppetLint.configuration.send('disable_class_inherits_from_params_class')

--- a/manifests/backports.pp
+++ b/manifests/backports.pp
@@ -34,7 +34,11 @@ class apt::backports(
   $pin_priority = 200,
 ) inherits apt::params {
 
-  if ! is_integer($pin_priority) {
+  if ! is_integer($pin_priority)
+      # Old stdlib depends on this value being an integer-like string
+      # instead of an actual integer. This inline_template tricks
+      # stdlib 2.x into interpreting it correctly when future parser is on.
+      and ! is_integer(inline_template('<%= @pin_priority.to_s %>')) {
     fail('$pin_priority must be an integer')
   }
 

--- a/manifests/hold.pp
+++ b/manifests/hold.pp
@@ -35,7 +35,11 @@ define apt::hold(
   validate_string($package)
   validate_string($version)
 
-  if ! is_integer($priority) {
+  if ! is_integer($priority)
+      # Old stdlib depends on this value being an integer-like string
+      # instead of an actual integer. This inline_template tricks
+      # stdlib 2.x into interpreting it correctly when future parser is on.
+      and ! is_integer(inline_template('<%= @priority.to_s %>')) {
     fail('$priority must be an integer')
   }
 

--- a/manifests/pin.pp
+++ b/manifests/pin.pp
@@ -20,7 +20,11 @@ define apt::pin(
 
   $preferences_d = $apt::params::preferences_d
 
-  if $order != '' and !is_integer($order) {
+  if $order != '' and ! is_integer($order)
+      # Old stdlib depends on this value being an integer-like string
+      # instead of an actual integer. This inline_template tricks
+      # stdlib 2.x into interpreting it correctly when future parser is on.
+      and ! is_integer(inline_template('<%= @order.to_s %>')) {
     fail('Only integers are allowed in the apt::pin order param')
   }
 

--- a/spec/classes/apt_spec.rb
+++ b/spec/classes/apt_spec.rb
@@ -206,8 +206,8 @@ describe 'apt', :type => :class do
       end
       it do
         expect {
-          should compile
-        }.to raise_error(Puppet::Error)
+          is_expected.to compile
+        }.to raise_error(/"foo" is not a boolean.  It looks to be a String/)
       end
     end
 
@@ -219,8 +219,8 @@ describe 'apt', :type => :class do
       end
       it do
         expect {
-          should compile
-        }.to raise_error(Puppet::Error)
+          is_expected.to compile
+        }.to raise_error(/"foo" is not a boolean.  It looks to be a String/)
       end
     end
 
@@ -232,8 +232,8 @@ describe 'apt', :type => :class do
       end
       it do
         expect {
-          should compile
-        }.to raise_error(Puppet::Error)
+          is_expected.to compile
+        }.to raise_error(/"foo" is not a boolean.  It looks to be a String/)
       end
     end
 
@@ -245,8 +245,8 @@ describe 'apt', :type => :class do
       end
       it do
         expect {
-          should compile
-        }.to raise_error(Puppet::Error)
+          is_expected.to compile
+        }.to raise_error(/"foo" is not a boolean.  It looks to be a String/)
       end
     end
 
@@ -257,8 +257,8 @@ describe 'apt', :type => :class do
 
       it do
         expect {
-          should compile
-        }.to raise_error(Puppet::Error, /This module only works on Debian or derivatives like Ubuntu/)
+          is_expected.to compile
+        }.to raise_error(/This module only works on Debian or derivatives like Ubuntu/)
       end
     end
   end

--- a/spec/classes/backports_spec.rb
+++ b/spec/classes/backports_spec.rb
@@ -32,7 +32,7 @@ describe 'apt::backports', :type => :class do
     context 'invalid priority' do
       let :params do { :pin_priority => 'banana' } end
       it 'should fail' do
-        expect { subject }.to raise_error(/must be an integer/)
+        expect { is_expected.to compile }.to raise_error(/must be an integer/)
       end
     end
   end

--- a/spec/classes/params_spec.rb
+++ b/spec/classes/params_spec.rb
@@ -5,11 +5,8 @@ describe 'apt::params', :type => :class do
 
   it { should contain_apt__params }
 
-  # There are 4 resources in this class currently
-  # there should not be any more resources because it is a params class
-  # The resources are class[apt::params], class[main], class[settings], stage[main]
   it "Should not contain any resources" do
-    subject.resources.size.should == 4
+    should have_resource_count(0)
   end
 
   describe "With unknown lsbdistid" do
@@ -19,8 +16,8 @@ describe 'apt::params', :type => :class do
 
     it do
       expect {
-       should compile
-      }.to raise_error(Puppet::Error, /Unsupported lsbdistid/)
+       is_expected.to compile
+      }.to raise_error(/Unsupported lsbdistid/)
     end
 
   end
@@ -31,8 +28,8 @@ describe 'apt::params', :type => :class do
 
     it do
       expect {
-        should compile
-      }.to raise_error(Puppet::Error, /Unable to determine lsbdistid, is lsb-release installed/)
+        is_expected.to compile
+      }.to raise_error(/Unable to determine lsbdistid, is lsb-release installed/)
     end
   end
 

--- a/spec/defines/hold_spec.rb
+++ b/spec/defines/hold_spec.rb
@@ -69,28 +69,28 @@ describe 'apt::hold' do
     context 'version => {}' do
       let :params do { :version => {}, } end
       it 'should fail' do
-        expect { subject }.to raise_error(/is not a string/)
+        expect { is_expected.to compile }.to raise_error(/is not a string/)
       end
     end
 
     context 'ensure => bananana' do
       let :params do default_params.merge({:ensure => 'bananana',}) end
       it 'should fail' do
-        expect { subject }.to raise_error(/does not match/)
+        expect { is_expected.to compile }.to raise_error(/does not match/)
       end
     end
 
     context 'package => []' do
       let :params do default_params.merge({:package => [],}) end
       it 'should fail' do
-        expect { subject }.to raise_error(/is not a string/)
+        expect { is_expected.to compile }.to raise_error(/is not a string/)
       end
     end
 
     context 'priority => bananana' do
       let :params do default_params.merge({:priority => 'bananana',}) end
       it 'should fail' do
-        expect { subject }.to raise_error(/must be an integer/)
+        expect { is_expected.to compile }.to raise_error(/must be an integer/)
       end
     end
   end

--- a/spec/defines/key_spec.rb
+++ b/spec/defines/key_spec.rb
@@ -138,7 +138,7 @@ describe 'apt::key', :type => :define do
         :key_server => '-pgp.mit.edu',
       } end
       it 'fails' do
-        expect { subject } .to raise_error(/does not match/)
+        expect { is_expected.to compile } .to raise_error(/does not match/)
       end
     end
 
@@ -147,7 +147,7 @@ describe 'apt::key', :type => :define do
         :key_server => '.pgp.mit.edu',
       } end
       it 'fails' do
-        expect { subject } .to raise_error(/does not match/)
+        expect { is_expected.to compile } .to raise_error(/does not match/)
       end
     end
 
@@ -156,7 +156,7 @@ describe 'apt::key', :type => :define do
         :key_server => "pgp.mit.edu.",
       } end
       it 'fails' do
-        expect { subject } .to raise_error(/does not match/)
+        expect { is_expected.to compile } .to raise_error(/does not match/)
       end
     end
     context "exceed character url" do
@@ -166,7 +166,7 @@ describe 'apt::key', :type => :define do
         }
       end
       it 'fails' do
-        expect { subject }.to raise_error(/does not match/)
+        expect { is_expected.to compile }.to raise_error(/does not match/)
       end
     end
     context "incorrect port number url" do
@@ -176,7 +176,7 @@ describe 'apt::key', :type => :define do
         }
       end
       it 'fails' do
-        expect { subject }.to raise_error(/does not match/)
+        expect { is_expected.to compile }.to raise_error(/does not match/)
       end
     end
     context "incorrect protocol for  url" do
@@ -186,7 +186,7 @@ describe 'apt::key', :type => :define do
         }
       end
       it 'fails' do
-        expect { subject }.to raise_error(/does not match/)
+        expect { is_expected.to compile }.to raise_error(/does not match/)
       end
     end
     context "missing port number url" do
@@ -196,7 +196,7 @@ describe 'apt::key', :type => :define do
         }
       end
       it 'fails' do
-        expect { subject }.to raise_error(/does not match/)
+        expect { is_expected.to compile }.to raise_error(/does not match/)
       end
     end
     context "url ending with a dot" do
@@ -206,7 +206,7 @@ describe 'apt::key', :type => :define do
         }
       end
       it 'fails' do
-        expect { subject }.to raise_error(/does not match/)
+        expect { is_expected.to compile }.to raise_error(/does not match/)
       end
     end
     context "url begin with a dash" do
@@ -214,7 +214,7 @@ describe 'apt::key', :type => :define do
         :key_server => "hkp://-pgp.mit.edu",
       } end
       it 'fails' do
-        expect { subject }.to raise_error(/does not match/)
+        expect { is_expected.to compile }.to raise_error(/does not match/)
       end
     end
     context 'invalid key' do
@@ -222,7 +222,7 @@ describe 'apt::key', :type => :define do
         'Out of rum. Why? Why are we out of rum?'
       end
       it 'fails' do
-        expect { subject }.to raise_error(/does not match/)
+        expect { is_expected.to compile }.to raise_error(/does not match/)
       end
     end
 
@@ -231,7 +231,7 @@ describe 'apt::key', :type => :define do
         :key_source => 'afp://puppetlabs.com/key.gpg',
       } end
       it 'fails' do
-        expect { subject }.to raise_error(/does not match/)
+        expect { is_expected.to compile }.to raise_error(/does not match/)
       end
     end
 
@@ -240,7 +240,7 @@ describe 'apt::key', :type => :define do
         :key_content => [],
       } end
       it 'fails' do
-        expect { subject }.to raise_error(/is not a string/)
+        expect { is_expected.to compile }.to raise_error(/is not a string/)
       end
     end
 
@@ -249,7 +249,7 @@ describe 'apt::key', :type => :define do
         :key_server => 'two bottles of rum',
       } end
       it 'fails' do
-        expect { subject }.to raise_error(/does not match/)
+        expect { is_expected.to compile }.to raise_error(/does not match/)
       end
     end
 
@@ -258,7 +258,7 @@ describe 'apt::key', :type => :define do
         :key_options => {},
       } end
       it 'fails' do
-        expect { subject }.to raise_error(/is not a string/)
+        expect { is_expected.to compile }.to raise_error(/is not a string/)
       end
     end
 
@@ -269,7 +269,7 @@ describe 'apt::key', :type => :define do
         }
       end
       it 'fails' do
-        expect { subject }.to raise_error(/does not match/)
+        expect { is_expected.to compile }.to raise_error(/does not match/)
       end
     end
 
@@ -308,7 +308,7 @@ describe 'apt::key', :type => :define do
           "apt::key { 'duplicate': key => #{title}, ensure => 'absent', }"
         end
         it 'informs the user of the impossibility' do
-          expect { subject }.to raise_error(/already ensured as absent/)
+          expect { is_expected.to compile }.to raise_error(/already ensured as absent/)
         end
       end
     end

--- a/spec/defines/key_spec.rb
+++ b/spec/defines/key_spec.rb
@@ -276,7 +276,7 @@ describe 'apt::key', :type => :define do
     describe 'duplication' do
       context 'two apt::key resources for same key, different titles' do
         let :pre_condition do
-          "apt::key { 'duplicate': key => #{title}, }"
+          "apt::key { 'duplicate': key => '#{title}', }"
         end
 
         it 'contains two apt::key resources' do
@@ -305,7 +305,7 @@ describe 'apt::key', :type => :define do
 
       context 'two apt::key resources, different ensure' do
         let :pre_condition do
-          "apt::key { 'duplicate': key => #{title}, ensure => 'absent', }"
+          "apt::key { 'duplicate': key => '#{title}', ensure => 'absent', }"
         end
         it 'informs the user of the impossibility' do
           expect { is_expected.to compile }.to raise_error(/already ensured as absent/)

--- a/spec/defines/pin_spec.rb
+++ b/spec/defines/pin_spec.rb
@@ -102,8 +102,8 @@ describe 'apt::pin', :type => :define do
       end
       it do
         expect {
-          should compile
-        }.to raise_error(Puppet::Error, /Only integers are allowed/)
+          is_expected.to compile
+        }.to raise_error(/Only integers are allowed/)
       end
     end
 
@@ -115,8 +115,8 @@ describe 'apt::pin', :type => :define do
       end
       it do
         expect {
-          should compile
-        }.to raise_error(Puppet::Error, /parameter version cannot be used in general form/)
+          is_expected.to compile
+        }.to raise_error(/parameter version cannot be used in general form/)
       end
     end
 
@@ -129,8 +129,8 @@ describe 'apt::pin', :type => :define do
       end
       it do
         expect {
-          should compile
-        }.to raise_error(Puppet::Error, /parameters release and origin are mutually exclusive/)
+          is_expected.to compile
+        }.to raise_error(/parameters release and origin are mutually exclusive/)
       end
     end
 
@@ -144,8 +144,8 @@ describe 'apt::pin', :type => :define do
       end
       it do
         expect {
-          should compile
-        }.to raise_error(Puppet::Error, /parameters release, origin, and version are mutually exclusive/)
+          is_expected.to compile
+        }.to raise_error(/parameters release, origin, and version are mutually exclusive/)
       end
     end
 
@@ -159,8 +159,8 @@ describe 'apt::pin', :type => :define do
       end
       it do
         expect {
-          should compile
-        }.to raise_error(Puppet::Error, /parameters release, origin, and version are mutually exclusive/)
+          is_expected.to compile
+        }.to raise_error(/parameters release, origin, and version are mutually exclusive/)
       end
     end
   end

--- a/spec/defines/ppa_spec.rb
+++ b/spec/defines/ppa_spec.rb
@@ -137,8 +137,8 @@ describe 'apt::ppa', :type => :define do
       let(:title) { 'ppa:foo' }
       it do
         expect {
-          should compile
-        }.to raise_error(Puppet::Error, /lsbdistcodename fact not available: release parameter required/)
+          is_expected.to compile
+        }.to raise_error(/lsbdistcodename fact not available: release parameter required/)
       end
     end
 
@@ -155,8 +155,8 @@ describe 'apt::ppa', :type => :define do
       let(:title) { 'ppa:foo' }
       it do
         expect {
-          should compile
-        }.to raise_error(Puppet::Error, /apt::ppa is currently supported on Ubuntu only./)
+          is_expected.to compile
+        }.to raise_error(/apt::ppa is currently supported on Ubuntu only./)
       end
     end
   end

--- a/spec/defines/source_spec.rb
+++ b/spec/defines/source_spec.rb
@@ -175,8 +175,8 @@ describe 'apt::source', :type => :define do
 
       it do
         expect {
-          should compile
-        }.to raise_error(Puppet::Error, /lsbdistcodename fact not available: release parameter required/)
+          is_expected.to compile
+        }.to raise_error(/lsbdistcodename fact not available: release parameter required/)
       end
     end
   end


### PR DESCRIPTION
This includes a hack to make the future parser work with stdlib 2.x since this module depends on it, and updating it would require a major version bump. It is not very pretty and I'm very open to removing it and waiting for a major update or finding a better way to do it.