### PR TITLE
handle broken hiera boolean values

### DIFF
--- a/templates/source.list.erb
+++ b/templates/source.list.erb
@@ -1,10 +1,10 @@
 # <%= @comment %>
-<%- if @include_deb then -%>
+<%- if @include_deb and @include_deb != 'false' then -%>
 deb <%- if @architecture or @trusted_source -%>
 [<%- if @architecture %>arch=<%= @architecture %> <% end %><% if @trusted_source %>trusted=yes<% end -%>
 ] <%- end %><%= @location %> <%= @release_real %> <%= @repos %>
 <%- end -%>
-<%- if @include_src then -%>
+<%- if @include_src and @include_src != 'false' then -%>
 deb-src <%- if @architecture or @trusted_source -%>
 [<%- if @architecture %>arch=<%= @architecture %> <% end %><% if @trusted_source %>trusted=yes<% end -%>
 ] <%- end %><%= @location %> <%= @release_real %> <%= @repos %>


### PR DESCRIPTION
The hiera support for adding sources...

```yaml
apt::sources:
  'debian_unstable':
    location: 'http://debian.mirror.iweb.ca/debian/'
    release: 'unstable'
    repos: 'main contrib non-free'
    include_src: 'false'
    include_deb: 'true'
```

...isn't working as expected. I'm unable to set `include_src` or `include_deb` to `false`. Hiera will pass the values as a string, thus the value is always `true`. A workaround is to also check for the string `false` instead of a boolean.