### PR TITLE
Allow changing legacy_origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ apt::sources:
 
 ####apt::unattended_upgrades
 
+* `legacy_origin`: If set to true, use the old `Unattended-Upgrade::Allowed-Origins` variable. If false, use `Unattended-Upgrade::Origins-Pattern`. OS-dependent defaults are defined in `apt::params`.
 * `origins`: The repositories from which to automatically upgrade included packages.
 * `blacklist`: A list of packages to **not** automatically upgrade.
 * `update`: How often, in days, to run `apt-get update`.

--- a/README.md
+++ b/README.md
@@ -74,12 +74,13 @@ class { 'apt':
 
   ```
   class { 'apt::unattended_upgrades':
-    origins     => $::apt::params::origins,
-    blacklist   => [],
-    update      => '1',
-    download    => '1',
-    upgrade     => '1',
-    autoclean   => '7',
+    legacy_origin => $::apt::params::legacy_origin,
+    origins       => $::apt::params::origins,
+    blacklist     => [],
+    update        => '1',
+    download      => '1',
+    upgrade       => '1',
+    autoclean     => '7',
   }
   ```
   

--- a/manifests/unattended_upgrades.pp
+++ b/manifests/unattended_upgrades.pp
@@ -14,6 +14,7 @@
 # file and in /etc/cron.daily/apt
 #
 class apt::unattended_upgrades (
+  $legacy_origin       = $::apt::params::legacy_origin,
   $origins             = $::apt::params::origins,
   $blacklist           = [],
   $update              = '1',
@@ -40,6 +41,7 @@ class apt::unattended_upgrades (
 ) inherits ::apt::params {
 
   validate_bool(
+    $legacy_origin,
     $auto_fix,
     $minimal_steps,
     $install_on_shutdown,

--- a/spec/classes/unattended_upgrades_spec.rb
+++ b/spec/classes/unattended_upgrades_spec.rb
@@ -155,6 +155,7 @@ describe 'apt::unattended_upgrades', :type => :class do
 
     let :params do
       {
+        'legacy_origin'       => true,
         'enable'              => '0',
         'backup_interval'     => '3',
         'backup_level'        => '1',
@@ -181,7 +182,7 @@ describe 'apt::unattended_upgrades', :type => :class do
       }
     end
 
-    it { is_expected.to contain_file("/etc/apt/apt.conf.d/50unattended-upgrades").with_content %r{Unattended-Upgrade::Origins-Pattern \{\n\t"bananas";\n\};} }
+    it { is_expected.to contain_file("/etc/apt/apt.conf.d/50unattended-upgrades").with_content %r{Unattended-Upgrade::Allowed-Origins \{\n\t"bananas";\n\};} }
     it { is_expected.to contain_file("/etc/apt/apt.conf.d/50unattended-upgrades").with_content %r{Unattended-Upgrade::Package-Blacklist \{\n\t"foo";\n\t"bar";\n\};} }
     it { is_expected.to contain_file("/etc/apt/apt.conf.d/50unattended-upgrades").with_content %r{Unattended-Upgrade::AutoFixInterruptedDpkg "false";}}
     it { is_expected.to contain_file("/etc/apt/apt.conf.d/50unattended-upgrades").with_content %r{Unattended-Upgrade::MinimalSteps "true";}}


### PR DESCRIPTION
Sometimes you don't want to use the default from params.pp