### PR TITLE
apt::source: Rename `trusted_source`.

### DIFF
--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -10,10 +10,10 @@ define apt::source(
   $key            = undef,
   $pin            = false,
   $architecture   = undef,
-  $trusted_source = false,
+  $allow_unsigned = false,
 ) {
   validate_string($architecture, $comment, $location, $repos)
-  validate_bool($trusted_source)
+  validate_bool($allow_unsigned)
   validate_hash($include)
 
   unless $release {

--- a/spec/defines/source_spec.rb
+++ b/spec/defines/source_spec.rb
@@ -44,7 +44,7 @@ describe 'apt::source' do
           :key               => GPG_KEY_ID,
           :pin               => '10',
           :architecture      => 'x86_64',
-          :trusted_source    => true,
+          :allow_unsigned    => true,
         }
       end
 
@@ -79,7 +79,7 @@ describe 'apt::source' do
                                   'source'  => 'http://apt.puppetlabs.com/pubkey.gpg',},
           :pin               => '10',
           :architecture      => 'x86_64',
-          :trusted_source    => true,
+          :allow_unsigned    => true,
         }
       end
 
@@ -115,7 +115,7 @@ describe 'apt::source' do
           :key            => GPG_KEY_ID,
           :pin            => '10',
           :architecture   => 'x86_64',
-          :trusted_source => true,
+          :allow_unsigned => true,
         }
       end
 
@@ -139,7 +139,7 @@ describe 'apt::source' do
     end
   end
 
-  context 'trusted_source true' do
+  context 'allow_unsigned true' do
     let :facts do
       {
         :lsbdistid       => 'Debian',
@@ -149,7 +149,7 @@ describe 'apt::source' do
     end
     let :params do
       {
-        :trusted_source => true,
+        :allow_unsigned => true,
       }
     end
 

--- a/templates/source.list.erb
+++ b/templates/source.list.erb
@@ -1,11 +1,11 @@
 # <%= @comment %>
 <%- if @_include['deb'] then -%>
-deb <%- if @architecture or @trusted_source -%>
-[<%- if @architecture %>arch=<%= @architecture %> <% end %><% if @trusted_source %>trusted=yes<% end -%>
+deb <%- if @architecture or @allow_unsigned -%>
+[<%- if @architecture %>arch=<%= @architecture %> <% end %><% if @allow_unsigned %>trusted=yes<% end -%>
 ] <%- end %><%= @location %> <%= @release %> <%= @repos %>
 <%- end -%>
 <%- if @_include['src'] then -%>
-deb-src <%- if @architecture or @trusted_source -%>
-[<%- if @architecture %>arch=<%= @architecture %> <% end %><% if @trusted_source %>trusted=yes<% end -%>
+deb-src <%- if @architecture or @allow_unsigned -%>
+[<%- if @architecture %>arch=<%= @architecture %> <% end %><% if @allow_unsigned %>trusted=yes<% end -%>
 ] <%- end %><%= @location %> <%= @release %> <%= @repos %>
 <%- end -%>


### PR DESCRIPTION
It is weird that `trusted_source` would default to `false` as that would
imply that we normally don't trust our sources. This is opposite to the
truth, by default we trust them but only if the Releases file can be
verified (meaning it is signed by a GPG key known to apt).

What we were telling apt is that it should trust this source even if the
Releases file and the repository is unsigned. This is better captured
with `allow_unsigned` and better highlights the danger of what you're
doing, installing packages from a source we cannot authenticate.