### PR TITLE
fixed type error

### DIFF
--- a/manifests/update.pp
+++ b/manifests/update.pp
@@ -17,7 +17,7 @@ class apt::update {
         #if we should kick apt_update.
         $daily_threshold = (strftime('%s') - 86400)
         if $::apt_update_last_success {
-          if $::apt_update_last_success < $daily_threshold {
+          if $::apt_update_last_success + 0 < $daily_threshold {
             $_kick_apt = true
           } else {
             $_kick_apt = false


### PR DESCRIPTION
the module gives me the following error on 3.7.4-1puppetlabs1 with parser=future

```
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Evaluation Error: Comparison of: String < Integer, is not possible. Caused by 'A String is not comparable to a non String'. at /etc/puppet/modules/apt/manifests/update.pp:20:41
```