### PR TITLE
Feature/master/apt reboot required fact

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ The apt module includes a few facts to describe the state of the Apt system:
 * `apt\_security\_updates`: The number of updates which are security updates
 * `apt\_package\_updates`: The package names that are available for update. In Facter 2.0 and later, this will be a list type; in earlier versions, it is a comma-delimited string.
 * `apt\_update\_last\_success`: The date, in epochtime, of the most recent successful `apt-get update` run. This is determined by reading the mtime of  /var/lib/apt/periodic/update-success-stamp.
+* `apt\_reboot\_required`: Determines if a reboot is necessary after updates have been installed. 
 
 **Note:** The facts depend on 'update-notifier' being installed on your system. Though this is a GNOME daemon only the support files are needed so the package 'update-notifier-common' is enough to enable this functionality.
 

--- a/lib/facter/apt_reboot_required.rb
+++ b/lib/facter/apt_reboot_required.rb
@@ -1,0 +1,7 @@
+# apt_reboot_required.rb
+Facter.add(:apt_reboot_required) do
+  confine :osfamily => 'Debian'
+  setcode do
+    File.file?('/var/run/reboot-required')
+  end
+end

--- a/lib/facter/apt_reboot_required.rb
+++ b/lib/facter/apt_reboot_required.rb
@@ -2,6 +2,6 @@
 Facter.add(:apt_reboot_required) do
   confine :osfamily => 'Debian'
   setcode do
-    File.file?('/var/run/reboot-required')
+    File.file?('/var/run/reboot-required') ? ( "true" ) : ( "false" )
   end
 end

--- a/lib/facter/apt_reboot_required.rb
+++ b/lib/facter/apt_reboot_required.rb
@@ -2,6 +2,6 @@
 Facter.add(:apt_reboot_required) do
   confine :osfamily => 'Debian'
   setcode do
-    File.file?('/var/run/reboot-required') ? ( "true" ) : ( "false" )
+    File.file?('/var/run/reboot-required') ? ( true ) : ( false )
   end
 end

--- a/spec/unit/facter/apt_reboot_required_spec.rb
+++ b/spec/unit/facter/apt_reboot_required_spec.rb
@@ -9,7 +9,7 @@ describe 'apt_reboot_required fact' do
       Facter.fact(:osfamily).stubs(:value).returns 'Debian'
       File.stubs(:file?).returns true
     }
-    it { expect Facter.fact(:apt_reboot_required).to eq(true) }
+    it { expect(Facter.fact(:apt_reboot_required).value).to eq true }
   end
 
   describe 'if a reboot is not required' do
@@ -17,7 +17,7 @@ describe 'apt_reboot_required fact' do
       Facter.fact(:osfamily).stubs(:value).returns 'Debian'
       File.stubs(:file?).returns false
     }
-    it { expect Facter.fact(:apt_reboot_required).to eq(false) }
+    it { expect(Facter.fact(:apt_reboot_required)).to eq nil }
   end
 
 end

--- a/spec/unit/facter/apt_reboot_required_spec.rb
+++ b/spec/unit/facter/apt_reboot_required_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe 'apt_reboot_required fact' do
+  subject { Facter.fact(:apt_reboot_required).value }
+  after(:each) { Facter.clear }
+
+  describe 'if a reboot is required' do
+    before {
+      Facter.fact(:osfamily).stubs(:value).returns 'Debian'
+      File.stubs(:file?).returns true
+    }
+    it { should eq("true") }
+  end
+
+  describe 'if a reboot is not required' do
+    before {
+      Facter.fact(:osfamily).stubs(:value).returns 'Debian'
+      File.stubs(:file?).returns false
+    }
+    it { expect(Facter.fact(:apt_reboot_required).nil?).to eq(true) }
+  end
+
+end

--- a/spec/unit/facter/apt_reboot_required_spec.rb
+++ b/spec/unit/facter/apt_reboot_required_spec.rb
@@ -17,7 +17,7 @@ describe 'apt_reboot_required fact' do
       Facter.fact(:osfamily).stubs(:value).returns 'Debian'
       File.stubs(:file?).returns false
     }
-    it { expect(Facter.fact(:apt_reboot_required).value).to eq nil }
+    it { expect(Facter.fact(:apt_reboot_required).value).to eq false }
   end
 
 end

--- a/spec/unit/facter/apt_reboot_required_spec.rb
+++ b/spec/unit/facter/apt_reboot_required_spec.rb
@@ -9,7 +9,7 @@ describe 'apt_reboot_required fact' do
       Facter.fact(:osfamily).stubs(:value).returns 'Debian'
       File.stubs(:file?).returns true
     }
-    it { should eq("true") }
+    it { expect Facter.fact(:apt_reboot_required).to eq(true) }
   end
 
   describe 'if a reboot is not required' do
@@ -17,7 +17,7 @@ describe 'apt_reboot_required fact' do
       Facter.fact(:osfamily).stubs(:value).returns 'Debian'
       File.stubs(:file?).returns false
     }
-    it { expect(Facter.fact(:apt_reboot_required).nil?).to eq(true) }
+    it { expect Facter.fact(:apt_reboot_required).to eq(false) }
   end
 
 end

--- a/spec/unit/facter/apt_reboot_required_spec.rb
+++ b/spec/unit/facter/apt_reboot_required_spec.rb
@@ -17,7 +17,7 @@ describe 'apt_reboot_required fact' do
       Facter.fact(:osfamily).stubs(:value).returns 'Debian'
       File.stubs(:file?).returns false
     }
-    it { expect(Facter.fact(:apt_reboot_required)).to eq nil }
+    it { expect(Facter.fact(:apt_reboot_required).value).to eq nil }
   end
 
 end


### PR DESCRIPTION
Simple custom fact to determine if a reboot is necessary after updates have been installed on Debian/Ubuntu systems. We found this useful in our environment so I wanted to share in case others found this useful as well. 