### PR TITLE
fix hiera example in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,8 +244,8 @@ apt::sources:
     key: '9AA38DCD55BE302B'
     key_server: 'subkeys.pgp.net'
     pin: '-10'
-    include_src: 'true'
-    include_deb: 'true'
+    include_src: true
+    include_deb: true
 
   'puppetlabs':
     location: 'http://apt.puppetlabs.com'


### PR DESCRIPTION
As a followup to https://github.com/puppetlabs/puppetlabs-apt/pull/436 this changes the documentation to use boolean values instead of strings in the hiera example.