### PR TITLE
Update tests to work with rspec-puppet 2.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,16 @@ matrix:
     env: PUPPET_GEM_VERSION="~> 3.0"
   - rvm: 2.0.0
     env: PUPPET_GEM_VERSION="~> 3.0"
+  - rvm: 1.9.3
+    env: PUPPET_GEM_VERSION="~> 3.0" FUTURE_PARSER="yes"
+  - rvm: 2.0.0
+    env: PUPPET_GEM_VERSION="~> 3.0" FUTURE_PARSER="yes"
+  - rvm: 1.9.3
+    env: PUPPET_GEM_VERSION="~> 4.0"
+  - rvm: 2.0.0
+    env: PUPPET_GEM_VERSION="~> 4.0"
+  allow_failures:
+    - env: PUPPET_GEM_VERSION="~> 4.0"
+    - env: PUPPET_GEM_VERSION="~> 3.0" FUTURE_PARSER="yes"
 notifications:
   email: false

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ end
 group :development, :unit_tests do
   gem 'rake',                    :require => false
   gem 'rspec-core', '3.1.7',     :require => false
-  gem 'rspec-puppet', '~> 1.0',  :require => false
+  gem 'rspec-puppet', '~> 2.0',  :require => false
   gem 'puppetlabs_spec_helper',  :require => false
   gem 'puppet-lint',             :require => false
   gem 'simplecov',               :require => false

--- a/spec/classes/apt_backports_spec.rb
+++ b/spec/classes/apt_backports_spec.rb
@@ -142,7 +142,7 @@ describe 'apt::backports', :type => :class do
       end
       it do
         expect {
-          is_expected.to compile
+          subject.call
         }.to raise_error(Puppet::Error, /If not on Debian or Ubuntu, you must explicitly pass location, release, repos, and key/)
       end
     end
@@ -156,7 +156,7 @@ describe 'apt::backports', :type => :class do
       end
       it do
         expect {
-          is_expected.to compile
+          subject.call
         }.to raise_error(Puppet::Error, /If not on Debian or Ubuntu, you must explicitly pass location, release, repos, and key/)
       end
     end
@@ -170,7 +170,7 @@ describe 'apt::backports', :type => :class do
       end
       it do
         expect {
-          is_expected.to compile
+          subject.call
         }.to raise_error(Puppet::Error, /If not on Debian or Ubuntu, you must explicitly pass location, release, repos, and key/)
       end
     end
@@ -184,7 +184,7 @@ describe 'apt::backports', :type => :class do
       end
       it do
         expect {
-          is_expected.to compile
+          subject.call
         }.to raise_error(Puppet::Error, /If not on Debian or Ubuntu, you must explicitly pass location, release, repos, and key/)
       end
     end
@@ -205,7 +205,7 @@ describe 'apt::backports', :type => :class do
       end
       it do
         expect {
-          is_expected.to compile
+          subject.call
         }.to raise_error(Puppet::Error, /is not a string/)
       end
     end
@@ -217,7 +217,7 @@ describe 'apt::backports', :type => :class do
       end
       it do
         expect {
-          is_expected.to compile
+          subject.call
         }.to raise_error(Puppet::Error, /is not a string/)
       end
     end
@@ -229,7 +229,7 @@ describe 'apt::backports', :type => :class do
       end
       it do
         expect {
-          is_expected.to compile
+          subject.call
         }.to raise_error(Puppet::Error, /is not a string/)
       end
     end
@@ -241,7 +241,7 @@ describe 'apt::backports', :type => :class do
       end
       it do
         expect {
-          is_expected.to compile
+          subject.call
         }.to raise_error(Puppet::Error, /is not a string/)
       end
     end
@@ -253,7 +253,7 @@ describe 'apt::backports', :type => :class do
       end
       it do
         expect {
-          is_expected.to compile
+          subject.call
         }.to raise_error(Puppet::Error, /pin must be either a string, number or hash/)
       end
     end

--- a/spec/classes/apt_spec.rb
+++ b/spec/classes/apt_spec.rb
@@ -101,8 +101,8 @@ describe 'apt' do
       }
     end
 
