### PR TITLE
Fix gpg key checking warings after f588f26

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ class { 'apt':
     release           => 'unstable',
     repos             => 'main contrib non-free',
     required_packages => 'debian-keyring debian-archive-keyring',
-    key               => '8B48AD6246925553',
+    key               => 'A1BD8E9D78F7FE5C3E65D8AF8B48AD6246925553',
     key_server        => 'subkeys.pgp.net',
     pin               => '-10',
     include_src       => true,

--- a/manifests/backports.pp
+++ b/manifests/backports.pp
@@ -58,8 +58,8 @@ class apt::backports(
   }
 
   $key = $distid ? {
-    'debian' => '46925553',
-    'ubuntu' => '437D05B5',
+    'debian' => 'A1BD8E9D78F7FE5C3E65D8AF8B48AD6246925553',
+    'ubuntu' => '630239CC130E1A7FD81A27B140976EAF437D05B5',
   }
   $repos = $distid ? {
     'debian' => 'main contrib non-free',

--- a/manifests/debian/testing.pp
+++ b/manifests/debian/testing.pp
@@ -14,7 +14,7 @@ class apt::debian::testing {
     release           => 'testing',
     repos             => 'main contrib non-free',
     required_packages => 'debian-keyring debian-archive-keyring',
-    key               => '46925553',
+    key               => 'A1BD8E9D78F7FE5C3E65D8AF8B48AD6246925553',
     key_server        => 'subkeys.pgp.net',
     pin               => '-10',
   }

--- a/manifests/debian/unstable.pp
+++ b/manifests/debian/unstable.pp
@@ -14,7 +14,7 @@ class apt::debian::unstable {
     release           => 'unstable',
     repos             => 'main contrib non-free',
     required_packages => 'debian-keyring debian-archive-keyring',
-    key               => '46925553',
+    key               => 'A1BD8E9D78F7FE5C3E65D8AF8B48AD6246925553',
     key_server        => 'subkeys.pgp.net',
     pin               => '-10',
   }

--- a/spec/acceptance/apt_spec.rb
+++ b/spec/acceptance/apt_spec.rb
@@ -25,7 +25,7 @@ describe 'apt class' do
             'ensure'     => present,
             'location'   => 'http://apt.puppetlabs.com',
             'repos'      => 'main',
-            'key'        => '4BD6EC30',
+            'key'        => '47B320EB4C7C375AA9DAE1A01054B7A24BD6EC30',
             'key_server' => 'pgp.mit.edu',
           }
         },

--- a/spec/classes/apt_spec.rb
+++ b/spec/classes/apt_spec.rb
@@ -155,7 +155,7 @@ describe 'apt', :type => :class do
         'release'           => 'unstable',
         'repos'             => 'main contrib non-free',
         'required_packages' => 'debian-keyring debian-archive-keyring',
-        'key'               => '55BE302B',
+        'key'               => '150C8614919D8446E01E83AF9AA38DCD55BE302B',
         'key_server'        => 'subkeys.pgp.net',
         'pin'               => '-10',
         'include_src'       => true
@@ -163,7 +163,7 @@ describe 'apt', :type => :class do
       'puppetlabs' => {
         'location'   => 'http://apt.puppetlabs.com',
         'repos'      => 'main',
-        'key'        => '4BD6EC30',
+        'key'        => '47B320EB4C7C375AA9DAE1A01054B7A24BD6EC30',
         'key_server' => 'pgp.mit.edu',
       }
     } } }

--- a/spec/classes/backports_spec.rb
+++ b/spec/classes/backports_spec.rb
@@ -17,7 +17,7 @@ describe 'apt::backports', :type => :class do
           'location'   => 'http://old-releases.ubuntu.com/ubuntu',
           'release'    => 'karmic-backports',
           'repos'      => 'main universe multiverse restricted',
-          'key'        => '437D05B5',
+          'key'        => '630239CC130E1A7FD81A27B140976EAF437D05B5',
           'key_server' => 'pgp.mit.edu',
         })
       }
@@ -51,7 +51,7 @@ describe 'apt::backports', :type => :class do
         'location'   => 'http://old-releases.ubuntu.com/ubuntu',
         'release'    => 'karmic-backports',
         'repos'      => 'main universe multiverse restricted',
-        'key'        => '437D05B5',
+        'key'        => '630239CC130E1A7FD81A27B140976EAF437D05B5',
         'key_server' => 'pgp.mit.edu',
       })
     }
@@ -77,7 +77,7 @@ describe 'apt::backports', :type => :class do
         'location'   => 'http://backports.debian.org/debian-backports',
         'release'    => 'squeeze-backports',
         'repos'      => 'main contrib non-free',
-        'key'        => '46925553',
+        'key'        => 'A1BD8E9D78F7FE5C3E65D8AF8B48AD6246925553',
         'key_server' => 'pgp.mit.edu',
       })
     }
@@ -103,7 +103,7 @@ describe 'apt::backports', :type => :class do
         'location'   => 'http://ftp.debian.org/debian/',
         'release'    => 'wheezy-backports',
         'repos'      => 'main contrib non-free',
-        'key'        => '46925553',
+        'key'        => 'A1BD8E9D78F7FE5C3E65D8AF8B48AD6246925553',
         'key_server' => 'pgp.mit.edu',
       })
     }
@@ -129,7 +129,7 @@ describe 'apt::backports', :type => :class do
         'location'   => 'http://us.archive.ubuntu.com/ubuntu',
         'release'    => 'trusty-backports',
         'repos'      => 'main universe multiverse restricted',
-        'key'        => '437D05B5',
+        'key'        => '630239CC130E1A7FD81A27B140976EAF437D05B5',
         'key_server' => 'pgp.mit.edu',
       })
     }
@@ -163,7 +163,7 @@ describe 'apt::backports', :type => :class do
         'location'   => location,
         'release'    => 'squeeze-backports',
         'repos'      => 'main contrib non-free',
-        'key'        => '46925553',
+        'key'        => 'A1BD8E9D78F7FE5C3E65D8AF8B48AD6246925553',
         'key_server' => 'pgp.mit.edu',
       })
     }

--- a/tests/source.pp
+++ b/tests/source.pp
@@ -15,7 +15,7 @@ apt::source { 'debian_testing':
   location   => 'http://debian.mirror.iweb.ca/debian/',
   release    => 'testing',
   repos      => 'main contrib non-free',
-  key        => '46925553',
+  key        => 'A1BD8E9D78F7FE5C3E65D8AF8B48AD6246925553',
   key_server => 'subkeys.pgp.net',
   pin        => '-10',
 }
@@ -23,7 +23,7 @@ apt::source { 'debian_unstable':
   location   => 'http://debian.mirror.iweb.ca/debian/',
   release    => 'unstable',
   repos      => 'main contrib non-free',
-  key        => '46925553',
+  key        => 'A1BD8E9D78F7FE5C3E65D8AF8B48AD6246925553',
   key_server => 'subkeys.pgp.net',
   pin        => '-10',
 }


### PR DESCRIPTION
Use the full fingerprint for all keys to silence the warning.