### PR TITLE
Travis test matrix updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,20 @@ matrix:
   fast_finish: true
   include:
   - rvm: 1.8.7
-    env: PUPPET_GEM_VERSION="~> 3.0"
+    env: PUPPET_GEM_VERSION="~> 3.0" ORDERING="random" STRICT_VARIABLES="yes"
   - rvm: 1.9.3
-    env: PUPPET_GEM_VERSION="~> 3.0"
+    env: PUPPET_GEM_VERSION="~> 3.0" ORDERING="random" STRICT_VARIABLES="yes"
   - rvm: 2.0.0
-    env: PUPPET_GEM_VERSION="~> 3.0"
+    env: PUPPET_GEM_VERSION="~> 3.0" ORDERING="random" STRICT_VARIABLES="yes"
+  - rvm: 2.1
+    env: PUPPET_GEM_VERSION="~> 3.0" ORDERING="random" STRICT_VARIABLES="yes"
+  - rvm: 2.1
+    env: PUPPET_GEM_VERSION="~> 3.0" ORDERING="random" STRICT_VARIABLES="yes" FUTURE_PARSER="yes"
+  - rvm: 1.9.3
+    env: PUPPET_GEM_VERSION="~> 4.0" ORDERING="random"
+  - rvm: 2.0.0
+    env: PUPPET_GEM_VERSION="~> 4.0" ORDERING="random"
+  - rvm: 2.1
+    env: PUPPET_GEM_VERSION="~> 4.0" ORDERING="random"
 notifications:
   email: false

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ end
 group :development, :unit_tests do
   gem 'rake',                    :require => false
   gem 'rspec-core', '3.1.7',     :require => false
-  gem 'rspec-puppet', '~> 1.0',  :require => false
+  gem 'rspec-puppet', '~> 2.1',  :require => false
   gem 'puppetlabs_spec_helper',  :require => false
   gem 'puppet-lint',             :require => false
   gem 'simplecov',               :require => false


### PR DESCRIPTION
* Puppet 3 on all supported Ruby versions with strict variables and
  random ordering.
* Puppet 3 on 2.1 with strict variables, future parser and random
  ordering.
* Puppet 4 on all supported Ruby versions and random ordering.