### PR TITLE
Add feature to overwrite sources.list with custom file

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,10 @@ Main class, includes all other classes.
 
   * 'preferences.list.d': Specifies whether to purge any unmanaged entries from `preferences.list.d`. Valid options: 'true' and 'false'. Default: 'false'.
 
+* `overwrite`: Hash to overwrite various files. Omitted keys are ignored. If the key is also set to `true` in the `purge` parameter the `overwrite` parameter is ignored. Valid options: a hash made up from the following keys:
+  
+  * 'sources.list': Expects a URI pointing to a remote file, or a fully qualified path to a file available on the local system that will overwrite the `/etc/apt/sources.list`.
+
 * `settings`: Creates new `apt::setting` resources. Valid options: a hash to be passed to the [`create_resources` function](https://docs.puppetlabs.com/references/latest/function.html#createresources). Default: {}.
 
 * `sources`: Creates new `apt::setting` resources. Valid options: a hash to be passed to the [`create_resources` function](https://docs.puppetlabs.com/references/latest/function.html#createresources). Default: {}.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,12 +1,13 @@
 #
 class apt(
-  $update   = {},
-  $purge    = {},
-  $proxy    = {},
-  $sources  = {},
-  $keys     = {},
-  $ppas     = {},
-  $settings = {},
+  $update    = {},
+  $purge     = {},
+  $proxy     = {},
+  $overwrite = {},
+  $sources   = {},
+  $keys      = {},
+  $ppas      = {},
+  $settings  = {},
 ) inherits ::apt::params {
 
   $frequency_options = ['always','daily','weekly','reluctantly']
@@ -59,6 +60,11 @@ class apt(
 
   $_proxy = merge($apt::proxy_defaults, $proxy)
 
+  validate_hash($overwrite)
+  if $overwrite['sources.list'] {
+    validate_string($overwrite['sources.list'])
+  }
+
   validate_hash($sources)
   validate_hash($keys)
   validate_hash($settings)
@@ -69,6 +75,11 @@ class apt(
       priority => '01',
       content  => template('apt/_header.erb', 'apt/proxy.erb'),
     }
+  }
+
+  $sources_list_template = $_purge['sources.list'] ? {
+    false => $overwrite['sources.list'],
+    true  => undef,
   }
 
   $sources_list_content = $_purge['sources.list'] ? {
@@ -99,6 +110,7 @@ class apt(
     group   => root,
     mode    => '0644',
     content => $sources_list_content,
+    source  => $sources_list_template,
     notify  => Exec['apt_update'],
   }
 

--- a/spec/classes/apt_spec.rb
+++ b/spec/classes/apt_spec.rb
@@ -129,7 +129,7 @@ describe 'apt' do
 
   context 'with source.list overwrite defined and source.list purge false' do
     let(:params) { {
-      :overwrite=> {
+      :overwrite => {
         'sources.list' => 'puppet:///files/my_sources.list',
       },
       :purge   => { 'sources.list' => false },
@@ -153,7 +153,7 @@ describe 'apt' do
       :overwrite => {
         'sources.list' => 'puppet:///files/my_sources.list',
       },
-      :purge   => { 'sources.list' => true },
+      :purge => { 'sources.list' => true },
     } }
 
     it {

--- a/spec/classes/apt_spec.rb
+++ b/spec/classes/apt_spec.rb
@@ -127,6 +127,42 @@ describe 'apt' do
 
   end
 
+  context 'with source.list overwrite defined and source.list purge false' do
+    let(:params) { {
+      :overwrite=> {
+        'sources.list' => 'puppet:///files/my_sources.list',
+      },
+      :purge   => { 'sources.list' => false },
+    } }
+
+    it {
+      is_expected.to contain_file('sources.list').only_with({
+        :ensure  => 'file',
+        :path    => '/etc/apt/sources.list',
+        :owner   => 'root',
+        :group   => 'root',
+        :mode    => '0644',
+        :source  => 'puppet:///files/my_sources.list',
+        :notify  => 'Exec[apt_update]',
+      })
+    }
+  end
+
+  context 'with source.list overwrite defined and source.list purge true' do
+    let(:params) { {
+      :overwrite => {
+        'sources.list' => 'puppet:///files/my_sources.list',
+      },
+      :purge   => { 'sources.list' => true },
+    } }
+
+    it {
+      is_expected.to contain_file('sources.list').with({
+        :source => nil,
+      })
+    }
+  end
+
   context 'with sources defined on valid osfamily' do
     let :facts do
       { :osfamily        => 'Debian',


### PR DESCRIPTION
As promised some weeks ago I finally got some time to implement the feature to overwrite the sources.list file.

This commit adds the `overwrite` parameter to the apt class which takes a hash as argument. With the `sources.list` key the `/etc/apt/sources.list` can be overwritten by a custom file. If `purge['sources.list']` is true then `overwrite['sources.list']` will be ignored.

The `overwrite` parameter can be extended for other files maybe.

Docs and test included this time.