### PR TITLE
apt::source: Merge `include_*` options into hash.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -87,6 +87,11 @@ class apt::params {
     'source'  => undef,
   }
 
+  $include_defaults = {
+    'deb' => true,
+    'src' => false,
+  }
+
   case $xfacts['lsbdistid'] {
     'ubuntu', 'debian': {
       $distid = $xfacts['lsbdistid']

--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -6,21 +6,22 @@ define apt::source(
   $location       = '',
   $release        = $::apt::xfacts['lsbdistcodename'],
   $repos          = 'main',
-  $include_src    = false,
-  $include_deb    = true,
+  $include        = {},
   $key            = undef,
   $pin            = false,
   $architecture   = undef,
   $trusted_source = false,
 ) {
   validate_string($architecture, $comment, $location, $repos)
-  validate_bool($trusted_source, $include_src, $include_deb)
+  validate_bool($trusted_source)
+  validate_hash($include)
 
   unless $release {
     fail('lsbdistcodename fact not available: release parameter required')
   }
 
   $_before = Apt::Setting["list-${title}"]
+  $_include = merge($::apt::include_defaults, $include)
 
   if $key {
     if is_hash($key) {

--- a/spec/classes/apt_spec.rb
+++ b/spec/classes/apt_spec.rb
@@ -142,7 +142,7 @@ describe 'apt' do
         'repos'             => 'main contrib non-free',
         'key'               => { 'id' => '55BE302B', 'server' => 'subkeys.pgp.net' },
         'pin'               => '-10',
-        'include_src'       => true,
+        'include'           => {'src' => true,},
       },
       'puppetlabs' => {
         'location'   => 'http://apt.puppetlabs.com',

--- a/spec/defines/source_spec.rb
+++ b/spec/defines/source_spec.rb
@@ -11,7 +11,7 @@ describe 'apt::source' do
     'my_source'
   end
 
-  context 'mostly defaults' do
+  context 'defaults' do
     let :facts do
       {
         :lsbdistid       => 'Debian',
@@ -20,17 +20,9 @@ describe 'apt::source' do
       }
     end
 
-    let :params do
-      {
-        :include_deb => false,
-        :include_src => true,
-      }
-    end
-
     it { is_expected.to contain_apt__setting('list-my_source').with({
-      :ensure => 'present',
-    }).with_content(/# my_source\ndeb-src  wheezy main\n/)
-
+      :ensure  => 'present',
+    }).without_content(/# my_source\ndeb-src  wheezy main\n/)
     }
   end
 
@@ -49,7 +41,6 @@ describe 'apt::source' do
           :location          => 'http://debian.mirror.iweb.ca/debian/',
           :release           => 'sid',
           :repos             => 'testing',
-          :include_src       => false,
           :key               => GPG_KEY_ID,
           :pin               => '10',
           :architecture      => 'x86_64',
@@ -83,7 +74,6 @@ describe 'apt::source' do
           :location          => 'http://debian.mirror.iweb.ca/debian/',
           :release           => 'sid',
           :repos             => 'testing',
-          :include_src       => false,
           :key               => { 'id' => GPG_KEY_ID, 'server' => 'pgp.mit.edu',
                                   'content' => 'GPG key content',
                                   'source'  => 'http://apt.puppetlabs.com/pubkey.gpg',},
@@ -122,7 +112,6 @@ describe 'apt::source' do
           :location       => 'http://debian.mirror.iweb.ca/debian/',
           :release        => 'sid',
           :repos          => 'testing',
-          :include_src    => false,
           :key            => GPG_KEY_ID,
           :pin            => '10',
           :architecture   => 'x86_64',
@@ -160,7 +149,6 @@ describe 'apt::source' do
     end
     let :params do
       {
-        :include_src    => false,
         :trusted_source => true,
       }
     end
@@ -181,8 +169,7 @@ describe 'apt::source' do
     end
     let :params do
       {
-        :include_deb  => false,
-        :include_src  => true,
+        :include      => {'deb' => false, 'src' => true,},
         :architecture => 'x86_64',
       }
     end

--- a/templates/source.list.erb
+++ b/templates/source.list.erb
@@ -1,10 +1,10 @@
 # <%= @comment %>
-<%- if @include_deb then -%>
+<%- if @_include['deb'] then -%>
 deb <%- if @architecture or @trusted_source -%>
 [<%- if @architecture %>arch=<%= @architecture %> <% end %><% if @trusted_source %>trusted=yes<% end -%>
 ] <%- end %><%= @location %> <%= @release %> <%= @repos %>
 <%- end -%>
-<%- if @include_src then -%>
+<%- if @_include['src'] then -%>
 deb-src <%- if @architecture or @trusted_source -%>
 [<%- if @architecture %>arch=<%= @architecture %> <% end %><% if @trusted_source %>trusted=yes<% end -%>
 ] <%- end %><%= @location %> <%= @release %> <%= @repos %>


### PR DESCRIPTION
This makes its behaviour similar to the `update`, `proxy` and `purge` hashes on the main classes bringing its API more in line with the rest of the module.