### PR TITLE
unattended_upgrades: Allow changing legacy_origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,12 +76,13 @@ class { 'apt':
 
   ```
   class { 'apt::unattended_upgrades':
-    origins     => $::apt::params::origins,
-    blacklist   => [],
-    update      => '1',
-    download    => '1',
-    upgrade     => '1',
-    autoclean   => '7',
+    legacy_origin => $::apt::params::legacy_origin,
+    origins       => $::apt::params::origins,
+    blacklist     => [],
+    update        => '1',
+    download      => '1',
+    upgrade       => '1',
+    autoclean     => '7',
   }
   ```
   

--- a/manifests/unattended_upgrades.pp
+++ b/manifests/unattended_upgrades.pp
@@ -14,6 +14,7 @@
 # file and in /etc/cron.daily/apt
 #
 class apt::unattended_upgrades (
+  $legacy_origin       = $::apt::params::legacy_origin,
   $origins             = $::apt::params::origins,
   $blacklist           = [],
   $update              = '1',
@@ -40,6 +41,7 @@ class apt::unattended_upgrades (
 ) inherits ::apt::params {
 
   validate_bool(
+    $legacy_origin,
     $auto_fix,
     $minimal_steps,
     $install_on_shutdown,


### PR DESCRIPTION
This enables using Origins-Pattern on Ubuntu.