### PR TITLE
Remove 'include apt::update'

### DIFF
--- a/manifests/ppa.pp
+++ b/manifests/ppa.pp
@@ -1,12 +1,9 @@
 # ppa.pp
-
 define apt::ppa(
   $ensure  = 'present',
   $release = $::lsbdistcodename,
   $options = $apt::params::ppa_options,
 ) {
-  include apt::update
-
   $sources_list_d = $apt::params::sources_list_d
 
   if ! $release {

--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -17,8 +17,6 @@ define apt::source(
   $architecture      = undef,
   $trusted_source    = false,
 ) {
-  include apt::update
-
   validate_string($architecture)
   validate_bool($trusted_source)
 


### PR DESCRIPTION
It is included in `class apt`, and there are no promises about anything
working without that.