### PR TITLE
Add base_name parameter to apt::setting

### DIFF
--- a/manifests/setting.pp
+++ b/manifests/setting.pp
@@ -1,5 +1,6 @@
 define apt::setting (
   $setting_type,
+  $base_name  = $title,
   $priority   = 50,
   $ensure     = file,
   $source     = undef,
@@ -19,6 +20,7 @@ define apt::setting (
 
   validate_re($setting_type, ['conf', 'pref', 'list'])
   validate_re($ensure,  ['file', 'present', 'absent'])
+  validate_string($base_name)
 
   unless is_integer($priority) {
     fail('apt::setting priority must be an integer')
@@ -41,7 +43,7 @@ define apt::setting (
   $_path = $::apt::config_files[$setting_type]['path']
   $_ext  = $::apt::config_files[$setting_type]['ext']
 
-  file { "${_path}/${_priority}${title}${_ext}":
+  file { "${_path}/${_priority}${base_name}${_ext}":
     ensure  => $ensure,
     owner   => $_file['owner'],
     group   => $_file['group'],

--- a/spec/defines/setting_spec.rb
+++ b/spec/defines/setting_spec.rb
@@ -95,6 +95,18 @@ describe 'apt::setting' do
     it { should contain_file('/etc/apt/apt.conf.d/100teddybear') }
   end
 
+  describe 'with base_name=puppy' do
+    let(:params) { default_params.merge({ :base_name => 'puppy' }) }
+    it { should contain_file('/etc/apt/apt.conf.d/50puppy') }
+  end
+
+  describe 'with base_name=true' do
+    let(:params) { default_params.merge({ :base_name => true }) }
+      it do
+        expect { should compile }.to raise_error(Puppet::Error, /not a string/)
+      end
+  end
+
   describe 'with ensure=absent' do
     let(:params) { default_params.merge({ :ensure => 'absent' }) }
     it { should contain_file('/etc/apt/apt.conf.d/50teddybear').with({


### PR DESCRIPTION
This allows you to work around duplicate resource issues when you have
settings of different types with the same name. When the files are built
it is path/${priority}${base_name}${extension}.