### PR TITLE
apt: Add apt::setting defined type.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,6 +11,27 @@ class apt::params {
     fail('This module only works on Debian or derivatives like Ubuntu')
   }
 
+  $config_files = {
+    'conf'   => {
+      'path' => $conf_d,
+      'ext'  => '',
+    },
+    'pref'   => {
+      'path' => $preferences_d,
+      'ext'  => '',
+    },
+    'list'   => {
+      'path' => $sources_list_d,
+      'ext'  => '.list',
+    }
+  }
+
+  $file_defaults = {
+    'owner' => 'root',
+    'group' => 'root',
+    'mode'  => '0644',
+  }
+
   case $::lsbdistid {
     'ubuntu', 'debian': {
       $distid = $::lsbdistid

--- a/manifests/setting.pp
+++ b/manifests/setting.pp
@@ -1,0 +1,52 @@
+define apt::setting (
+  $type,
+  $priority   = 50,
+  $ensure     = file,
+  $source     = undef,
+  $content    = undef,
+  $file_perms = {},
+) {
+
+  $_file = merge($::apt::file_defaults, $file_perms)
+
+  if $content and $source {
+    fail('apt::setting cannot have both content and source')
+  }
+
+  if !$content and !$source {
+    fail('apt::setting needs either of content or source')
+  }
+
+  validate_re($type, ['conf', 'pref', 'list'])
+  validate_re($ensure,  ['file', 'present', 'absent'])
+
+  unless is_integer($priority) {
+    fail('apt::setting priority must be an integer')
+  }
+
+  if $source {
+    validate_string($source)
+  }
+
+  if $content {
+    validate_string($content)
+  }
+
+  if $type == 'list' {
+    $_priority = ''
+  } else {
+    $_priority = $priority
+  }
+
+  $_path = $::apt::config_files[$type]['path']
+  $_ext  = $::apt::config_files[$type]['ext']
+
+  file { "${_path}/${_priority}${title}${_ext}":
+    ensure  => $ensure,
+    owner   => $_file['owner'],
+    group   => $_file['group'],
+    mode    => $_file['mode'],
+    content => $content,
+    source  => $source,
+  }
+}

--- a/spec/defines/setting_spec.rb
+++ b/spec/defines/setting_spec.rb
@@ -1,0 +1,133 @@
+require 'spec_helper'
+
+describe 'apt::setting' do
+  let(:pre_condition) { 'class { "apt": }' }
+  let(:facts) { { :lsbdistid => 'Debian', :osfamily => 'Debian' } }
+  let(:title) { 'teddybear' }
+
+  let(:default_params) { { :type => 'conf', :content => 'di' } }
+
+  describe 'when using the defaults' do
+    context 'without type' do
+      it do
+        expect { should compile }.to raise_error(Puppet::Error, /Must pass type /)
+      end
+    end
+
+    context 'without source or content' do
+      let(:params) { { :type => 'conf' } }
+      it do
+        expect { should compile }.to raise_error(Puppet::Error, /needs either of /)
+      end
+    end
+
+    context 'with type=conf' do
+      let(:params) { default_params }
+      it { should contain_file('/etc/apt/apt.conf.d/50teddybear') }
+    end
+
+    context 'with type=pref' do
+      let(:params) { { :type => 'pref', :content => 'di' } }
+      it { should contain_file('/etc/apt/preferences.d/50teddybear') }
+    end
+
+    context 'with type=list' do
+      let(:params) { { :type => 'list', :content => 'di' } }
+      it { should contain_file('/etc/apt/sources.list.d/teddybear.list') }
+    end
+
+    context 'with source' do
+      let(:params) { { :type => 'conf', :source => 'puppet:///la/die/dah' } }
+      it {
+        should contain_file('/etc/apt/apt.conf.d/50teddybear').with({
+        :ensure => 'file',
+        :owner  => 'root',
+        :group  => 'root',
+        :mode   => '0644',
+        :source => "#{params[:source]}",
+      })}
+    end
+
+    context 'with content' do
+      let(:params) { default_params }
+      it { should contain_file('/etc/apt/apt.conf.d/50teddybear').with({
+        :ensure  => 'file',
+        :owner   => 'root',
+        :group   => 'root',
+        :mode    => '0644',
+        :content => "#{params[:content]}",
+      })}
+    end
+  end
+
+  describe 'when trying to pull one over' do
+    context 'with source and content' do
+      let(:params) { default_params.merge({ :source => 'la' }) }
+      it do
+        expect { should compile }.to raise_error(Puppet::Error, /cannot have both /)
+      end
+    end
+
+    context 'with type=ext' do
+      let(:params) { default_params.merge({ :type => 'ext' }) }
+      it do
+        expect { should compile }.to raise_error(Puppet::Error, /"ext" does not /)
+      end
+    end
+
+    context 'with ensure=banana' do
+      let(:params) { default_params.merge({ :ensure => 'banana' }) }
+      it do
+        expect { should compile }.to raise_error(Puppet::Error, /"banana" does not /)
+      end
+    end
+
+    context 'with priority=1.2' do
+      let(:params) { default_params.merge({ :priority => 1.2 }) }
+      it do
+        expect { should compile }.to raise_error(Puppet::Error, /be an integer /)
+      end
+    end
+  end
+
+  describe 'with priority=100' do
+    let(:params) { default_params.merge({ :priority => 100 }) }
+    it { should contain_file('/etc/apt/apt.conf.d/100teddybear') }
+  end
+
+  describe 'with ensure=absent' do
+    let(:params) { default_params.merge({ :ensure => 'absent' }) }
+    it { should contain_file('/etc/apt/apt.conf.d/50teddybear').with({
+      :ensure => 'absent',
+    })}
+  end
+
+  describe 'with file_perms' do
+    context "{'owner' => 'roosevelt'}" do
+      let(:params) { default_params.merge({ :file_perms => {'owner' => 'roosevelt'} }) }
+      it { should contain_file('/etc/apt/apt.conf.d/50teddybear').with({
+        :owner => 'roosevelt',
+        :group => 'root',
+        :mode  => '0644',
+      })}
+    end
+
+    context "'group' => 'roosevelt'}" do
+      let(:params) { default_params.merge({ :file_perms => {'group' => 'roosevelt'} }) }
+      it { should contain_file('/etc/apt/apt.conf.d/50teddybear').with({
+        :owner => 'root',
+        :group => 'roosevelt',
+        :mode  => '0644',
+      })}
+    end
+
+    context "'owner' => 'roosevelt'}" do
+      let(:params) { default_params.merge({ :file_perms => {'mode' => '0600'} }) }
+      it { should contain_file('/etc/apt/apt.conf.d/50teddybear').with({
+        :owner => 'root',
+        :group => 'root',
+        :mode  => '0600',
+      })}
+    end
+  end
+end


### PR DESCRIPTION
This is a 'base' type. It's a simple wrapper around a file which takes `type`, `ensure`, `content`, `source` and `file_perms`. It is intended for usage by `apt::conf`, `apt::source` and an upcoming `apt::pref`.