-    it { is_expected.to contain_file('sources.list').without({
-      :content => "# Repos managed by puppet.\n",
+    it { is_expected.to contain_file('sources.list').with({
+      :content => nil,
     })}
 
     it { is_expected.to contain_file('sources.list.d').with({
@@ -230,7 +230,7 @@ describe 'apt' do
       let(:params) { { :purge => { 'sources.list' => 'banana' }, } }
       it do
         expect {
-          is_expected.to compile
+          subject.call
         }.to raise_error(Puppet::Error)
       end
     end
@@ -239,7 +239,7 @@ describe 'apt' do
       let(:params) { { :purge => { 'sources.list.d' => 'banana' }, } }
       it do
         expect {
-          is_expected.to compile
+          subject.call
         }.to raise_error(Puppet::Error)
       end
     end
@@ -248,7 +248,7 @@ describe 'apt' do
       let(:params) { { :purge => { 'preferences' => 'banana' }, } }
       it do
         expect {
-          is_expected.to compile
+          subject.call
         }.to raise_error(Puppet::Error)
       end
     end
@@ -257,7 +257,7 @@ describe 'apt' do
       let(:params) { { :purge => { 'preferences.d' => 'banana' }, } }
       it do
         expect {
-          is_expected.to compile
+          subject.call
         }.to raise_error(Puppet::Error)
       end
     end
@@ -269,7 +269,7 @@ describe 'apt' do
 
       it do
         expect {
-          is_expected.to compile
+          subject.call
         }.to raise_error(Puppet::Error, /This module only works on Debian or derivatives like Ubuntu/)
       end
     end

--- a/spec/classes/params_spec.rb
+++ b/spec/classes/params_spec.rb
@@ -9,16 +9,16 @@ describe 'apt::params', :type => :class do
   # there should not be any more resources because it is a params class
   # The resources are class[apt::params], class[main], class[settings], stage[main]
   it "Should not contain any resources" do
-    expect(subject.resources.size).to eq(4)
+    expect(subject.call.resources.size).to eq(4)
   end
 
   describe "With lsb-release not installed" do
-    let(:facts) { { :lsbdistid => '', :osfamily => 'Debian' } }
+    let(:facts) { { :osfamily => 'Debian' } }
     let (:title) { 'my_package' }
 
     it do
       expect {
-        is_expected.to compile
+        subject.call
       }.to raise_error(Puppet::Error, /Unable to determine lsbdistid, is lsb-release installed/)
     end
   end

--- a/spec/defines/conf_spec.rb
+++ b/spec/defines/conf_spec.rb
@@ -38,7 +38,7 @@ describe 'apt::conf', :type => :define do
     end
 
     it 'fails' do
-      expect { subject } .to raise_error(/pass in content/)
+      expect { subject.call } .to raise_error(/pass in content/)
     end
   end
 

--- a/spec/defines/key_spec.rb
+++ b/spec/defines/key_spec.rb
@@ -143,7 +143,7 @@ describe 'apt::key' do
         :server => '-pgp.mit.edu',
       } end
       it 'fails' do
-        expect { subject } .to raise_error(/does not match/)
+        expect { subject.call } .to raise_error(/does not match/)
       end
     end
 
@@ -152,7 +152,7 @@ describe 'apt::key' do
         :server => '.pgp.mit.edu',
       } end
       it 'fails' do
-        expect { subject } .to raise_error(/does not match/)
+        expect { subject.call } .to raise_error(/does not match/)
       end
     end
 
@@ -161,7 +161,7 @@ describe 'apt::key' do
         :server => "pgp.mit.edu.",
       } end
       it 'fails' do
-        expect { subject } .to raise_error(/does not match/)
+        expect { subject.call } .to raise_error(/does not match/)
       end
     end
     context "exceed character url" do
@@ -171,7 +171,7 @@ describe 'apt::key' do
         }
       end
       it 'fails' do
-        expect { subject }.to raise_error(/does not match/)
+        expect { subject.call }.to raise_error(/does not match/)
       end
     end
     context "incorrect port number url" do
@@ -181,7 +181,7 @@ describe 'apt::key' do
         }
       end
       it 'fails' do
-        expect { subject }.to raise_error(/does not match/)
+        expect { subject.call }.to raise_error(/does not match/)
       end
     end
     context "incorrect protocol for  url" do
@@ -191,7 +191,7 @@ describe 'apt::key' do
         }
       end
       it 'fails' do
