### PR TITLE
apt_key: fix parsing invalid dates when using GnuPG 2.x

### DIFF
--- a/lib/puppet/provider/apt_key/apt_key.rb
+++ b/lib/puppet/provider/apt_key/apt_key.rb
@@ -142,11 +142,11 @@ Puppet::Type.type(:apt_key).provide(:apt_key) do
         extracted_key = execute(["#{command(:gpg)} --with-fingerprint --with-colons #{file.path} | awk -F: '/^fpr:/ { print $10 }'"], :failonfail => false)
         extracted_key = extracted_key.chomp
         if extracted_key != name
-          fail ("The id in your manifest #{resource[:name]} and the fingerprint from content/source do not match. Please check there is not an error in the id or check the content/source is legitimate.")
+          fail("The id in your manifest #{resource[:name]} and the fingerprint from content/source do not match. Please check there is not an error in the id or check the content/source is legitimate.")
         end
       else
-        warning ('/usr/bin/gpg cannot be found for verification of the id.')
-      end 
+        warning('/usr/bin/gpg cannot be found for verification of the id.')
+      end
     end
     file.path
   end

--- a/lib/puppet/provider/apt_key/apt_key.rb
+++ b/lib/puppet/provider/apt_key/apt_key.rb
@@ -1,4 +1,3 @@
-require 'date'
 require 'open-uri'
 require 'net/ftp'
 require 'tempfile'
@@ -19,7 +18,7 @@ Puppet::Type.type(:apt_key).provide(:apt_key) do
   commands   :gpg      => '/usr/bin/gpg'
 
   def self.instances
-    cli_args = ['adv','--list-keys', '--with-colons', '--fingerprint']
+    cli_args = ['adv','--list-keys', '--with-colons', '--fingerprint', '--fixed-list-mode']
 
     if RUBY_VERSION > '1.8.7'
       key_output = apt_key(cli_args).encode('UTF-8', 'binary', :invalid => :replace, :undef => :replace, :replace => '')
@@ -46,7 +45,7 @@ Puppet::Type.type(:apt_key).provide(:apt_key) do
       expired = false
 
       if line_hash[:key_expiry]
-        expired = Date.today > Date.parse(line_hash[:key_expiry])
+        expired = Time.now >= line_hash[:key_expiry]
       end
 
       new(
@@ -57,10 +56,10 @@ Puppet::Type.type(:apt_key).provide(:apt_key) do
         :long        => line_hash[:key_long],
         :ensure      => :present,
         :expired     => expired,
-        :expiry      => line_hash[:key_expiry],
+        :expiry      => line_hash[:key_expiry].nil? ? nil : line_hash[:key_expiry].strftime("%Y-%m-%d"),
         :size        => line_hash[:key_size],
         :type        => line_hash[:key_type],
-        :created     => line_hash[:key_created]
+        :created     => line_hash[:key_created].strftime("%Y-%m-%d")
       )
     end
     key_array.compact!
@@ -96,8 +95,8 @@ Puppet::Type.type(:apt_key).provide(:apt_key) do
       :key_short       => fingerprint[-8..-1], # last 8 characters of fingerprint
       :key_size        => pub_split[2],
       :key_type        => nil,
-      :key_created     => pub_split[5],
-      :key_expiry      => pub_split[6].empty? ? nil : pub_split[6],
+      :key_created     => Time.at(pub_split[5].to_i),
+      :key_expiry      => pub_split[6].empty? ? nil : Time.at(pub_split[6].to_i),
     }
 
     # set key type based on types defined in /usr/share/doc/gnupg/DETAILS.gz


### PR DESCRIPTION
If one should happen to have redirected `/usr/bin/gpg` to run GnuPG 2.x rather than the more usual GnuPG 1.x, the `apt_key` provider fails with the following error:

    Could not prefetch apt_key provider 'apt_key': invalid date

This is because the output of `--with-colons` defaults to using `fixed-list-mode` in 2.x but did not do so for 1.x. This new format gives much more information about keys and also uses timestamps in seconds from 1970-01-01 (UNIX epoch) rather than dates in the format `YYYY-MM-DD`.

It's likely that GnuPG 2.x will replace GnuPG 1.x as the default version of GnuPG in Debian fairly soon, so I think it will pay to be forward-compatible. I also know I'm not the only person to have made the switch already, though this is currently a manual process so this will be uncommon still.

This patch adds `--fixed-list-mode` when calling `apt-key`, and adjusts the code to parse the timestamps instead. This actually has several advantages:

* Works the same with GnuPG 1.x and 2.x.
* More accurate expiry time tracking, not just entire days.
* No need to `require 'date'` any longer.
* Will allow the provider to expose more key information in future.

Tested on:
* Debian Wheezy (Puppet 2.7.23, Ruby 1.8.7p358)
* Debian Jessie (Puppet 3.7.2, Ruby 2.1.5p273)

The second commit also sneaks in some unrelated whitespace fixes within the same file.