### PR TITLE
Add possibility to define apt config files within hiera.

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,17 @@ class { 'apt':
     
 * `apt::conf`: Specifies a custom configuration file. The priority defaults to 50, but you can set the priority parameter to load the file earlier or later. The content parameter passes specified content, if any, into the file resource.
 
+#### Hiera example
+
+```
+<pre>
+apt::configs:
+  'no_proxy':
+    content: 'Acquire::http::Proxy { apt.puppetlabs.com DIRECT; };'
+    priority: 05
+</pre>
+```
+
 * `apt::hold`: Holds a specific version of a package. You can hold a package to a full version or a partial version.
 
   To set a package's ensure attribute to 'latest' but get the version specified by `apt::hold`:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -54,6 +54,7 @@
 class apt(
   $always_apt_update    = false,
   $apt_update_frequency = 'reluctantly',
+  $configs              = undef,
   $disable_keys         = undef,
   $proxy_host           = undef,
   $proxy_port           = '8080',
@@ -213,4 +214,11 @@ class apt(
     validate_hash($sources)
     create_resources('apt::source', $sources)
   }
+
+  # manage configs if present
+  if $configs != undef {
+    validate_hash($configs)
+    create_resources('apt::conf', $configs)
+  }
+
 }


### PR DESCRIPTION
I don't know why this isn't in the code yet but I find it very pleasent if every aspect of a module can be managed via hiera (i think this is also the goal of puppetlabs). Therefore and because I just needed this I added the feature for apt::conf.