### PR TITLE
Make apt::setting notify Exec['apt_update'] by default

### DIFF
--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -26,7 +26,6 @@ define apt::source(
   apt::setting { "list-${name}":
     ensure  => $ensure,
     content => template('apt/_header.erb', 'apt/source.list.erb'),
-    notify  => Exec['apt_update'],
   }
 
   if ($pin != false) {
@@ -52,10 +51,5 @@ define apt::source(
       key_source  => $key_source,
       before      => Apt::Setting["list-${name}"],
     }
-  }
-
-  # Need anchor to provide containment for dependencies.
-  anchor { "apt::source::${name}":
-    require => Class['apt::update'],
   }
 }

--- a/spec/classes/apt_spec.rb
+++ b/spec/classes/apt_spec.rb
@@ -112,7 +112,6 @@ describe 'apt', :type => :class do
     it {
       is_expected.to contain_apt__setting('list-debian_unstable').with({
         'ensure'  => 'present',
-        'notify'  => 'Exec[apt_update]',
       })
     }
 
@@ -122,7 +121,6 @@ describe 'apt', :type => :class do
     it {
       is_expected.to contain_apt__setting('list-puppetlabs').with({
         'ensure'  => 'present',
-        'notify'  => 'Exec[apt_update]',
       })
     }
 

--- a/spec/defines/setting_spec.rb
+++ b/spec/defines/setting_spec.rb
@@ -16,25 +16,25 @@ describe 'apt::setting' do
 
     context 'with title=conf-teddybear ' do
       let(:params) { default_params }
-      it { is_expected.to contain_file('/etc/apt/apt.conf.d/50teddybear') }
+      it { is_expected.to contain_file('/etc/apt/apt.conf.d/50teddybear').that_notifies('Exec[apt_update]') }
     end
 
     context 'with title=pref-teddybear' do
       let(:title) { 'pref-teddybear' }
       let(:params) { default_params }
-      it { is_expected.to contain_file('/etc/apt/preferences.d/50teddybear') }
+      it { is_expected.to contain_file('/etc/apt/preferences.d/50teddybear').that_notifies('Exec[apt_update]') }
     end
 
     context 'with title=list-teddybear' do
       let(:title) { 'list-teddybear' }
       let(:params) { default_params }
