### PR TITLE
Convert to use apt::setting instead of file resource

### DIFF
--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -1,14 +1,13 @@
 define apt::conf (
   $content,
   $ensure   = present,
-  $priority = '50'
+  $priority = '50',
 ) {
-
-  file { "${apt::conf_d}/${priority}${name}":
-    ensure  => $ensure,
-    content => template('apt/_header.erb', 'apt/conf.erb'),
-    owner   => root,
-    group   => root,
-    mode    => '0644',
+  apt::setting { "conf-${name}":
+    ensure       => $ensure,
+    base_name    => $name,
+    setting_type => 'conf',
+    priority     => $priority,
+    content      => template('apt/_header.erb', 'apt/conf.erb'),
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -30,12 +30,11 @@ class apt(
     }
   }
 
-  file { '/etc/apt/apt.conf.d/15update-stamp':
-    ensure  => 'file',
-    content => template('apt/_header.erb', 'apt/15update-stamp.erb'),
-    group   => 'root',
-    mode    => '0644',
-    owner   => 'root',
+  apt::setting { 'conf-update-stamp':
+    base_name    => 'update-stamp',
+    setting_type => 'conf',
+    priority     => 15,
+    content      => template('apt/_header.erb', 'apt/15update-stamp.erb'),
   }
 
   file { 'sources.list':

--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -23,8 +23,9 @@ define apt::source(
     fail('lsbdistcodename fact not available: release parameter required')
   }
 
-  apt::setting { $name:
+  apt::setting { "list-${name}":
     ensure       => $ensure,
+    base_name    => $name,
     setting_type => 'list',
     content      => template('apt/_header.erb', 'apt/source.list.erb'),
     notify       => Exec['apt_update'],
@@ -38,7 +39,7 @@ define apt::source(
     apt::pin { $name:
       ensure   => $ensure,
       priority => $pin,
-      before   => Apt::Setting[$name],
+      before   => Apt::Setting["list-${name}"],
       origin   => $host,
     }
   }
@@ -51,7 +52,7 @@ define apt::source(
       key_server  => $key_server,
       key_content => $key_content,
       key_source  => $key_source,
-      before      => Apt::Setting[$name],
+      before      => Apt::Setting["list-${name}"],
     }
   }
 

--- a/spec/classes/apt_spec.rb
+++ b/spec/classes/apt_spec.rb
@@ -110,7 +110,7 @@ describe 'apt', :type => :class do
     } } }
 
     it {
-      is_expected.to contain_apt__setting('debian_unstable').with({
+      is_expected.to contain_apt__setting('list-debian_unstable').with({
         'ensure'  => 'present',
         'notify'  => 'Exec[apt_update]',
       })
@@ -120,7 +120,7 @@ describe 'apt', :type => :class do
     it { is_expected.to contain_file('/etc/apt/sources.list.d/debian_unstable.list').with_content(/^deb-src http:\/\/debian.mirror.iweb.ca\/debian\/ unstable main contrib non-free$/) }
 
     it {
-      is_expected.to contain_apt__setting('puppetlabs').with({
+      is_expected.to contain_apt__setting('list-puppetlabs').with({
         'ensure'  => 'present',
         'notify'  => 'Exec[apt_update]',
       })

--- a/spec/defines/pin_spec.rb
+++ b/spec/defines/pin_spec.rb
@@ -7,13 +7,10 @@ describe 'apt::pin', :type => :define do
   let(:title) { 'my_pin' }
 
   context 'defaults' do
-    it { is_expected.to contain_file("my_pin.pref").with_content(/Explanation: : my_pin\nPackage: \*\nPin: release a=my_pin\nPin-Priority: 0\n/)}
-    it { is_expected.to contain_file("my_pin.pref").with({
-      'ensure' => 'present',
-      'path'   => '/etc/apt/preferences.d/my_pin.pref',
-      'owner'  => 'root',
-      'group'  => 'root',
-      'mode'   => '0644',
+    it { is_expected.to contain_apt__setting("pref-my_pin").with_content(/Explanation: : my_pin\nPackage: \*\nPin: release a=my_pin\nPin-Priority: 0\n/)}
+    it { is_expected.to contain_apt__setting("pref-my_pin").with({
+      'setting_type' => 'pref',
+      'base_name'    => 'my_pin',
     })
     }
   end
@@ -25,13 +22,10 @@ describe 'apt::pin', :type => :define do
         'version'  => '1',
       }
     end
-    it { is_expected.to contain_file("my_pin.pref").with_content(/Explanation: : my_pin\nPackage: vim\nPin: version 1\nPin-Priority: 0\n/)}
-    it { is_expected.to contain_file("my_pin.pref").with({
-      'ensure' => 'present',
-      'path'   => '/etc/apt/preferences.d/my_pin.pref',
-      'owner'  => 'root',
-      'group'  => 'root',
-      'mode'   => '0644',
+    it { is_expected.to contain_apt__setting("pref-my_pin").with_content(/Explanation: : my_pin\nPackage: vim\nPin: version 1\nPin-Priority: 0\n/)}
+    it { is_expected.to contain_apt__setting("pref-my_pin").with({
+      'setting_type' => 'pref',
+      'base_name'    => 'my_pin',
     })
     }
   end
@@ -43,13 +37,10 @@ describe 'apt::pin', :type => :define do
         'origin'   => 'test',
       }
     end
-    it { is_expected.to contain_file("my_pin.pref").with_content(/Explanation: : my_pin\nPackage: vim\nPin: origin test\nPin-Priority: 0\n/)}
-    it { is_expected.to contain_file("my_pin.pref").with({
-      'ensure' => 'present',
-      'path'   => '/etc/apt/preferences.d/my_pin.pref',
-      'owner'  => 'root',
-      'group'  => 'root',
-      'mode'   => '0644',
+    it { is_expected.to contain_apt__setting("pref-my_pin").with_content(/Explanation: : my_pin\nPackage: vim\nPin: origin test\nPin-Priority: 0\n/)}
+    it { is_expected.to contain_apt__setting("pref-my_pin").with({
+      'setting_type' => 'pref',
+      'base_name'    => 'my_pin',
     })
     }
   end
@@ -68,13 +59,11 @@ describe 'apt::pin', :type => :define do
         'priority'        => 10,
       }
     end
-    it { is_expected.to contain_file("my_pin.pref").with_content(/Explanation: foo\nPackage: \*\nPin: release a=1, n=bar, v=2, c=baz, o=foobar, l=foobaz\nPin-Priority: 10\n/) }
-    it { is_expected.to contain_file("my_pin.pref").with({
-      'ensure' => 'present',
-      'path'   => '/etc/apt/preferences.d/99-my_pin.pref',
-      'owner'  => 'root',
-      'group'  => 'root',
-      'mode'   => '0644',
+    it { is_expected.to contain_apt__setting("pref-my_pin").with_content(/Explanation: foo\nPackage: \*\nPin: release a=1, n=bar, v=2, c=baz, o=foobar, l=foobaz\nPin-Priority: 10\n/) }
+    it { is_expected.to contain_apt__setting("pref-my_pin").with({
+      'setting_type' => 'pref',
+      'base_name'    => 'my_pin',
+      'priority'     => 99,
     })
     }
   end
@@ -85,7 +74,7 @@ describe 'apt::pin', :type => :define do
         'ensure' => 'absent'
       }
     end
-    it { is_expected.to contain_file("my_pin.pref").with({
+    it { is_expected.to contain_apt__setting("pref-my_pin").with({
       'ensure' => 'absent',
     })
     }
@@ -93,7 +82,7 @@ describe 'apt::pin', :type => :define do
 
   context 'bad characters' do
     let(:title) { 'such  bad && wow!' }
-    it { is_expected.to contain_file("such__bad____wow_.pref") }
+    it { is_expected.to contain_apt__setting("pref-such__bad____wow_") }
   end
 
   describe 'validation' do

--- a/spec/defines/source_spec.rb
+++ b/spec/defines/source_spec.rb
@@ -27,7 +27,7 @@ describe 'apt::source', :type => :define do
       }
     end
 
-    it { is_expected.to contain_apt__setting('my_source').that_notifies('Exec[apt_update]').with({
+    it { is_expected.to contain_apt__setting('list-my_source').that_notifies('Exec[apt_update]').with({
       'ensure' => 'present',
     }).with_content(/# my_source\ndeb-src  wheezy main\n/)
     }
@@ -58,19 +58,19 @@ describe 'apt::source', :type => :define do
       }
     end
 
-    it { is_expected.to contain_apt__setting('my_source').that_notifies('Exec[apt_update]').with({
+    it { is_expected.to contain_apt__setting('list-my_source').that_notifies('Exec[apt_update]').with({
       'ensure' => 'present',
     }).with_content(/# foo\ndeb \[arch=x86_64 trusted=yes\] http:\/\/debian\.mirror\.iweb\.ca\/debian\/ sid testing\n/).without_content(/deb-src/)
     }
 
-    it { is_expected.to contain_apt__pin('my_source').that_comes_before('Apt::Setting[my_source]').with({
+    it { is_expected.to contain_apt__pin('my_source').that_comes_before('Apt::Setting[list-my_source]').with({
       'ensure'   => 'present',
       'priority' => '10',
       'origin'   => 'debian.mirror.iweb.ca',
     })
     }
 
-    it { is_expected.to contain_apt__key("Add key: #{GPG_KEY_ID} from Apt::Source my_source").that_comes_before('Apt::Setting[my_source]').with({
+    it { is_expected.to contain_apt__key("Add key: #{GPG_KEY_ID} from Apt::Source my_source").that_comes_before('Apt::Setting[list-my_source]').with({
       'ensure' => 'present',
         'key'  => GPG_KEY_ID,
         'key_server' => 'pgp.mit.edu',
@@ -95,7 +95,7 @@ describe 'apt::source', :type => :define do
       }
     end
 
-    it { is_expected.to contain_apt__setting('my_source').that_notifies('Exec[apt_update]').with({
+    it { is_expected.to contain_apt__setting('list-my_source').that_notifies('Exec[apt_update]').with({
       'ensure' => 'present',
     }).with_content(/# my_source\ndeb \[trusted=yes\]  wheezy main\n/)
     }
@@ -117,7 +117,7 @@ describe 'apt::source', :type => :define do
       }
     end
 
-    it { is_expected.to contain_apt__setting('my_source').that_notifies('Exec[apt_update]').with({
+    it { is_expected.to contain_apt__setting('list-my_source').that_notifies('Exec[apt_update]').with({
       'ensure' => 'present',
     }).with_content(/# my_source\ndeb-src \[arch=x86_64 \]  wheezy main\n/)
     }
@@ -137,7 +137,7 @@ describe 'apt::source', :type => :define do
       }
     end
 
-    it { is_expected.to contain_apt__setting('my_source').that_notifies('Exec[apt_update]').with({
+    it { is_expected.to contain_apt__setting('list-my_source').that_notifies('Exec[apt_update]').with({
       'ensure' => 'absent'
     })
     }


### PR DESCRIPTION
Working on this revealed an issue in apt::setting where we're very prone to duplicate resources. This won't work until that issue is resolved.