-        expect { subject }.to raise_error(/does not match/)
+        expect { subject.call }.to raise_error(/does not match/)
       end
     end
     context "missing port number url" do
@@ -201,7 +201,7 @@ describe 'apt::key' do
         }
       end
       it 'fails' do
-        expect { subject }.to raise_error(/does not match/)
+        expect { subject.call }.to raise_error(/does not match/)
       end
     end
     context "url ending with a dot" do
@@ -211,7 +211,7 @@ describe 'apt::key' do
         }
       end
       it 'fails' do
-        expect { subject }.to raise_error(/does not match/)
+        expect { subject.call }.to raise_error(/does not match/)
       end
     end
     context "url begin with a dash" do
@@ -219,7 +219,7 @@ describe 'apt::key' do
         :server => "hkp://-pgp.mit.edu",
       } end
       it 'fails' do
-        expect { subject }.to raise_error(/does not match/)
+        expect { subject.call }.to raise_error(/does not match/)
       end
     end
     context 'invalid key' do
@@ -227,7 +227,7 @@ describe 'apt::key' do
         'Out of rum. Why? Why are we out of rum?'
       end
       it 'fails' do
-        expect { subject }.to raise_error(/does not match/)
+        expect { subject.call }.to raise_error(/does not match/)
       end
     end
 
@@ -236,7 +236,7 @@ describe 'apt::key' do
         :source => 'afp://puppetlabs.com/key.gpg',
       } end
       it 'fails' do
-        expect { subject }.to raise_error(/does not match/)
+        expect { subject.call }.to raise_error(/does not match/)
       end
     end
 
@@ -245,7 +245,7 @@ describe 'apt::key' do
         :content => [],
       } end
       it 'fails' do
-        expect { subject }.to raise_error(/is not a string/)
+        expect { subject.call }.to raise_error(/is not a string/)
       end
     end
 
@@ -254,7 +254,7 @@ describe 'apt::key' do
         :server => 'two bottles of rum',
       } end
       it 'fails' do
-        expect { subject }.to raise_error(/does not match/)
+        expect { subject.call }.to raise_error(/does not match/)
       end
     end
 
@@ -263,7 +263,7 @@ describe 'apt::key' do
         :options => {},
       } end
       it 'fails' do
-        expect { subject }.to raise_error(/is not a string/)
+        expect { subject.call }.to raise_error(/is not a string/)
       end
     end
 
@@ -274,7 +274,7 @@ describe 'apt::key' do
         }
       end
       it 'fails' do
-        expect { subject }.to raise_error(/does not match/)
+        expect { subject.call }.to raise_error(/does not match/)
       end
     end
 
@@ -315,7 +315,7 @@ describe 'apt::key' do
           apt::key { 'duplicate': id => '#{title}', ensure => 'absent', }"
         end
         it 'informs the user of the impossibility' do
-          expect { subject }.to raise_error(/already ensured as absent/)
+          expect { subject.call }.to raise_error(/already ensured as absent/)
         end
       end
     end

--- a/spec/defines/pin_spec.rb
+++ b/spec/defines/pin_spec.rb
@@ -80,7 +80,7 @@ describe 'apt::pin', :type => :define do
       end
       it do
         expect {
-          is_expected.to compile
+          subject.call
         }.to raise_error(Puppet::Error, /Only integers are allowed/)
       end
     end
@@ -93,7 +93,7 @@ describe 'apt::pin', :type => :define do
       end
       it do
         expect {
-          is_expected.to compile
+          subject.call
         }.to raise_error(Puppet::Error, /parameter version cannot be used in general form/)
       end
     end
@@ -107,7 +107,7 @@ describe 'apt::pin', :type => :define do
       end
       it do
         expect {
-          is_expected.to compile
+          subject.call
         }.to raise_error(Puppet::Error, /parameters release and origin are mutually exclusive/)
       end
     end
