### PR TITLE
apt::params: Make the class private.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,4 +1,9 @@
 class apt::params {
+
+  if $caller_module_name and $caller_module_name != $module_name {
+    fail('apt::params is a private class and cannot be accessed directly')
+  }
+
   $root           = '/etc/apt'
   $provider       = '/usr/bin/apt-get'
   $sources_list   = "${root}/sources.list"


### PR DESCRIPTION
Prevent direct access to apt::params. This will ensure that any other
module cannot blindly access apt::params and get settings that have been
potentially overridden at the apt level.

Our own module still can since any class in apt has a module_name of
'apt' but that's up to us to prevent from happening.

Every setting must now be accessed by a qualified lookup into the apt
namespace.


![nan batman](http://sd.keepcalm-o-matic.co.uk/i/keep-calm-and-nananana-batman-2.png)