### PR TITLE
Apt key exists check

### DIFF
--- a/lib/puppet/provider/apt_key/apt_key.rb
+++ b/lib/puppet/provider/apt_key/apt_key.rb
@@ -137,7 +137,12 @@ Puppet::Type.type(:apt_key).provide(:apt_key) do
   end
 
   def exists?
-    @property_hash[:ensure] == :present
+    # check if an existing, unexpired key with the same id is present
+    if self.class.instances.one?{ |key| key.id == resource[:id] && ! key.expired }
+      true
+    else
+      @property_hash[:ensure] == :present
+    end
   end
 
   def create

--- a/lib/puppet/provider/apt_key/apt_key.rb
+++ b/lib/puppet/provider/apt_key/apt_key.rb
@@ -137,8 +137,9 @@ Puppet::Type.type(:apt_key).provide(:apt_key) do
   end
 
   def exists?
-    # check if an existing, unexpired key with the same id is present
-    if self.class.instances.one?{ |key| key.id == resource[:id] && ! key.expired }
+    # check if an existing, unexpired key with the same id is present; 
+    # we check for the last 8 characters of :id to support long key ids
+    if self.class.instances.one?{ |key| key.id == resource[:id][8..-1] && ! key.expired }
       true
     else
       @property_hash[:ensure] == :present


### PR DESCRIPTION
see JIRA issue https://tickets.puppetlabs.com/browse/MODULES-1862

currently the apt_key provider assumes a resource exists if it is going to be installed, as the create method does the right thing.

With this change the exists call additionally checks, if a key with the requested id is already installed. This makes the resource more declarative, since it does not try to install it in all cases.

We encountered this issue to support local-running puppet on an offline machine with a source parameter on apt_key. This always attempted to download the source and failed subsequently.