### PR TITLE
Convert specs to RSpec 3.1.7 syntax with Transpec

### DIFF
--- a/spec/classes/apt_spec.rb
+++ b/spec/classes/apt_spec.rb
@@ -3,7 +3,7 @@ describe 'apt', :type => :class do
   let(:facts) { { :lsbdistid => 'Debian', :osfamily => 'Debian' } }
 
   context 'defaults' do
-    it { should contain_file('sources.list').that_notifies('Exec[apt_update]').only_with({
+    it { is_expected.to contain_file('sources.list').that_notifies('Exec[apt_update]').only_with({
       'ensure' => 'present',
       'path'   => '/etc/apt/sources.list',
       'owner'  => 'root',
@@ -12,7 +12,7 @@ describe 'apt', :type => :class do
       'notify' => 'Exec[apt_update]',
     })}
 
-    it { should contain_file('sources.list.d').that_notifies('Exec[apt_update]').only_with({
+    it { is_expected.to contain_file('sources.list.d').that_notifies('Exec[apt_update]').only_with({
       'ensure'  => 'directory',
       'path'    => '/etc/apt/sources.list.d',
       'owner'   => 'root',
@@ -22,7 +22,7 @@ describe 'apt', :type => :class do
       'notify'  => 'Exec[apt_update]',
     })}
 
-    it { should contain_file('preferences.d').only_with({
+    it { is_expected.to contain_file('preferences.d').only_with({
       'ensure'  => 'directory',
       'path'    => '/etc/apt/preferences.d',
       'owner'   => 'root',
@@ -32,14 +32,14 @@ describe 'apt', :type => :class do
     })}
 
     it 'should lay down /etc/apt/apt.conf.d/15update-stamp' do
-      should contain_file('/etc/apt/apt.conf.d/15update-stamp').with({
+      is_expected.to contain_file('/etc/apt/apt.conf.d/15update-stamp').with({
         'group' => 'root',
         'mode'  => '0644',
         'owner' => 'root',
       }).with_content(/APT::Update::Post-Invoke-Success \{"touch \/var\/lib\/apt\/periodic\/update-success-stamp 2>\/dev\/null \|\| true";\};/)
     end
 
-    it { should contain_exec('apt_update').with({
+    it { is_expected.to contain_exec('apt_update').with({
       'refreshonly' => 'true',
     })}
   end
@@ -57,26 +57,26 @@ describe 'apt', :type => :class do
       }
     end
 
-    it { should contain_file('sources.list').with({
+    it { is_expected.to contain_file('sources.list').with({
       'content' => "# Repos managed by puppet.\n"
     })}
 
-    it { should contain_file('sources.list.d').with({
+    it { is_expected.to contain_file('sources.list.d').with({
       'purge'   => 'true',
       'recurse' => 'true',
     })}
 
-    it { should contain_file('apt-preferences').only_with({
+    it { is_expected.to contain_file('apt-preferences').only_with({
       'ensure' => 'absent',
       'path'   => '/etc/apt/preferences',
     })}
 
-    it { should contain_file('preferences.d').with({
+    it { is_expected.to contain_file('preferences.d').with({
       'purge'   => 'true',
       'recurse' => 'true',
     })}
 
-    it { should contain_exec('apt_update').with({
+    it { is_expected.to contain_exec('apt_update').with({
       'refreshonly' => 'false',
       'timeout'     => '1',
       'tries'       => '3',
@@ -110,23 +110,23 @@ describe 'apt', :type => :class do
     } } }
 
     it {
-      should contain_apt__setting('debian_unstable').with({
+      is_expected.to contain_apt__setting('debian_unstable').with({
         'ensure'  => 'present',
         'notify'  => 'Exec[apt_update]',
       })
     }
 
-    it { should contain_file('/etc/apt/sources.list.d/debian_unstable.list').with_content(/^deb http:\/\/debian.mirror.iweb.ca\/debian\/ unstable main contrib non-free$/) }
-    it { should contain_file('/etc/apt/sources.list.d/debian_unstable.list').with_content(/^deb-src http:\/\/debian.mirror.iweb.ca\/debian\/ unstable main contrib non-free$/) }
+    it { is_expected.to contain_file('/etc/apt/sources.list.d/debian_unstable.list').with_content(/^deb http:\/\/debian.mirror.iweb.ca\/debian\/ unstable main contrib non-free$/) }
+    it { is_expected.to contain_file('/etc/apt/sources.list.d/debian_unstable.list').with_content(/^deb-src http:\/\/debian.mirror.iweb.ca\/debian\/ unstable main contrib non-free$/) }
 
     it {
-      should contain_apt__setting('puppetlabs').with({
+      is_expected.to contain_apt__setting('puppetlabs').with({
         'ensure'  => 'present',
         'notify'  => 'Exec[apt_update]',
       })
     }
 
-    it { should contain_file('/etc/apt/sources.list.d/puppetlabs.list').with_content(/^deb http:\/\/apt.puppetlabs.com precise main$/) }
+    it { is_expected.to contain_file('/etc/apt/sources.list.d/puppetlabs.list').with_content(/^deb http:\/\/apt.puppetlabs.com precise main$/) }
   end
 
   describe 'failing tests' do
@@ -138,7 +138,7 @@ describe 'apt', :type => :class do
       end
       it do
         expect {
-          should compile
+          is_expected.to compile
         }.to raise_error(Puppet::Error)
       end
     end
@@ -151,7 +151,7 @@ describe 'apt', :type => :class do
       end
       it do
         expect {
-          should compile
+          is_expected.to compile
         }.to raise_error(Puppet::Error)
       end
     end
@@ -164,7 +164,7 @@ describe 'apt', :type => :class do
       end
       it do
         expect {
-          should compile
+          is_expected.to compile
         }.to raise_error(Puppet::Error)
       end
     end
@@ -177,7 +177,7 @@ describe 'apt', :type => :class do
       end
       it do
         expect {
-          should compile
+          is_expected.to compile
         }.to raise_error(Puppet::Error)
       end
     end
@@ -189,7 +189,7 @@ describe 'apt', :type => :class do
 
       it do
         expect {
-          should compile
+          is_expected.to compile
         }.to raise_error(Puppet::Error, /This module only works on Debian or derivatives like Ubuntu/)
       end
     end

--- a/spec/classes/apt_update_spec.rb
+++ b/spec/classes/apt_update_spec.rb
@@ -8,7 +8,7 @@ describe 'apt::update', :type => :class do
     let (:pre_condition) { "class{'::apt': always_apt_update => true}" }
     it 'should trigger an apt-get update run' do
       #set the apt_update exec's refreshonly attribute to false
-      should contain_exec('apt_update').with({'refreshonly' => false })
+      is_expected.to contain_exec('apt_update').with({'refreshonly' => false })
     end
     ['always','daily','weekly','reluctantly'].each do |update_frequency|
       context "when apt::apt_update_frequency has the value of #{update_frequency}" do
@@ -18,7 +18,7 @@ describe 'apt::update', :type => :class do
             let (:pre_condition) { "class{'::apt': always_apt_update => true, apt_update_frequency => '#{update_frequency}' }" }
             it 'should trigger an apt-get update run' do
               # set the apt_update exec's refreshonly attribute to false
-              should contain_exec('apt_update').with({'refreshonly' => false})
+              is_expected.to contain_exec('apt_update').with({'refreshonly' => false})
             end
           end
           context 'when $::apt_update_last_success is nil' do
@@ -26,7 +26,7 @@ describe 'apt::update', :type => :class do
             let (:pre_condition) { "class{'::apt': always_apt_update => true, apt_update_frequency => '#{update_frequency}' }" }
             it 'should trigger an apt-get update run' do
               #set the apt_update exec\'s refreshonly attribute to false
-              should contain_exec('apt_update').with({'refreshonly' => false})
+              is_expected.to contain_exec('apt_update').with({'refreshonly' => false})
             end
           end
         end
@@ -42,7 +42,7 @@ describe 'apt::update', :type => :class do
           let (:pre_condition) { "class{'::apt': always_apt_update => false, apt_update_frequency => 'always' }" }
           it 'should trigger an apt-get update run' do
             #set the apt_update exec's refreshonly attribute to false
-            should contain_exec('apt_update').with({'refreshonly' => false})
+            is_expected.to contain_exec('apt_update').with({'refreshonly' => false})
           end
         end
       end
@@ -51,7 +51,7 @@ describe 'apt::update', :type => :class do
         let (:pre_condition) { "class{ '::apt': always_apt_update => false, apt_update_frequency => 'always' }" }
         it 'should trigger an apt-get update run' do
           #set the apt_update exec\'s refreshonly attribute to false
-          should contain_exec('apt_update').with({'refreshonly' => false})
+          is_expected.to contain_exec('apt_update').with({'refreshonly' => false})
         end
       end
     end
@@ -62,7 +62,7 @@ describe 'apt::update', :type => :class do
           let (:pre_condition) { "class{ '::apt': always_apt_update => false, apt_update_frequency => 'reluctantly' }" }
           it 'should not trigger an apt-get update run' do
             #don't change the apt_update exec's refreshonly attribute. (it should be true)
-            should contain_exec('apt_update').with({'refreshonly' => true})
+            is_expected.to contain_exec('apt_update').with({'refreshonly' => true})
           end
         end
       end
@@ -71,7 +71,7 @@ describe 'apt::update', :type => :class do
         let (:pre_condition) { "class{ '::apt': always_apt_update => false, apt_update_frequency => 'reluctantly' }" }
         it 'should not trigger an apt-get update run' do
           #don't change the apt_update exec's refreshonly attribute. (it should be true)
-          should contain_exec('apt_update').with({'refreshonly' => true})
+          is_expected.to contain_exec('apt_update').with({'refreshonly' => true})
         end
       end
     end
@@ -83,7 +83,7 @@ describe 'apt::update', :type => :class do
             let (:pre_condition) { "class{ '::apt': always_apt_update => false, apt_update_frequency => '#{update_frequency}' }" }
             it 'should trigger an apt-get update run' do
               #set the apt_update exec\'s refreshonly attribute to false
-              should contain_exec('apt_update').with({'refreshonly' => false})
+              is_expected.to contain_exec('apt_update').with({'refreshonly' => false})
             end
           end
         end
@@ -92,7 +92,7 @@ describe 'apt::update', :type => :class do
           let (:pre_condition) { "class{ '::apt': always_apt_update => false, apt_update_frequency => '#{update_frequency}' }" }
           it 'should not trigger an apt-get update run' do
             #don't change the apt_update exec\'s refreshonly attribute. (it should be true)
-            should contain_exec('apt_update').with({'refreshonly' => true})
+            is_expected.to contain_exec('apt_update').with({'refreshonly' => true})
           end
         end
         context 'when $::apt_update_last_success is nil' do
@@ -100,7 +100,7 @@ describe 'apt::update', :type => :class do
           let (:pre_condition) { "class{ '::apt': always_apt_update => false, apt_update_frequency => '#{update_frequency}' }" }
           it 'should trigger an apt-get update run' do
             #set the apt_update exec\'s refreshonly attribute to false
-            should contain_exec('apt_update').with({'refreshonly' => false})
+            is_expected.to contain_exec('apt_update').with({'refreshonly' => false})
           end
         end
       end

--- a/spec/classes/params_spec.rb
+++ b/spec/classes/params_spec.rb
@@ -3,13 +3,13 @@ describe 'apt::params', :type => :class do
   let(:facts) { { :lsbdistid => 'Debian', :osfamily => 'Debian' } }
   let (:title) { 'my_package' }
 
-  it { should contain_apt__params }
+  it { is_expected.to contain_apt__params }
 
   # There are 4 resources in this class currently
   # there should not be any more resources because it is a params class
   # The resources are class[apt::params], class[main], class[settings], stage[main]
   it "Should not contain any resources" do
-    subject.resources.size.should == 4
+    expect(subject.resources.size).to eq(4)
   end
 
   describe "With unknown lsbdistid" do
@@ -19,7 +19,7 @@ describe 'apt::params', :type => :class do
 
     it do
       expect {
-       should compile
+       is_expected.to compile
       }.to raise_error(Puppet::Error, /Unsupported lsbdistid/)
     end
 
@@ -31,7 +31,7 @@ describe 'apt::params', :type => :class do
 
     it do
       expect {
-        should compile
+        is_expected.to compile
       }.to raise_error(Puppet::Error, /Unable to determine lsbdistid, is lsb-release installed/)
     end
   end

--- a/spec/defines/conf_spec.rb
+++ b/spec/defines/conf_spec.rb
@@ -20,7 +20,7 @@ describe 'apt::conf', :type => :define do
       "/etc/apt/apt.conf.d/00norecommends"
     end
 
-    it { should contain_file(filename).with({
+    it { is_expected.to contain_file(filename).with({
           'ensure'    => 'present',
           'content'   => /Apt::Install-Recommends 0;\nApt::AutoRemove::InstallRecommends 1;/,
           'owner'     => 'root',
@@ -43,7 +43,7 @@ describe 'apt::conf', :type => :define do
       "/etc/apt/apt.conf.d/00norecommends"
     end
 
-    it { should contain_file(filename).with({
+    it { is_expected.to contain_file(filename).with({
         'ensure'    => 'absent',
         'content'   => /Apt::Install-Recommends 0;\nApt::AutoRemove::InstallRecommends 1;/,
         'owner'     => 'root',

--- a/spec/defines/key_spec.rb
+++ b/spec/defines/key_spec.rb
@@ -11,7 +11,7 @@ describe 'apt::key', :type => :define do
   describe 'normal operation' do
     describe 'default options' do
       it 'contains the apt_key' do
-        should contain_apt_key(title).with({
+        is_expected.to contain_apt_key(title).with({
           :id                => title,
           :ensure            => 'present',
           :source            => nil,
@@ -21,7 +21,7 @@ describe 'apt::key', :type => :define do
         })
       end
       it 'contains the apt_key present anchor' do
-        should contain_anchor("apt_key #{title} present")
+        is_expected.to contain_anchor("apt_key #{title} present")
       end
     end
 
@@ -35,7 +35,7 @@ describe 'apt::key', :type => :define do
       } end
 
       it 'contains the apt_key' do
-        should contain_apt_key(title).with({
+        is_expected.to contain_apt_key(title).with({
           :id                => GPG_KEY_ID,
           :ensure            => 'present',
           :source            => nil,
@@ -45,7 +45,7 @@ describe 'apt::key', :type => :define do
         })
       end
       it 'contains the apt_key present anchor' do
-        should contain_anchor("apt_key #{GPG_KEY_ID} present")
+        is_expected.to contain_anchor("apt_key #{GPG_KEY_ID} present")
       end
     end
 
@@ -55,7 +55,7 @@ describe 'apt::key', :type => :define do
       } end
 
       it 'contains the apt_key' do
-        should contain_apt_key(title).with({
+        is_expected.to contain_apt_key(title).with({
           :id                => title,
           :ensure            => 'absent',
           :source            => nil,
@@ -65,7 +65,7 @@ describe 'apt::key', :type => :define do
         })
       end
       it 'contains the apt_key absent anchor' do
-        should contain_anchor("apt_key #{title} absent")
+        is_expected.to contain_anchor("apt_key #{title} absent")
       end
     end
 
@@ -78,7 +78,7 @@ describe 'apt::key', :type => :define do
       } end
 
       it 'contains the apt_key' do
-        should contain_apt_key(title).with({
+        is_expected.to contain_apt_key(title).with({
           :id                => title,
           :ensure            => 'present',
           :source            => 'http://apt.puppetlabs.com/pubkey.gpg',
@@ -88,7 +88,7 @@ describe 'apt::key', :type => :define do
         })
       end
       it 'contains the apt_key present anchor' do
-        should contain_anchor("apt_key #{title} present")
+        is_expected.to contain_anchor("apt_key #{title} present")
       end
     end
 
@@ -97,7 +97,7 @@ describe 'apt::key', :type => :define do
         :key_server => 'p-gp.m-it.edu',
       } end
       it 'contains the apt_key' do
-        should contain_apt_key(title).with({
+        is_expected.to contain_apt_key(title).with({
           :id        => title,
           :server => 'p-gp.m-it.edu',
         })
@@ -111,7 +111,7 @@ describe 'apt::key', :type => :define do
         }
       end
       it 'contains the apt_key' do
-        should contain_apt_key(title).with({
+        is_expected.to contain_apt_key(title).with({
           :id        => title,
           :server => 'hkp://pgp.mit.edu',
         })
@@ -124,7 +124,7 @@ describe 'apt::key', :type => :define do
         }
       end
       it 'contains the apt_key' do
-        should contain_apt_key(title).with({
+        is_expected.to contain_apt_key(title).with({
           :id        => title,
           :server => 'hkp://pgp.mit.edu:80',
         })
@@ -280,18 +280,18 @@ describe 'apt::key', :type => :define do
         end
 
         it 'contains two apt::key resources' do
-          should contain_apt__key('duplicate').with({
+          is_expected.to contain_apt__key('duplicate').with({
             :key    => title,
             :ensure => 'present',
           })
-          should contain_apt__key(title).with({
+          is_expected.to contain_apt__key(title).with({
             :key    => title,
             :ensure => 'present',
           })
         end
 
         it 'contains only a single apt_key' do
-          should contain_apt_key('duplicate').with({
+          is_expected.to contain_apt_key('duplicate').with({
             :id                => title,
             :ensure            => 'present',
             :source            => nil,
@@ -299,7 +299,7 @@ describe 'apt::key', :type => :define do
             :content           => nil,
             :keyserver_options => nil,
           })
-          should_not contain_apt_key(title)
+          is_expected.not_to contain_apt_key(title)
         end
       end
 

--- a/spec/defines/pin_spec.rb
+++ b/spec/defines/pin_spec.rb
@@ -105,7 +105,7 @@ describe 'apt::pin', :type => :define do
       end
       it do
         expect {
-          should compile
+          is_expected.to compile
         }.to raise_error(Puppet::Error, /Only integers are allowed/)
       end
     end
@@ -118,7 +118,7 @@ describe 'apt::pin', :type => :define do
       end
       it do
         expect {
-          should compile
+          is_expected.to compile
         }.to raise_error(Puppet::Error, /parameter version cannot be used in general form/)
       end
     end
@@ -132,7 +132,7 @@ describe 'apt::pin', :type => :define do
       end
       it do
         expect {
-          should compile
+          is_expected.to compile
         }.to raise_error(Puppet::Error, /parameters release and origin are mutually exclusive/)
       end
     end
@@ -147,7 +147,7 @@ describe 'apt::pin', :type => :define do
       end
       it do
         expect {
-          should compile
+          is_expected.to compile
         }.to raise_error(Puppet::Error, /parameters release, origin, and version are mutually exclusive/)
       end
     end
@@ -162,7 +162,7 @@ describe 'apt::pin', :type => :define do
       end
       it do
         expect {
-          should compile
+          is_expected.to compile
         }.to raise_error(Puppet::Error, /parameters release, origin, and version are mutually exclusive/)
       end
     end

--- a/spec/defines/ppa_spec.rb
+++ b/spec/defines/ppa_spec.rb
@@ -96,7 +96,7 @@ describe 'apt::ppa', :type => :define do
       let(:title) { 'ppa:foo' }
       it do
         expect {
-          should compile
+          is_expected.to compile
         }.to raise_error(Puppet::Error, /lsbdistcodename fact not available: release parameter required/)
       end
     end
@@ -114,7 +114,7 @@ describe 'apt::ppa', :type => :define do
       let(:title) { 'ppa:foo' }
       it do
         expect {
-          should compile
+          is_expected.to compile
         }.to raise_error(Puppet::Error, /apt::ppa is currently supported on Ubuntu only./)
       end
     end

--- a/spec/defines/setting_spec.rb
+++ b/spec/defines/setting_spec.rb
@@ -10,36 +10,36 @@ describe 'apt::setting' do
   describe 'when using the defaults' do
     context 'without setting_type' do
       it do
-        expect { should compile }.to raise_error(Puppet::Error, /Must pass setting_type /)
+        expect { is_expected.to compile }.to raise_error(Puppet::Error, /Must pass setting_type /)
       end
     end
 
     context 'without source or content' do
       let(:params) { { :setting_type => 'conf' } }
       it do
-        expect { should compile }.to raise_error(Puppet::Error, /needs either of /)
+        expect { is_expected.to compile }.to raise_error(Puppet::Error, /needs either of /)
       end
     end
 
     context 'with setting_type=conf' do
       let(:params) { default_params }
-      it { should contain_file('/etc/apt/apt.conf.d/50teddybear') }
+      it { is_expected.to contain_file('/etc/apt/apt.conf.d/50teddybear') }
     end
 
     context 'with setting_type=pref' do
       let(:params) { { :setting_type => 'pref', :content => 'di' } }
-      it { should contain_file('/etc/apt/preferences.d/50teddybear') }
+      it { is_expected.to contain_file('/etc/apt/preferences.d/50teddybear') }
     end
 
     context 'with setting_type=list' do
       let(:params) { { :setting_type => 'list', :content => 'di' } }
-      it { should contain_file('/etc/apt/sources.list.d/teddybear.list') }
+      it { is_expected.to contain_file('/etc/apt/sources.list.d/teddybear.list') }
     end
 
     context 'with source' do
       let(:params) { { :setting_type => 'conf', :source => 'puppet:///la/die/dah' } }
       it {
-        should contain_file('/etc/apt/apt.conf.d/50teddybear').with({
+        is_expected.to contain_file('/etc/apt/apt.conf.d/50teddybear').with({
         :ensure => 'file',
         :owner  => 'root',
         :group  => 'root',
@@ -50,7 +50,7 @@ describe 'apt::setting' do
 
     context 'with content' do
       let(:params) { default_params }
-      it { should contain_file('/etc/apt/apt.conf.d/50teddybear').with({
+      it { is_expected.to contain_file('/etc/apt/apt.conf.d/50teddybear').with({
         :ensure  => 'file',
         :owner   => 'root',
         :group   => 'root',
@@ -64,40 +64,40 @@ describe 'apt::setting' do
     context 'with source and content' do
       let(:params) { default_params.merge({ :source => 'la' }) }
       it do
-        expect { should compile }.to raise_error(Puppet::Error, /cannot have both /)
+        expect { is_expected.to compile }.to raise_error(Puppet::Error, /cannot have both /)
       end
     end
 
     context 'with setting_type=ext' do
       let(:params) { default_params.merge({ :setting_type => 'ext' }) }
       it do
-        expect { should compile }.to raise_error(Puppet::Error, /"ext" does not /)
+        expect { is_expected.to compile }.to raise_error(Puppet::Error, /"ext" does not /)
       end
     end
 
     context 'with ensure=banana' do
       let(:params) { default_params.merge({ :ensure => 'banana' }) }
       it do
-        expect { should compile }.to raise_error(Puppet::Error, /"banana" does not /)
+        expect { is_expected.to compile }.to raise_error(Puppet::Error, /"banana" does not /)
       end
     end
 
     context 'with priority=1.2' do
       let(:params) { default_params.merge({ :priority => 1.2 }) }
       it do
-        expect { should compile }.to raise_error(Puppet::Error, /be an integer /)
+        expect { is_expected.to compile }.to raise_error(Puppet::Error, /be an integer /)
       end
     end
   end
 
   describe 'with priority=100' do
     let(:params) { default_params.merge({ :priority => 100 }) }
-    it { should contain_file('/etc/apt/apt.conf.d/100teddybear') }
+    it { is_expected.to contain_file('/etc/apt/apt.conf.d/100teddybear') }
   end
 
   describe 'with ensure=absent' do
     let(:params) { default_params.merge({ :ensure => 'absent' }) }
-    it { should contain_file('/etc/apt/apt.conf.d/50teddybear').with({
+    it { is_expected.to contain_file('/etc/apt/apt.conf.d/50teddybear').with({
       :ensure => 'absent',
     })}
   end
@@ -105,7 +105,7 @@ describe 'apt::setting' do
   describe 'with file_perms' do
     context "{'owner' => 'roosevelt'}" do
       let(:params) { default_params.merge({ :file_perms => {'owner' => 'roosevelt'} }) }
-      it { should contain_file('/etc/apt/apt.conf.d/50teddybear').with({
+      it { is_expected.to contain_file('/etc/apt/apt.conf.d/50teddybear').with({
         :owner => 'roosevelt',
         :group => 'root',
         :mode  => '0644',
@@ -114,7 +114,7 @@ describe 'apt::setting' do
 
     context "'group' => 'roosevelt'}" do
       let(:params) { default_params.merge({ :file_perms => {'group' => 'roosevelt'} }) }
-      it { should contain_file('/etc/apt/apt.conf.d/50teddybear').with({
+      it { is_expected.to contain_file('/etc/apt/apt.conf.d/50teddybear').with({
         :owner => 'root',
         :group => 'roosevelt',
         :mode  => '0644',
@@ -123,7 +123,7 @@ describe 'apt::setting' do
 
     context "'owner' => 'roosevelt'}" do
       let(:params) { default_params.merge({ :file_perms => {'mode' => '0600'} }) }
-      it { should contain_file('/etc/apt/apt.conf.d/50teddybear').with({
+      it { is_expected.to contain_file('/etc/apt/apt.conf.d/50teddybear').with({
         :owner => 'root',
         :group => 'root',
         :mode  => '0600',

--- a/spec/defines/source_spec.rb
+++ b/spec/defines/source_spec.rb
@@ -154,7 +154,7 @@ describe 'apt::source', :type => :define do
 
       it do
         expect {
-          should compile
+          is_expected.to compile
         }.to raise_error(Puppet::Error, /lsbdistcodename fact not available: release parameter required/)
       end
     end

--- a/spec/unit/facter/apt_has_updates_spec.rb
+++ b/spec/unit/facter/apt_has_updates_spec.rb
@@ -8,7 +8,7 @@ describe 'apt_has_updates fact' do
     before {
       Facter.fact(:osfamily).expects(:value).at_least(1).returns 'RedHat'
     }
-    it { should be_nil }
+    it { is_expected.to be_nil }
   end
 
   describe 'on Debian based distro missing update-notifier-common' do
@@ -17,7 +17,7 @@ describe 'apt_has_updates fact' do
       File.stubs(:executable?) # Stub all other calls
       File.expects(:executable?).with('/usr/lib/update-notifier/apt-check').returns false
     }
-    it { should be_nil }
+    it { is_expected.to be_nil }
   end
 
   describe 'on Debian based distro with broken packages' do
@@ -28,7 +28,7 @@ describe 'apt_has_updates fact' do
       File.expects(:executable?).with('/usr/lib/update-notifier/apt-check').returns true
       Facter::Util::Resolution.expects(:exec).with('/usr/lib/update-notifier/apt-check 2>&1').returns "E: Error: BrokenCount > 0"
     }
-    it { should be_nil }
+    it { is_expected.to be_nil }
   end
 
   describe 'on Debian based distro with unknown error with semicolons' do
@@ -39,7 +39,7 @@ describe 'apt_has_updates fact' do
       File.expects(:executable?).with('/usr/lib/update-notifier/apt-check').returns true
       Facter::Util::Resolution.expects(:exec).with('/usr/lib/update-notifier/apt-check 2>&1').returns "E: Unknown Error: 'This error contains something that could be parsed like 4;3' (10)"
     }
-    it { should be_nil }
+    it { is_expected.to be_nil }
   end
 
   describe 'on Debian based distro' do
@@ -50,7 +50,7 @@ describe 'apt_has_updates fact' do
       File.expects(:executable?).with('/usr/lib/update-notifier/apt-check').returns true
       Facter::Util::Resolution.expects(:exec).with('/usr/lib/update-notifier/apt-check 2>&1').returns "4;3"
     }
-    it { should be true }
+    it { is_expected.to be true }
   end
 end
 

--- a/spec/unit/facter/apt_package_updates_spec.rb
+++ b/spec/unit/facter/apt_package_updates_spec.rb
@@ -8,7 +8,7 @@ describe 'apt_package_updates fact' do
     before { 
       Facter.fact(:apt_has_updates).stubs(:value).returns false
     }
-    it { should be nil }
+    it { is_expected.to be nil }
   end
 
   describe 'when apt has updates' do
@@ -22,9 +22,9 @@ describe 'apt_package_updates fact' do
     }
     it {
       if Facter.version < '2.0.0'
-        should == 'puppet-common,linux-generic,linux-image-generic'
+        is_expected.to eq('puppet-common,linux-generic,linux-image-generic')
       else
-        should == ['puppet-common', 'linux-generic', 'linux-image-generic']
+        is_expected.to eq(['puppet-common', 'linux-generic', 'linux-image-generic'])
       end
     }
   end

--- a/spec/unit/facter/apt_security_updates_spec.rb
+++ b/spec/unit/facter/apt_security_updates_spec.rb
@@ -8,7 +8,7 @@ describe 'apt_security_updates fact' do
     before { 
       Facter.fact(:apt_has_updates).stubs(:value).returns false
     }
-    it { should be nil }
+    it { is_expected.to be nil }
   end
 
   describe 'when apt has security updates' do
@@ -19,7 +19,7 @@ describe 'apt_security_updates fact' do
       File.expects(:executable?).with('/usr/lib/update-notifier/apt-check').returns true
       Facter::Util::Resolution.expects(:exec).with('/usr/lib/update-notifier/apt-check 2>&1').returns "14;7"
     }
-    it { should == 7 }
+    it { is_expected.to eq(7) }
   end
 
 end

--- a/spec/unit/facter/apt_update_last_success_spec.rb
+++ b/spec/unit/facter/apt_update_last_success_spec.rb
@@ -10,7 +10,7 @@ describe 'apt_update_last_success fact' do
       File.stubs(:exists?).returns false
     }
     it 'should have a value of -1' do
-      should == -1
+      is_expected.to eq(-1)
     end
   end
 
@@ -21,7 +21,7 @@ describe 'apt_update_last_success fact' do
       File.stubs(:mtime).returns 1407660561
     }
     it 'should have the value of the mtime of the file' do
-      should == 1407660561
+      is_expected.to eq(1407660561)
     end
   end
 

--- a/spec/unit/facter/apt_updates_spec.rb
+++ b/spec/unit/facter/apt_updates_spec.rb
@@ -8,7 +8,7 @@ describe 'apt_updates fact' do
     before { 
       Facter.fact(:apt_has_updates).stubs(:value).returns false
     }
-    it { should be nil }
+    it { is_expected.to be nil }
   end
 
   describe 'when apt has updates' do
@@ -19,7 +19,7 @@ describe 'apt_updates fact' do
       File.expects(:executable?).with('/usr/lib/update-notifier/apt-check').returns true
       Facter::Util::Resolution.expects(:exec).with('/usr/lib/update-notifier/apt-check 2>&1').returns "14;7"
     }
-    it { should == 14 }
+    it { is_expected.to eq(14) }
   end
 
 end

--- a/spec/unit/puppet/type/apt_key_spec.rb
+++ b/spec/unit/puppet/type/apt_key_spec.rb
@@ -7,23 +7,23 @@ describe Puppet::Type::type(:apt_key) do
       :id => '4BD6EC30'
     )}
     it 'id is set' do
-      resource[:id].should eq '4BD6EC30'
+      expect(resource[:id]).to eq '4BD6EC30'
     end
 
     it 'name is set to id' do
-      resource[:name].should eq '4BD6EC30'
+      expect(resource[:name]).to eq '4BD6EC30'
     end
 
     it 'keyserver is default' do
-      resource[:server].should eq :'keyserver.ubuntu.com'
+      expect(resource[:server]).to eq :'keyserver.ubuntu.com'
     end
 
     it 'source is not set' do
-      resource[:source].should eq nil
+      expect(resource[:source]).to eq nil
     end
 
     it 'content is not set' do
-      resource[:content].should eq nil
+      expect(resource[:content]).to eq nil
     end
   end
 
@@ -32,7 +32,7 @@ describe Puppet::Type::type(:apt_key) do
       :id => '4bd6ec30'
     )}
     it 'id is set' do
-      resource[:id].should eq '4BD6EC30'
+      expect(resource[:id]).to eq '4BD6EC30'
     end
   end
 
@@ -41,7 +41,7 @@ describe Puppet::Type::type(:apt_key) do
       :id => 'FFFFFFFF4BD6EC30'
     )}
     it 'id is set' do
-      resource[:id].should eq 'FFFFFFFF4BD6EC30'
+      expect(resource[:id]).to eq 'FFFFFFFF4BD6EC30'
     end
   end
 
@@ -50,7 +50,7 @@ describe Puppet::Type::type(:apt_key) do
       :id => '0x4BD6EC30'
     )}
     it 'id is set' do
-      resource[:id].should eq '4BD6EC30'
+      expect(resource[:id]).to eq '4BD6EC30'
     end
   end
 
@@ -59,7 +59,7 @@ describe Puppet::Type::type(:apt_key) do
       :id => '0x4bd6ec30'
     )}
     it 'id is set' do
-      resource[:id].should eq '4BD6EC30'
+      expect(resource[:id]).to eq '4BD6EC30'
     end
   end
 
@@ -68,7 +68,7 @@ describe Puppet::Type::type(:apt_key) do
       :id => '0xFFFFFFFF4BD6EC30'
     )}
     it 'id is set' do
-      resource[:id].should eq 'FFFFFFFF4BD6EC30'
+      expect(resource[:id]).to eq 'FFFFFFFF4BD6EC30'
     end
   end
 
@@ -79,7 +79,7 @@ describe Puppet::Type::type(:apt_key) do
     )}
 
     it 'source is set to the URL' do
-      resource[:source].should eq 'http://apt.puppetlabs.com/pubkey.gpg'
+      expect(resource[:source]).to eq 'http://apt.puppetlabs.com/pubkey.gpg'
     end
   end
 
@@ -90,7 +90,7 @@ describe Puppet::Type::type(:apt_key) do
     )}
 
     it 'content is set to the string' do
-      resource[:content].should eq 'http://apt.puppetlabs.com/pubkey.gpg'
+      expect(resource[:content]).to eq 'http://apt.puppetlabs.com/pubkey.gpg'
     end
   end
 
@@ -101,7 +101,7 @@ describe Puppet::Type::type(:apt_key) do
     )}
 
     it 'keyserver is set to Debian' do
-      resource[:server].should eq 'http://keyring.debian.org'
+      expect(resource[:server]).to eq 'http://keyring.debian.org'
     end
   end
 


### PR DESCRIPTION
This conversion is done by Transpec 3.0.8 with the following command:
    transpec spec/classes spec/defines spec/unit

* 87 conversions
    from: it { should ... }
      to: it { is_expected.to ... }

* 14 conversions
    from: obj.should
      to: expect(obj).to

* 7 conversions
    from: == expected
      to: eq(expected)

* 1 conversion
    from: it { should_not ... }
      to: it { is_expected.not_to ... }

For more details: https://github.com/yujinakayama/transpec#supported-conversions