@@ -122,7 +122,7 @@ describe 'apt::pin', :type => :define do
       end
       it do
         expect {
-          is_expected.to compile
+          subject.call
         }.to raise_error(Puppet::Error, /parameters release, origin, and version are mutually exclusive/)
       end
     end
@@ -137,7 +137,7 @@ describe 'apt::pin', :type => :define do
       end
       it do
         expect {
-          is_expected.to compile
+          subject.call
         }.to raise_error(Puppet::Error, /parameters release, origin, and version are mutually exclusive/)
       end
     end

--- a/spec/defines/ppa_spec.rb
+++ b/spec/defines/ppa_spec.rb
@@ -279,7 +279,7 @@ describe 'apt::ppa' do
       let(:title) { 'ppa:foo' }
       it do
         expect {
-          is_expected.to compile
+          subject.call
         }.to raise_error(Puppet::Error, /lsbdistcodename fact not available: release parameter required/)
       end
     end
@@ -297,7 +297,7 @@ describe 'apt::ppa' do
       let(:title) { 'ppa:foo' }
       it do
         expect {
-          is_expected.to compile
+          subject.call
         }.to raise_error(Puppet::Error, /not currently supported on Debian/)
       end
     end

--- a/spec/defines/setting_spec.rb
+++ b/spec/defines/setting_spec.rb
@@ -10,7 +10,7 @@ describe 'apt::setting' do
   describe 'when using the defaults' do
     context 'without source or content' do
       it do
-        expect { is_expected.to compile }.to raise_error(Puppet::Error, /needs either of /)
+        expect { subject.call }.to raise_error(Puppet::Error, /needs either of /)
       end
     end
 
@@ -74,7 +74,7 @@ describe 'apt::setting' do
     context 'with source and content' do
       let(:params) { default_params.merge({ :source => 'la' }) }
       it do
-        expect { is_expected.to compile }.to raise_error(Puppet::Error, /cannot have both /)
+        expect { subject.call }.to raise_error(Puppet::Error, /cannot have both /)
       end
     end
 
@@ -82,21 +82,21 @@ describe 'apt::setting' do
       let(:title) { 'ext-teddybear' }
       let(:params) { default_params }
       it do
-        expect { is_expected.to compile }.to raise_error(Puppet::Error, /must start with /)
+        expect { subject.call }.to raise_error(Puppet::Error, /must start with /)
       end
     end
 
     context 'with ensure=banana' do
       let(:params) { default_params.merge({ :ensure => 'banana' }) }
       it do
-        expect { is_expected.to compile }.to raise_error(Puppet::Error, /"banana" does not /)
+        expect { subject.call }.to raise_error(Puppet::Error, /"banana" does not /)
       end
     end
 
     context 'with priority=1.2' do
       let(:params) { default_params.merge({ :priority => 1.2 }) }
       it do
-        expect { is_expected.to compile }.to raise_error(Puppet::Error, /be an integer /)
+        expect { subject.call }.to raise_error(Puppet::Error, /be an integer /)
       end
     end
   end

--- a/spec/defines/source_spec.rb
+++ b/spec/defines/source_spec.rb
@@ -22,7 +22,7 @@ describe 'apt::source' do
       end
       it do
         expect {
-          is_expected.to compile
+          subject.call
         }.to raise_error(Puppet::Error, /source entry without specifying a location/)
       end
     end
@@ -256,7 +256,7 @@ describe 'apt::source' do
 
       it do
         expect {
-          is_expected.to compile
+          subject.call
         }.to raise_error(Puppet::Error, /lsbdistcodename fact not available: release parameter required/)
       end
     end
@@ -278,7 +278,7 @@ describe 'apt::source' do
 
       it do
         expect {
-          is_expected.to compile
+          subject.call
         }.to raise_error(Puppet::Error, /invalid value for pin/)
       end
     end


### PR DESCRIPTION
Also enable future parser testing. Need to allow failures with future
parser for now since none of the published gems have the fix for
PUP-4379