### PR TITLE
(MODULES-1156, MODULES-769) Update anchors

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -133,10 +133,7 @@ class apt(
     notify  => Exec['apt_update'],
   }
 
-  # Need anchor to provide containment for dependencies.
-  anchor { 'apt::update':
-    require => Class['apt::update'],
-  }
+  contain 'apt::update'
 
   # manage sources if present
   if $sources {

--- a/manifests/ppa.pp
+++ b/manifests/ppa.pp
@@ -60,9 +60,4 @@ define apt::ppa(
       notify => Exec['apt_update'],
     }
   }
-
-  # Need anchor to provide containment for dependencies.
-  anchor { "apt::ppa::${name}":
-    require => Class['apt::update'],
-  }
 }

--- a/manifests/setting.pp
+++ b/manifests/setting.pp
@@ -60,10 +60,4 @@ define apt::setting (
     source  => $source,
     notify  => $_notify,
   }
-
-  if $notify_update {
-    anchor { "apt::setting::${name}":
-      require => Class['apt::update']
-    }
-  }
 }

--- a/spec/defines/ppa_spec.rb
+++ b/spec/defines/ppa_spec.rb
@@ -27,9 +27,17 @@ describe 'apt::ppa' do
     }
   end
 
-  describe 'apt included, no proxy' do
+  describe 'ppa depending on ppa, MODULES-1156' do
     let :pre_condition do
       'class { "apt": }'
+    end
+  end
+
+  describe 'apt included, no proxy' do
+    let :pre_condition do
+      'class { "apt": }
+      apt::ppa { "ppa:foo2": }
+      '
     end
     let :facts do
       {
@@ -42,11 +50,13 @@ describe 'apt::ppa' do
     end
     let :params do
       {
-        :options => '',
+        :options        => '',
         :package_manage => true,
+        :require        => 'Apt::Ppa[ppa:foo2]',
       }
     end
     let(:title) { 'ppa:foo' }
+    it { is_expected.to compile.with_all_deps }
     it { is_expected.to contain_package('software-properties-common') }
     it { is_expected.to contain_exec('add-apt-repository-ppa:foo').that_notifies('Exec[apt_update]').with({
       :environment => [],

--- a/spec/defines/setting_spec.rb
+++ b/spec/defines/setting_spec.rb
@@ -55,6 +55,21 @@ describe 'apt::setting' do
     end
   end
 
+  describe 'settings requiring settings, MODULES-769' do
+    let(:pre_condition) do
+      'class { "apt": }
+      apt::setting { "list-teddybear": content => "foo" }
+      '
+    end
+    let(:facts) { { :lsbdistid => 'Debian', :osfamily => 'Debian', :lsbdistcodename => 'wheezy' } }
+    let(:title) { 'conf-teddybear' }
+    let(:default_params) { { :content => 'di' } }
+
+    let(:params) { default_params.merge({ :require => 'Apt::Setting[list-teddybear]' }) }
+
+    it { is_expected.to compile.with_all_deps }
+  end
+
   describe 'when trying to pull one over' do
     context 'with source and content' do
       let(:params) { default_params.merge({ :source => 'la' }) }


### PR DESCRIPTION
I think our anchors for `Class['apt::update']` were backwards since the code was all setting notifies, but we were using requires. This was leading to a bunch of dependency cycle issues.