### PR TITLE
(MODULES-1915) include apt do not add all sources defined with hiera

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -211,6 +211,10 @@ class apt(
   # manage sources if present
   if $sources != undef {
     validate_hash($sources)
-    create_resources('apt::source', $sources)
+    $full_hash_sources = hiera_hash('apt::source', $sources)
+    create_resources('apt::source', $full_hash_sources)
+  } else {
+    $full_hash_sources = hiera_hash('apt::source', {})
+    create_resources('apt::source', $full_hash_sources)
   }
 }


### PR DESCRIPTION
I can use hiera_hash() from my profile, but I'll see a duplicate definition error, because "include apt" will create the sources partially.
