### PR TITLE
Add parameters to deploy sources and pins in chroots

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,7 @@ apt::sources:
 * `component`: Names the licensing component associated with the packages in the directory tree of the Release file. defaults to ''. Typical values can be 'main', 'dependencies' and 'restricted'
 * `originator`: Names the originator of the packages in the directory tree of the Release file. Defaults to ''. Most commonly, this is Debian.
 * `label`: Names the label of the packages in the directory tree of the Release file. Defaults to ''. Most commonly, this is Debian.
+* `preferences_d`: Override the preferences.d directory path. Defaults to '/etc/apt/preferences.d'.
 
 **Note**: Parameters release, origin, and version are mutually exclusive.
 

--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ apt::sources:
 * `pin`: See apt::pin
 * `architecture`: can be used to specify for which architectures information should be downloaded. If this option is not set all architectures defined by the APT::Architectures option will be downloaded. Defaults to 'undef' which means all. Example values can be 'i386' or 'i386,alpha,powerpc'.
 * `trusted_source` can be set to indicate that packages from this source are always authenticated even if the Release file is not signed or the signature can't be checked. Defaults to false. Can be 'true' or 'false'.
+* `sources_list_d`: Override the sources.list.d directory path. Defaults to '/etc/apt/sources.list.d'.
 
 ####apt::key
 

--- a/manifests/pin.pp
+++ b/manifests/pin.pp
@@ -14,11 +14,15 @@ define apt::pin(
   $release_version = '', # v=
   $component       = '', # c=
   $originator      = '', # o=
-  $label           = ''  # l=
+  $label           = '', # l=
+  $preferences_d   = undef,
 ) {
   include apt::params
 
-  $preferences_d = $apt::params::preferences_d
+  $_preferences_d = $preferences_d ? {
+    undef   => $apt::params::preferences_d,
+    default => $preferences_d,
+  }
 
   if $order != '' and !is_integer($order) {
     fail('Only integers are allowed in the apt::pin order param')
@@ -67,8 +71,8 @@ define apt::pin(
   $file_name = regsubst($title, '[^0-9a-z\-_\.]', '_', 'IG')
 
   $path = $order ? {
-    ''      => "${preferences_d}/${file_name}.pref",
-    default => "${preferences_d}/${order}-${file_name}.pref",
+    ''      => "${_preferences_d}/${file_name}.pref",
+    default => "${_preferences_d}/${order}-${file_name}.pref",
   }
   file { "${file_name}.pref":
     ensure  => $ensure,

--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -17,6 +17,7 @@ define apt::source(
   $pin               = false,
   $architecture      = undef,
   $trusted_source    = false,
+  $sources_list_d    = undef,
 ) {
 
   include apt::params
@@ -25,7 +26,10 @@ define apt::source(
   validate_string($architecture)
   validate_bool($trusted_source)
 
-  $sources_list_d = $apt::params::sources_list_d
+  $_sources_list_d = $sources_list_d ? {
+    undef   => $apt::params::sources_list_d,
+    default => $sources_list_d,
+  }
   $provider       = $apt::params::provider
 
   if $release == 'UNDEF' {
@@ -40,7 +44,7 @@ define apt::source(
 
   file { "${name}.list":
     ensure  => $ensure,
-    path    => "${sources_list_d}/${name}.list",
+    path    => "${_sources_list_d}/${name}.list",
     owner   => root,
     group   => root,
     mode    => '0644',


### PR DESCRIPTION
This can be used to deploy preferences inside chrooted environments (e.g. build chroots).