### PR TITLE
Make installation of software-properties optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,14 @@ apt::sources:
 
 It is recommended to read the manpage 'apt_preferences(5)'
 
+####apt::ppa
+
+* `ensure`: Whether we are adding or removing the PPA. Can be 'present' or 'absent'. Defaults to 'present'.
+* `release`: The codename for the operating system you're running. Defaults to `$lsbdistcodename`. Required if lsb-release is not installed.
+* `options`: Options to be passed to the `apt-add-repository` command. OS-dependent defaults are set in `apt::params`.
+* `package_name`: The package that provides the `apt-add-repository` command. OS-dependent defaults are set in `apt::params`.
+* `package_manage`: Whether or not to manage the package providing `apt-add-repository`. Defaults to true.
+
 ### Testing
 
 The apt module is mostly a collection of defined resource types, which provide reusable logic for managing Apt. It provides smoke tests for testing functionality on a target system, as well as spec tests for checking a compiled catalog against an expected set of resources.

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -64,18 +64,28 @@ class apt::params {
         'lucid': {
           $backports_location = 'http://us.archive.ubuntu.com/ubuntu'
           $ppa_options        = undef
+          $ppa_package        = 'python-software-properties'
           $legacy_origin      = true
           $origins            = ['${distro_id} ${distro_codename}-security'] #lint:ignore:single_quote_string_with_variables
         }
-        'precise', 'trusty', 'utopic', 'vivid': {
+        'precise': {
           $backports_location = 'http://us.archive.ubuntu.com/ubuntu'
           $ppa_options        = '-y'
+          $ppa_package        = 'python-software-properties'
+          $legacy_origin      = true
+          $origins            = ['${distro_id}:${distro_codename}-security'] #lint:ignore:single_quote_string_with_variables
+        }
+        'trusty', 'utopic', 'vivid': {
+          $backports_location = 'http://us.archive.ubuntu.com/ubuntu'
+          $ppa_options        = '-y'
+          $ppa_package        = 'software-properties-common'
           $legacy_origin      = true
           $origins            = ['${distro_id}:${distro_codename}-security'] #lint:ignore:single_quote_string_with_variables
         }
         default: {
           $backports_location = 'http://old-releases.ubuntu.com/ubuntu'
           $ppa_options        = '-y'
+          $ppa_package        = 'python-software-properties'
           $legacy_origin      = true
           $origins            = ['${distro_id}:${distro_codename}-security'] #lint:ignore:single_quote_string_with_variables
         }

--- a/manifests/ppa.pp
+++ b/manifests/ppa.pp
@@ -1,9 +1,11 @@
 # ppa.pp
 
 define apt::ppa(
-  $ensure  = 'present',
-  $release = $::lsbdistcodename,
-  $options = $apt::params::ppa_options,
+  $ensure         = 'present',
+  $release        = $::lsbdistcodename,
+  $options        = $::apt::params::ppa_options,
+  $package_name   = $::apt::params::ppa_package,
+  $package_manage = true,
 ) {
   include apt::params
   include apt::update
@@ -24,52 +26,48 @@ define apt::ppa(
   $sources_list_d_filename  = "${filename_without_ppa}-${release}.list"
 
   if $ensure == 'present' {
-    $package = $::lsbdistrelease ? {
-        /^[1-9]\..*|1[01]\..*|12.04$/ => 'python-software-properties',
-        default  => 'software-properties-common',
-    }
+    if $package_manage {
+      if ! defined(Package[$package_name]) {
+        package { $package_name: }
+      }
 
-    if ! defined(Package[$package]) {
-        package { $package: }
-    }
-
-    if defined(Class[apt]) {
-        $proxy_host = $apt::proxy_host
-        $proxy_port = $apt::proxy_port
-        case $proxy_host {
-          false, '', undef: {
-            $proxy_env = []
-          }
-          default: {
-            $proxy_env = ["http_proxy=http://${proxy_host}:${proxy_port}", "https_proxy=http://${proxy_host}:${proxy_port}"]
-          }
-        }
+      $_require = [File['sources.list.d'], Package[$package_name]]
     } else {
-        $proxy_env = []
+      $_require = File['sources.list.d']
     }
+
+    if defined(Class['apt']) {
+      case $::apt::proxy_host {
+        false, '', undef: {
+          $proxy_env = []
+        }
+        default: {
+          $proxy_env = ["http_proxy=http://${::apt::proxy_host}:${::apt::proxy_port}", "https_proxy=http://${::apt::proxy_host}:${::apt::proxy_port}"]
+        }
+      }
+    } else {
+      $proxy_env = []
+    }
+
     exec { "add-apt-repository-${name}":
-        environment => $proxy_env,
-        command     => "/usr/bin/add-apt-repository ${options} ${name}",
-        unless      => "/usr/bin/test -s ${sources_list_d}/${sources_list_d_filename}",
-        user        => 'root',
-        logoutput   => 'on_failure',
-        notify      => Exec['apt_update'],
-        require     => [
-        File['sources.list.d'],
-        Package[$package],
-        ],
+      environment => $proxy_env,
+      command     => "/usr/bin/add-apt-repository ${options} ${name}",
+      unless      => "/usr/bin/test -s ${sources_list_d}/${sources_list_d_filename}",
+      user        => 'root',
+      logoutput   => 'on_failure',
+      notify      => Exec['apt_update'],
+      require     => $_require,
     }
 
     file { "${sources_list_d}/${sources_list_d_filename}":
-        ensure  => file,
-        require => Exec["add-apt-repository-${name}"],
+      ensure  => file,
+      require => Exec["add-apt-repository-${name}"],
     }
   }
   else {
-
     file { "${sources_list_d}/${sources_list_d_filename}":
-        ensure => 'absent',
-        notify => Exec['apt_update'],
+      ensure => 'absent',
+      notify => Exec['apt_update'],
     }
   }
 

--- a/spec/defines/ppa_spec.rb
+++ b/spec/defines/ppa_spec.rb
@@ -32,6 +32,78 @@ describe 'apt::ppa', :type => :define do
     }
   end
 
+  describe 'package_name => software-properties-common' do
+    let :pre_condition do
+      'class { "apt": }'
+    end
+    let :params do
+      {
+        :package_name => 'software-properties-common'
+      }
+    end
+    let :facts do
+      {
+        :lsbdistrelease  => '11.04',
+        :lsbdistcodename => 'natty',
+        :operatingsystem => 'Ubuntu',
+        :osfamily        => 'Debian',
+        :lsbdistid       => 'Ubuntu',
+      }
+    end
+
+    let(:title) { 'ppa:needs/such.substitution/wow' }
+    it { is_expected.to contain_package('software-properties-common') }
+    it { is_expected.to contain_exec('add-apt-repository-ppa:needs/such.substitution/wow').that_notifies('Exec[apt_update]').with({
+      'environment' => [],
+      'command'     => '/usr/bin/add-apt-repository -y ppa:needs/such.substitution/wow',
+      'unless'      => '/usr/bin/test -s /etc/apt/sources.list.d/needs-such_substitution-wow-natty.list',
+      'user'        => 'root',
+      'logoutput'   => 'on_failure',
+    })
+    }
+
+    it { is_expected.to contain_file('/etc/apt/sources.list.d/needs-such_substitution-wow-natty.list').that_requires('Exec[add-apt-repository-ppa:needs/such.substitution/wow]').with({
+      'ensure' => 'file',
+    })
+    }
+  end
+
+  describe 'package_manage => false' do
+    let :pre_condition do
+      'class { "apt": }'
+    end
+    let :facts do
+      {
+        :lsbdistrelease  => '11.04',
+        :lsbdistcodename => 'natty',
+        :operatingsystem => 'Ubuntu',
+        :osfamily        => 'Debian',
+        :lsbdistid       => 'Ubuntu',
+      }
+    end
+    let :params do
+      {
+        :package_manage => false,
+      }
+    end
+
+    let(:title) { 'ppa:needs/such.substitution/wow' }
+    it { is_expected.to_not contain_package('python-software-properties') }
+    it { is_expected.to contain_exec('add-apt-repository-ppa:needs/such.substitution/wow').that_notifies('Exec[apt_update]').with({
+      'environment' => [],
+      'command'     => '/usr/bin/add-apt-repository -y ppa:needs/such.substitution/wow',
+      'unless'      => '/usr/bin/test -s /etc/apt/sources.list.d/needs-such_substitution-wow-natty.list',
+      'user'        => 'root',
+      'logoutput'   => 'on_failure',
+    })
+    }
+
+    it { is_expected.to contain_file('/etc/apt/sources.list.d/needs-such_substitution-wow-natty.list').that_requires('Exec[add-apt-repository-ppa:needs/such.substitution/wow]').with({
+      'ensure' => 'file',
+    })
+    }
+  end
+
   describe 'apt included, no proxy' do
     let :pre_condition do
       'class { "apt": }'


### PR DESCRIPTION
This is cherry-picked from the PPA cleanup happening for the 2.0.0 release.

Conflicts:
	manifests/params.pp
	manifests/ppa.pp