### PR TITLE
Inheritance of apt::params means it can't be private

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,9 +1,5 @@
 class apt::params {
 
-  if defined('$caller_module_name') and $caller_module_name and $caller_module_name != $module_name {
-    fail('apt::params is a private class and cannot be accessed directly')
-  }
-
   if $::osfamily != 'Debian' {
     fail('This module only works on Debian or derivatives like Ubuntu')
   }


### PR DESCRIPTION
Otherwise, if another module has `class { 'apt': }` in it everything
fails, as `$caller_module_name` will be the other module name.