### PR TITLE
Remove default support for Linux Mint and Cumulus Networks

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -88,39 +88,8 @@ class apt::params {
   }
 
   case $xfacts['lsbdistid'] {
-    'ubuntu', 'debian': {
-      $distid = $xfacts['lsbdistid']
-      $distcodename = $xfacts['lsbdistcodename']
-    }
-    'linuxmint': {
-      if $xfacts['lsbdistcodename'] == 'debian' {
-        $distid = 'debian'
-        $distcodename = 'wheezy'
-      } else {
-        $distid = 'ubuntu'
-        $distcodename = $xfacts['lsbdistcodename'] ? {
-          'qiana'  => 'trusty',
-          'petra'  => 'saucy',
-          'olivia' => 'raring',
-          'nadia'  => 'quantal',
-          'maya'   => 'precise',
-        }
-      }
-    }
-    'Cumulus Networks': {
-      $distid = 'debian'
-      $distcodename = $::lsbdistcodename
-    }
-    undef: {
-      fail('Unable to determine lsbdistid, is lsb-release installed?')
-    }
-    default: {
-      fail("Unsupported lsbdistid (${::lsbdistid})")
-    }
-  }
-  case $distid {
     'debian': {
-      case $distcodename {
+      case $xfacts['lsbdistcodename'] {
         'squeeze': {
           $backports = {
             'location' => 'http://backports.debian.org/debian-backports',
@@ -144,7 +113,7 @@ class apt::params {
         'repos'    => 'main universe multiverse restricted',
       }
 
-      case $distcodename {
+      case $xfacts['lsbdistcodename'] {
         'lucid': {
           $ppa_options        = undef
           $ppa_package        = 'python-software-properties'
@@ -163,7 +132,10 @@ class apt::params {
         }
       }
     }
-    '', default: {
+    undef: {
+      fail('Unable to determine lsbdistid, is lsb-release installed?')
+    }
+    default: {
       $ppa_options = undef
       $ppa_package = undef
       $backports   = undef

--- a/manifests/ppa.pp
+++ b/manifests/ppa.pp
@@ -10,8 +10,8 @@ define apt::ppa(
     fail('lsbdistcodename fact not available: release parameter required')
   }
 
-  if $::apt::distid != 'ubuntu' {
-    fail('apt::ppa is currently supported on Ubuntu and LinuxMint only.')
+  if $::apt::xfacts['lsbdistid'] == 'Debian' {
+    fail('apt::ppa is not currently supported on Debian.')
   }
 
   $filename_without_slashes = regsubst($name, '/', '-', 'G')

--- a/spec/classes/params_spec.rb
+++ b/spec/classes/params_spec.rb
@@ -12,19 +12,6 @@ describe 'apt::params', :type => :class do
     expect(subject.resources.size).to eq(4)
   end
 
-  describe "With unknown lsbdistid" do
-
-    let(:facts) { { :lsbdistid => 'CentOS', :osfamily => 'Debian' } }
-    let (:title) { 'my_package' }
-
-    it do
-      expect {
-       is_expected.to compile
-      }.to raise_error(Puppet::Error, /Unsupported lsbdistid/)
-    end
-
-  end
-
   describe "With lsb-release not installed" do
     let(:facts) { { :lsbdistid => '', :osfamily => 'Debian' } }
     let (:title) { 'my_package' }

--- a/spec/defines/ppa_spec.rb
+++ b/spec/defines/ppa_spec.rb
@@ -298,7 +298,7 @@ describe 'apt::ppa' do
       it do
         expect {
           is_expected.to compile
-        }.to raise_error(Puppet::Error, /supported on Ubuntu and LinuxMint only/)
+        }.to raise_error(Puppet::Error, /not currently supported on Debian/)
       end
     end
   end


### PR DESCRIPTION
NOTE: While out-of-the box support is disabled, it is still possible to
get the same configurations, it will just require explicitly setting the
necessary codename-munging.

This should only affect `apt::ppa`