-      it { is_expected.to contain_file('/etc/apt/sources.list.d/teddybear.list') }
+      it { is_expected.to contain_file('/etc/apt/sources.list.d/teddybear.list').that_notifies('Exec[apt_update]') }
     end
 
     context 'with source' do
       let(:params) { { :source => 'puppet:///la/die/dah' } }
       it {
-        is_expected.to contain_file('/etc/apt/apt.conf.d/50teddybear').with({
+        is_expected.to contain_file('/etc/apt/apt.conf.d/50teddybear').that_notifies('Exec[apt_update]').with({
         :ensure => 'file',
         :owner  => 'root',
         :group  => 'root',
@@ -45,7 +45,7 @@ describe 'apt::setting' do
 
     context 'with content' do
       let(:params) { default_params }
-      it { is_expected.to contain_file('/etc/apt/apt.conf.d/50teddybear').with({
+      it { is_expected.to contain_file('/etc/apt/apt.conf.d/50teddybear').that_notifies('Exec[apt_update]').with({
         :ensure  => 'file',
         :owner   => 'root',
         :group   => 'root',
@@ -88,12 +88,12 @@ describe 'apt::setting' do
 
   describe 'with priority=100' do
     let(:params) { default_params.merge({ :priority => 100 }) }
-    it { is_expected.to contain_file('/etc/apt/apt.conf.d/100teddybear') }
+    it { is_expected.to contain_file('/etc/apt/apt.conf.d/100teddybear').that_notifies('Exec[apt_update]') }
   end
 
   describe 'with ensure=absent' do
     let(:params) { default_params.merge({ :ensure => 'absent' }) }
-    it { is_expected.to contain_file('/etc/apt/apt.conf.d/50teddybear').with({
+    it { is_expected.to contain_file('/etc/apt/apt.conf.d/50teddybear').that_notifies('Exec[apt_update]').with({
       :ensure => 'absent',
     })}
   end
@@ -101,7 +101,7 @@ describe 'apt::setting' do
   describe 'with file_perms' do
     context "{'owner' => 'roosevelt'}" do
       let(:params) { default_params.merge({ :file_perms => {'owner' => 'roosevelt'} }) }
-      it { is_expected.to contain_file('/etc/apt/apt.conf.d/50teddybear').with({
+      it { is_expected.to contain_file('/etc/apt/apt.conf.d/50teddybear').that_notifies('Exec[apt_update]').with({
         :owner => 'roosevelt',
         :group => 'root',
         :mode  => '0644',
@@ -110,7 +110,7 @@ describe 'apt::setting' do
 
     context "'group' => 'roosevelt'}" do
       let(:params) { default_params.merge({ :file_perms => {'group' => 'roosevelt'} }) }
-      it { is_expected.to contain_file('/etc/apt/apt.conf.d/50teddybear').with({
+      it { is_expected.to contain_file('/etc/apt/apt.conf.d/50teddybear').that_notifies('Exec[apt_update]').with({
         :owner => 'root',
         :group => 'roosevelt',
         :mode  => '0644',
@@ -119,11 +119,18 @@ describe 'apt::setting' do
 
     context "'owner' => 'roosevelt'}" do
       let(:params) { default_params.merge({ :file_perms => {'mode' => '0600'} }) }
-      it { is_expected.to contain_file('/etc/apt/apt.conf.d/50teddybear').with({
+      it { is_expected.to contain_file('/etc/apt/apt.conf.d/50teddybear').that_notifies('Exec[apt_update]').with({
         :owner => 'root',
         :group => 'root',
         :mode  => '0600',
       })}
     end
+
+    context "'notify_update' => false}" do
+      let(:params) { default_params.merge({ :notify_update => false }) }
+      it { is_expected.to contain_file('/etc/apt/apt.conf.d/50teddybear') }
+      it { is_expected.not_to contain_file('/etc/apt/apt.conf.d/50teddybear').that_notifies('Exec[apt_update]') }
+    end
+
   end
 end

--- a/spec/defines/source_spec.rb
+++ b/spec/defines/source_spec.rb
@@ -27,7 +27,7 @@ describe 'apt::source', :type => :define do
       }
     end
 
-    it { is_expected.to contain_apt__setting('list-my_source').that_notifies('Exec[apt_update]').with({
+    it { is_expected.to contain_apt__setting('list-my_source').with({
       'ensure' => 'present',
     }).with_content(/# my_source\ndeb-src  wheezy main\n/)
     }
@@ -58,7 +58,7 @@ describe 'apt::source', :type => :define do
       }
     end
 
-    it { is_expected.to contain_apt__setting('list-my_source').that_notifies('Exec[apt_update]').with({
+    it { is_expected.to contain_apt__setting('list-my_source').with({
       'ensure' => 'present',
     }).with_content(/# foo\ndeb \[arch=x86_64 trusted=yes\] http:\/\/debian\.mirror\.iweb\.ca\/debian\/ sid testing\n/).without_content(/deb-src/)
     }
@@ -95,7 +95,7 @@ describe 'apt::source', :type => :define do
       }
     end
 
-    it { is_expected.to contain_apt__setting('list-my_source').that_notifies('Exec[apt_update]').with({
+    it { is_expected.to contain_apt__setting('list-my_source').with({
       'ensure' => 'present',
     }).with_content(/# my_source\ndeb \[trusted=yes\]  wheezy main\n/)
     }
@@ -117,7 +117,7 @@ describe 'apt::source', :type => :define do
       }
     end
 
-    it { is_expected.to contain_apt__setting('list-my_source').that_notifies('Exec[apt_update]').with({
+    it { is_expected.to contain_apt__setting('list-my_source').with({
       'ensure' => 'present',
     }).with_content(/# my_source\ndeb-src \[arch=x86_64 \]  wheezy main\n/)
     }
@@ -137,7 +137,7 @@ describe 'apt::source', :type => :define do
       }
     end
 
-    it { is_expected.to contain_apt__setting('list-my_source').that_notifies('Exec[apt_update]').with({
+    it { is_expected.to contain_apt__setting('list-my_source').with({
       'ensure' => 'absent'
     })
     }


### PR DESCRIPTION
Can be disabled by setting `notify_update => false`