### PR TITLE
MODULES-1827 adding Cumulus Linux detection

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -25,6 +25,10 @@ class apt::params {
         }
       }
     }
+    'Cumulus Networks': {
+      $distid = 'debian'
+      $distcodename = $::lsbdistcodename
+    }
     '': {
       fail('Unable to determine lsbdistid, is lsb-release installed?')
     }


### PR DESCRIPTION
the apt module did not correctly detect Cumulus Linux with lsbdistid.
This change adds several lines in params.pp to detect Cumulus Linux and
set $distid and $distcodename
