### PR TITLE
apt::setting: Remove file_perms.

### DIFF
--- a/manifests/setting.pp
+++ b/manifests/setting.pp
@@ -3,11 +3,8 @@ define apt::setting (
   $ensure        = file,
   $source        = undef,
   $content       = undef,
-  $file_perms    = {},
   $notify_update = true,
 ) {
-
-  $_file = merge($::apt::file_defaults, $file_perms)
 
   if $content and $source {
     fail('apt::setting cannot have both content and source')
@@ -56,9 +53,9 @@ define apt::setting (
 
   file { "${_path}/${_priority}${base_name}${_ext}":
     ensure  => $ensure,
-    owner   => $_file['owner'],
-    group   => $_file['group'],
-    mode    => $_file['mode'],
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
     content => $content,
     source  => $source,
     notify  => $_notify,

--- a/spec/defines/setting_spec.rb
+++ b/spec/defines/setting_spec.rb
@@ -97,40 +97,4 @@ describe 'apt::setting' do
       :ensure => 'absent',
     })}
   end
-
-  describe 'with file_perms' do
-    context "{'owner' => 'roosevelt'}" do
-      let(:params) { default_params.merge({ :file_perms => {'owner' => 'roosevelt'} }) }
-      it { is_expected.to contain_file('/etc/apt/apt.conf.d/50teddybear').that_notifies('Exec[apt_update]').with({
-        :owner => 'roosevelt',
-        :group => 'root',
-        :mode  => '0644',
-      })}
-    end
-
-    context "'group' => 'roosevelt'}" do
-      let(:params) { default_params.merge({ :file_perms => {'group' => 'roosevelt'} }) }
-      it { is_expected.to contain_file('/etc/apt/apt.conf.d/50teddybear').that_notifies('Exec[apt_update]').with({
-        :owner => 'root',
-        :group => 'roosevelt',
-        :mode  => '0644',
-      })}
-    end
-
-    context "'owner' => 'roosevelt'}" do
-      let(:params) { default_params.merge({ :file_perms => {'mode' => '0600'} }) }
-      it { is_expected.to contain_file('/etc/apt/apt.conf.d/50teddybear').that_notifies('Exec[apt_update]').with({
-        :owner => 'root',
-        :group => 'root',
-        :mode  => '0600',
-      })}
-    end
-
-    context "'notify_update' => false}" do
-      let(:params) { default_params.merge({ :notify_update => false }) }
-      it { is_expected.to contain_file('/etc/apt/apt.conf.d/50teddybear') }
-      it { is_expected.not_to contain_file('/etc/apt/apt.conf.d/50teddybear').that_notifies('Exec[apt_update]') }
-    end
-
-  end
 end


### PR DESCRIPTION
This was a great idea but is pretty pointless. It's also not being used by anything and not exposed as a switch on the main class so it would almost never affect any behaviour.