### PR TITLE
Cleanup for `apt::source`

### DIFF
--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -23,16 +23,12 @@ define apt::source(
     fail('lsbdistcodename fact not available: release parameter required')
   }
 
-  file { "${name}.list":
-    ensure  => $ensure,
-    path    => "${::apt::sources_list_d}/${name}.list",
-    owner   => root,
-    group   => root,
-    mode    => '0644',
-    content => template('apt/_header.erb', 'apt/source.list.erb'),
-    notify  => Exec['apt_update'],
+  apt::setting { $name:
+    ensure       => $ensure,
+    setting_type => 'list',
+    content      => template('apt/_header.erb', 'apt/source.list.erb'),
+    notify       => Exec['apt_update'],
   }
-
 
   if ($pin != false) {
     # Get the host portion out of the url so we can pin to origin
@@ -42,7 +38,7 @@ define apt::source(
     apt::pin { $name:
       ensure   => $ensure,
       priority => $pin,
-      before   => File["${name}.list"],
+      before   => Apt::Setting[$name],
       origin   => $host,
     }
   }
@@ -55,7 +51,7 @@ define apt::source(
       key_server  => $key_server,
       key_content => $key_content,
       key_source  => $key_source,
-      before      => File["${name}.list"],
+      before      => Apt::Setting[$name],
     }
   }
 

--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -1,13 +1,12 @@
 # source.pp
 # add an apt source
-
 define apt::source(
   $comment           = $name,
   $ensure            = present,
   $location          = '',
-  $release           = 'UNDEF',
+  $release           = $::lsbdistcodename,
   $repos             = 'main',
-  $include_src       = true,
+  $include_src       = false,
   $include_deb       = true,
   $key               = undef,
   $key_server        = 'keyserver.ubuntu.com',
@@ -17,17 +16,11 @@ define apt::source(
   $architecture      = undef,
   $trusted_source    = false,
 ) {
-  validate_string($architecture)
-  validate_bool($trusted_source)
+  validate_string($architecture, $comment, $location, $release, $repos, $key_server)
+  validate_bool($trusted_source, $include_src, $include_deb)
 
-  if $release == 'UNDEF' {
-    if $::lsbdistcodename == undef {
-      fail('lsbdistcodename fact not available: release parameter required')
-    } else {
-      $release_real = $::lsbdistcodename
-    }
-  } else {
-    $release_real = $release
+  if ! $release {
+    fail('lsbdistcodename fact not available: release parameter required')
   }
 
   file { "${name}.list":

--- a/spec/classes/apt_spec.rb
+++ b/spec/classes/apt_spec.rb
@@ -110,31 +110,23 @@ describe 'apt', :type => :class do
     } } }
 
     it {
-      should contain_file('debian_unstable.list').with({
+      should contain_apt__setting('debian_unstable').with({
         'ensure'  => 'present',
-        'path'    => '/etc/apt/sources.list.d/debian_unstable.list',
-        'owner'   => 'root',
-        'group'   => 'root',
-        'mode'    => '0644',
         'notify'  => 'Exec[apt_update]',
       })
     }
 
-    it { should contain_file('debian_unstable.list').with_content(/^deb http:\/\/debian.mirror.iweb.ca\/debian\/ unstable main contrib non-free$/) }
-    it { should contain_file('debian_unstable.list').with_content(/^deb-src http:\/\/debian.mirror.iweb.ca\/debian\/ unstable main contrib non-free$/) }
+    it { should contain_file('/etc/apt/sources.list.d/debian_unstable.list').with_content(/^deb http:\/\/debian.mirror.iweb.ca\/debian\/ unstable main contrib non-free$/) }
+    it { should contain_file('/etc/apt/sources.list.d/debian_unstable.list').with_content(/^deb-src http:\/\/debian.mirror.iweb.ca\/debian\/ unstable main contrib non-free$/) }
 
     it {
-      should contain_file('puppetlabs.list').with({
+      should contain_apt__setting('puppetlabs').with({
         'ensure'  => 'present',
-        'path'    => '/etc/apt/sources.list.d/puppetlabs.list',
-        'owner'   => 'root',
-        'group'   => 'root',
-        'mode'    => '0644',
         'notify'  => 'Exec[apt_update]',
       })
     }
 
-    it { should contain_file('puppetlabs.list').with_content(/^deb http:\/\/apt.puppetlabs.com precise main$/) }
+    it { should contain_file('/etc/apt/sources.list.d/puppetlabs.list').with_content(/^deb http:\/\/apt.puppetlabs.com precise main$/) }
   end
 
   describe 'failing tests' do

--- a/spec/classes/apt_spec.rb
+++ b/spec/classes/apt_spec.rb
@@ -135,7 +135,6 @@ describe 'apt', :type => :class do
     }
 
     it { should contain_file('puppetlabs.list').with_content(/^deb http:\/\/apt.puppetlabs.com precise main$/) }
-    it { should contain_file('puppetlabs.list').with_content(/^deb-src http:\/\/apt.puppetlabs.com precise main$/) }
   end
 
   describe 'failing tests' do

--- a/spec/defines/source_spec.rb
+++ b/spec/defines/source_spec.rb
@@ -27,12 +27,8 @@ describe 'apt::source', :type => :define do
       }
     end
 
-    it { is_expected.to contain_file('my_source.list').that_notifies('Exec[apt_update]').with({
+    it { is_expected.to contain_apt__setting('my_source').that_notifies('Exec[apt_update]').with({
       'ensure' => 'present',
-      'path'   => '/etc/apt/sources.list.d/my_source.list',
-      'owner'  => 'root',
-      'group'  => 'root',
-      'mode'   => '0644',
     }).with_content(/# my_source\ndeb-src  wheezy main\n/)
     }
   end
@@ -62,23 +58,19 @@ describe 'apt::source', :type => :define do
       }
     end
 
-    it { is_expected.to contain_file('my_source.list').that_notifies('Exec[apt_update]').with({
+    it { is_expected.to contain_apt__setting('my_source').that_notifies('Exec[apt_update]').with({
       'ensure' => 'present',
-      'path'   => '/etc/apt/sources.list.d/my_source.list',
-      'owner'  => 'root',
-      'group'  => 'root',
-      'mode'   => '0644',
     }).with_content(/# foo\ndeb \[arch=x86_64 trusted=yes\] http:\/\/debian\.mirror\.iweb\.ca\/debian\/ sid testing\n/).without_content(/deb-src/)
     }
 
-    it { is_expected.to contain_apt__pin('my_source').that_comes_before('File[my_source.list]').with({
+    it { is_expected.to contain_apt__pin('my_source').that_comes_before('Apt::Setting[my_source]').with({
       'ensure'   => 'present',
       'priority' => '10',
       'origin'   => 'debian.mirror.iweb.ca',
     })
     }
 
-    it { is_expected.to contain_apt__key("Add key: #{GPG_KEY_ID} from Apt::Source my_source").that_comes_before('File[my_source.list]').with({
+    it { is_expected.to contain_apt__key("Add key: #{GPG_KEY_ID} from Apt::Source my_source").that_comes_before('Apt::Setting[my_source]').with({
       'ensure' => 'present',
         'key'  => GPG_KEY_ID,
         'key_server' => 'pgp.mit.edu',
@@ -103,12 +95,8 @@ describe 'apt::source', :type => :define do
       }
     end
 
-    it { is_expected.to contain_file('my_source.list').that_notifies('Exec[apt_update]').with({
+    it { is_expected.to contain_apt__setting('my_source').that_notifies('Exec[apt_update]').with({
       'ensure' => 'present',
-      'path'   => '/etc/apt/sources.list.d/my_source.list',
-      'owner'  => 'root',
-      'group'  => 'root',
-      'mode'   => '0644',
     }).with_content(/# my_source\ndeb \[trusted=yes\]  wheezy main\n/)
     }
   end
@@ -129,12 +117,8 @@ describe 'apt::source', :type => :define do
       }
     end
 
-    it { is_expected.to contain_file('my_source.list').that_notifies('Exec[apt_update]').with({
+    it { is_expected.to contain_apt__setting('my_source').that_notifies('Exec[apt_update]').with({
       'ensure' => 'present',
-      'path'   => '/etc/apt/sources.list.d/my_source.list',
-      'owner'  => 'root',
-      'group'  => 'root',
-      'mode'   => '0644',
     }).with_content(/# my_source\ndeb-src \[arch=x86_64 \]  wheezy main\n/)
     }
   end
@@ -153,7 +137,7 @@ describe 'apt::source', :type => :define do
       }
     end
 
-    it { is_expected.to contain_file('my_source.list').that_notifies('Exec[apt_update]').with({
+    it { is_expected.to contain_apt__setting('my_source').that_notifies('Exec[apt_update]').with({
       'ensure' => 'absent'
     })
     }

--- a/spec/defines/source_spec.rb
+++ b/spec/defines/source_spec.rb
@@ -23,6 +23,7 @@ describe 'apt::source', :type => :define do
     let :params do
       {
         'include_deb' => false,
+        'include_src' => true,
       }
     end
 
@@ -123,6 +124,7 @@ describe 'apt::source', :type => :define do
     let :params do
       {
         'include_deb'  => false,
+        'include_src'  => true,
         'architecture' => 'x86_64',
       }
     end

--- a/templates/source.list.erb
+++ b/templates/source.list.erb
@@ -2,10 +2,10 @@
 <%- if @include_deb then -%>
 deb <%- if @architecture or @trusted_source -%>
 [<%- if @architecture %>arch=<%= @architecture %> <% end %><% if @trusted_source %>trusted=yes<% end -%>
-] <%- end %><%= @location %> <%= @release_real %> <%= @repos %>
+] <%- end %><%= @location %> <%= @release %> <%= @repos %>
 <%- end -%>
 <%- if @include_src then -%>
 deb-src <%- if @architecture or @trusted_source -%>
 [<%- if @architecture %>arch=<%= @architecture %> <% end %><% if @trusted_source %>trusted=yes<% end -%>
-] <%- end %><%= @location %> <%= @release_real %> <%= @repos %>
+] <%- end %><%= @location %> <%= @release %> <%= @repos %>
 <%- end -%>


### PR DESCRIPTION
* Update `release` to default to `$::lsbdistcodename`
* Default `include_src` to false
* Validate more things!
* Stop redefining variables from `apt::params`