### PR TITLE
Don't stub puppetversion

### DIFF
--- a/spec/classes/apt_backports_spec.rb
+++ b/spec/classes/apt_backports_spec.rb
@@ -10,7 +10,7 @@ describe 'apt::backports', :type => :class do
           :lsbdistid       => 'Debian',
           :osfamily        => 'Debian',
           :lsbdistcodename => 'wheezy',
-          :puppetversion   => '3.5.0',
+          :puppetversion   => Puppet.version,
         }
       end
       it { is_expected.to contain_apt__source('backports').with({
@@ -28,7 +28,7 @@ describe 'apt::backports', :type => :class do
           :lsbdistid       => 'Debian',
           :osfamily        => 'Debian',
           :lsbdistcodename => 'squeeze',
-          :puppetversion   => '3.5.0',
+          :puppetversion   => Puppet.version,
         }
       end
       it { is_expected.to contain_apt__source('backports').with({
@@ -46,7 +46,7 @@ describe 'apt::backports', :type => :class do
           :lsbdistid       => 'Ubuntu',
           :osfamily        => 'Debian',
           :lsbdistcodename => 'trusty',
-          :puppetversion   => '3.5.0',
+          :puppetversion   => Puppet.version,
         }
       end
       it { is_expected.to contain_apt__source('backports').with({
@@ -64,7 +64,7 @@ describe 'apt::backports', :type => :class do
           :lsbdistid       => 'Ubuntu',
           :osfamily        => 'Debian',
           :lsbdistcodename => 'trusty',
-          :puppetversion   => '3.5.0',
+          :puppetversion   => Puppet.version,
         }
       end
       let(:params) do
@@ -91,7 +91,7 @@ describe 'apt::backports', :type => :class do
           :lsbdistid       => 'Ubuntu',
           :osfamily        => 'Debian',
           :lsbdistcodename => 'trusty',
-          :puppetversion   => '3.5.0',
+          :puppetversion   => Puppet.version,
         }
       end
       let(:params) do
@@ -117,7 +117,7 @@ describe 'apt::backports', :type => :class do
         :lsbdistid       => 'linuxmint',
         :osfamily        => 'Debian',
         :lsbdistcodename => 'qiana',
-        :puppetversion   => '3.5.0',
+        :puppetversion   => Puppet.version,
       }
     end
     context 'sets all the needed things' do
@@ -201,7 +201,7 @@ describe 'apt::backports', :type => :class do
         :lsbdistid       => 'Ubuntu',
         :osfamily        => 'Debian',
         :lsbdistcodename => 'trusty',
-        :puppetversion   => '3.5.0',
+        :puppetversion   => Puppet.version,
       }
     end
     context 'invalid location' do

--- a/spec/classes/apt_spec.rb
+++ b/spec/classes/apt_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 describe 'apt' do
-  let(:facts) { { :lsbdistid => 'Debian', :osfamily => 'Debian', :lsbdistcodename => 'wheezy', :puppetversion   => '3.5.0'} }
+  let(:facts) { { :lsbdistid => 'Debian', :osfamily => 'Debian', :lsbdistcodename => 'wheezy', :puppetversion   => Puppet.version} }
 
   context 'defaults' do
     it { is_expected.to contain_file('sources.list').that_notifies('Exec[apt_update]').only_with({
@@ -132,7 +132,7 @@ describe 'apt' do
       { :osfamily        => 'Debian',
         :lsbdistcodename => 'precise',
         :lsbdistid       => 'Debian',
-        :puppetversion   => '3.5.0',
+        :puppetversion   => Puppet.version,
       }
     end
     let(:params) { { :sources => {
@@ -174,7 +174,7 @@ describe 'apt' do
       { :osfamily        => 'Debian',
         :lsbdistcodename => 'precise',
         :lsbdistid       => 'Debian',
-        :puppetversion   => '3.5.0',
+        :puppetversion   => Puppet.version,
       }
     end
     let(:params) { { :keys => {
@@ -200,7 +200,7 @@ describe 'apt' do
       { :osfamily        => 'Debian',
         :lsbdistcodename => 'precise',
         :lsbdistid       => 'ubuntu',
-        :puppetversion   => '3.5.0',
+        :puppetversion   => Puppet.version,
       }
     end
     let(:params) { { :ppas => {
@@ -217,7 +217,7 @@ describe 'apt' do
       { :osfamily        => 'Debian',
         :lsbdistcodename => 'precise',
         :lsbdistid       => 'Debian',
-        :puppetversion   => '3.5.0',
+        :puppetversion   => Puppet.version,
       }
     end
     let(:params) { { :settings => {
@@ -268,7 +268,7 @@ describe 'apt' do
 
     context 'with unsupported osfamily' do
       let :facts do
-        { :osfamily => 'Darwin', :puppetversion   => '3.5.0',}
+        { :osfamily => 'Darwin', :puppetversion   => Puppet.version,}
       end
 
       it do

--- a/spec/classes/apt_update_spec.rb
+++ b/spec/classes/apt_update_spec.rb
@@ -5,7 +5,7 @@ describe 'apt::update', :type => :class do
   context "and apt::update['frequency']='always'" do
     { 'a recent run' => Time.now.to_i, 'we are due for a run' => 1406660561,'the update-success-stamp file does not exist' => -1 }.each_pair do |desc, factval|
       context "and $::apt_update_last_success indicates #{desc}" do
-        let(:facts) { { :lsbdistid => 'Debian', :osfamily => 'Debian', :apt_update_last_success => factval, :lsbdistcodename => 'wheezy', :puppetversion   => '3.5.0', } }
+        let(:facts) { { :lsbdistid => 'Debian', :osfamily => 'Debian', :apt_update_last_success => factval, :lsbdistcodename => 'wheezy', :puppetversion   => Puppet.version, } }
         let (:pre_condition) { "class{'::apt': update => {'frequency' => 'always' },}" }
         it 'should trigger an apt-get update run' do
           #set the apt_update exec's refreshonly attribute to false
@@ -14,7 +14,7 @@ describe 'apt::update', :type => :class do
       end
     end
     context 'when $::apt_update_last_success is nil' do
-      let(:facts) { { :lsbdistid => 'Debian', :osfamily => 'Debian', :lsbdistcodename => 'wheezy', :puppetversion   => '3.5.0', } }
+      let(:facts) { { :lsbdistid => 'Debian', :osfamily => 'Debian', :lsbdistcodename => 'wheezy', :puppetversion   => Puppet.version, } }
       let (:pre_condition) { "class{ '::apt': update => {'frequency' => 'always' },}" }
       it 'should trigger an apt-get update run' do
         #set the apt_update exec\'s refreshonly attribute to false
@@ -25,7 +25,7 @@ describe 'apt::update', :type => :class do
   context "and apt::update['frequency']='reluctantly'" do
     {'a recent run' => Time.now.to_i, 'we are due for a run' => 1406660561,'the update-success-stamp file does not exist' => -1 }.each_pair do |desc, factval|
       context "and $::apt_update_last_success indicates #{desc}" do
-        let(:facts) { { :lsbdistid => 'Debian', :osfamily => 'Debian', :apt_update_last_success => factval, :lsbdistcodename => 'wheezy', :puppetversion   => '3.5.0',} }
+        let(:facts) { { :lsbdistid => 'Debian', :osfamily => 'Debian', :apt_update_last_success => factval, :lsbdistcodename => 'wheezy', :puppetversion   => Puppet.version,} }
         let (:pre_condition) { "class{ '::apt': update => {'frequency' => 'reluctantly' },}" }
         it 'should not trigger an apt-get update run' do
           #don't change the apt_update exec's refreshonly attribute. (it should be true)
@@ -34,7 +34,7 @@ describe 'apt::update', :type => :class do
       end
     end
     context 'when $::apt_update_last_success is nil' do
-      let(:facts) { { :lsbdistid => 'Debian', :osfamily => 'Debian', :lsbdistcodename => 'wheezy', :puppetversion   => '3.5.0', } }
+      let(:facts) { { :lsbdistid => 'Debian', :osfamily => 'Debian', :lsbdistcodename => 'wheezy', :puppetversion   => Puppet.version, } }
       let (:pre_condition) { "class{ '::apt': update => {'frequency' => 'reluctantly' },}" }
       it 'should not trigger an apt-get update run' do
         #don't change the apt_update exec's refreshonly attribute. (it should be true)
@@ -46,7 +46,7 @@ describe 'apt::update', :type => :class do
     context "and apt::update['frequency'] has the value of #{update_frequency}" do
       { 'we are due for a run' => 1406660561,'the update-success-stamp file does not exist' => -1 }.each_pair do |desc, factval|
         context "and $::apt_update_last_success indicates #{desc}" do
-          let(:facts) { { :lsbdistid => 'Debian', :osfamily => 'Debian', :apt_update_last_success => factval, :lsbdistcodename => 'wheezy', :puppetversion   => '3.5.0', } }
+          let(:facts) { { :lsbdistid => 'Debian', :osfamily => 'Debian', :apt_update_last_success => factval, :lsbdistcodename => 'wheezy', :puppetversion   => Puppet.version, } }
           let (:pre_condition) { "class{ '::apt': update => {'frequency' => '#{update_frequency}',} }" }
           it 'should trigger an apt-get update run' do
             #set the apt_update exec\'s refreshonly attribute to false
@@ -55,7 +55,7 @@ describe 'apt::update', :type => :class do
         end
       end
       context 'when the $::apt_update_last_success fact has a recent value' do
-        let(:facts) { { :lsbdistid => 'Debian', :osfamily => 'Debian', :lsbdistcodename => 'wheezy', :apt_update_last_success => Time.now.to_i, :puppetversion   => '3.5.0', } }
+        let(:facts) { { :lsbdistid => 'Debian', :osfamily => 'Debian', :lsbdistcodename => 'wheezy', :apt_update_last_success => Time.now.to_i, :puppetversion   => Puppet.version, } }
         let (:pre_condition) { "class{ '::apt': update => {'frequency' => '#{update_frequency}',} }" }
         it 'should not trigger an apt-get update run' do
           #don't change the apt_update exec\'s refreshonly attribute. (it should be true)
@@ -63,7 +63,7 @@ describe 'apt::update', :type => :class do
         end
       end
       context 'when $::apt_update_last_success is nil' do
-        let(:facts) { { :lsbdistid => 'Debian', :osfamily => 'Debian', :lsbdistcodename => 'wheezy', :apt_update_last_success => nil, :puppetversion   => '3.5.0', } }
+        let(:facts) { { :lsbdistid => 'Debian', :osfamily => 'Debian', :lsbdistcodename => 'wheezy', :apt_update_last_success => nil, :puppetversion   => Puppet.version, } }
         let (:pre_condition) { "class{ '::apt': update => {'frequency' => '#{update_frequency}',} }" }
         it 'should trigger an apt-get update run' do
           #set the apt_update exec\'s refreshonly attribute to false

--- a/spec/classes/params_spec.rb
+++ b/spec/classes/params_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 describe 'apt::params', :type => :class do
-  let(:facts) { { :lsbdistid => 'Debian', :osfamily => 'Debian', :lsbdistcodename => 'wheezy', :puppetversion   => '3.5.0', } }
+  let(:facts) { { :lsbdistid => 'Debian', :osfamily => 'Debian', :lsbdistcodename => 'wheezy', :puppetversion   => Puppet.version, } }
   let (:title) { 'my_package' }
 
   it { is_expected.to contain_apt__params }
@@ -13,7 +13,7 @@ describe 'apt::params', :type => :class do
   end
 
   describe "With lsb-release not installed" do
-    let(:facts) { { :osfamily => 'Debian', :puppetversion   => '3.5.0', } }
+    let(:facts) { { :osfamily => 'Debian', :puppetversion   => Puppet.version, } }
     let (:title) { 'my_package' }
 
     it do
@@ -22,18 +22,4 @@ describe 'apt::params', :type => :class do
       }.to raise_error(Puppet::Error, /Unable to determine lsbdistid, please install lsb-release first/)
     end
   end
-
-  describe "With old puppet version" do
-    let(:facts) { { :lsbdistid => 'Debian', :osfamily => 'Debian', :lsbdistcodename => 'wheezy', :lsbdistrelease => 'foo', :lsbdistdescription => 'bar', :lsbminordistrelease => 'baz', :lsbmajdistrelease => 'foobar', :puppetversion   => '3.4.0', } }
-    let(:title) { 'my_package' }
-    it { is_expected.to contain_apt__params }
-
-    # There are 4 resources in this class currently
-    # there should not be any more resources because it is a params class
-    # The resources are class[apt::params], class[main], class[settings], stage[main]
-    it "Should not contain any resources" do
-      expect(subject.call.resources.size).to eq(4)
-    end
-  end
-
 end

--- a/spec/defines/conf_spec.rb
+++ b/spec/defines/conf_spec.rb
@@ -3,7 +3,7 @@ describe 'apt::conf', :type => :define do
   let :pre_condition do
     'class { "apt": }'
   end
-  let(:facts) { { :lsbdistid => 'Debian', :osfamily => 'Debian', :lsbdistcodename => 'wheezy', :puppetversion   => '3.5.0', } }
+  let(:facts) { { :lsbdistid => 'Debian', :osfamily => 'Debian', :lsbdistcodename => 'wheezy', :puppetversion   => Puppet.version, } }
   let :title do
     'norecommends'
   end

--- a/spec/defines/key_spec.rb
+++ b/spec/defines/key_spec.rb
@@ -5,7 +5,7 @@ describe 'apt::key' do
     'class { "apt": }'
   end
 
-  let(:facts) { { :lsbdistid => 'Debian', :osfamily => 'Debian', :lsbdistcodename => 'wheezy', :puppetversion   => '3.5.0', } }
+  let(:facts) { { :lsbdistid => 'Debian', :osfamily => 'Debian', :lsbdistcodename => 'wheezy', :puppetversion   => Puppet.version, } }
 
   GPG_KEY_ID = '47B320EB4C7C375AA9DAE1A01054B7A24BD6EC30'
 

--- a/spec/defines/pin_spec.rb
+++ b/spec/defines/pin_spec.rb
@@ -3,7 +3,7 @@ describe 'apt::pin', :type => :define do
   let :pre_condition do
     'class { "apt": }'
   end
-  let(:facts) { { :lsbdistid => 'Debian', :osfamily => 'Debian', :lsbdistcodename => 'wheezy', :puppetversion   => '3.5.0', } }
+  let(:facts) { { :lsbdistid => 'Debian', :osfamily => 'Debian', :lsbdistcodename => 'wheezy', :puppetversion   => Puppet.version, } }
   let(:title) { 'my_pin' }
 
   context 'defaults' do

--- a/spec/defines/ppa_spec.rb
+++ b/spec/defines/ppa_spec.rb
@@ -12,7 +12,7 @@ describe 'apt::ppa' do
         :operatingsystem => 'Ubuntu',
         :osfamily        => 'Debian',
         :lsbdistid       => 'Ubuntu',
-        :puppetversion   => '3.5.0',
+        :puppetversion   => Puppet.version,
       }
     end
 
@@ -51,7 +51,7 @@ describe 'apt::ppa' do
         :operatingsystem => 'Ubuntu',
         :osfamily        => 'Debian',
         :lsbdistid       => 'Ubuntu',
-        :puppetversion   => '3.5.0',
+        :puppetversion   => Puppet.version,
       }
     end
 
@@ -83,7 +83,7 @@ describe 'apt::ppa' do
         :operatingsystem => 'Ubuntu',
         :osfamily        => 'Debian',
         :lsbdistid       => 'Ubuntu',
-        :puppetversion   => '3.5.0',
+        :puppetversion   => Puppet.version,
       }
     end
     let :params do
@@ -122,7 +122,7 @@ describe 'apt::ppa' do
         :operatingsystem => 'Ubuntu',
         :lsbdistid       => 'Ubuntu',
         :osfamily        => 'Debian',
-        :puppetversion   => '3.5.0',
+        :puppetversion   => Puppet.version,
       }
     end
     let :params do
@@ -158,7 +158,7 @@ describe 'apt::ppa' do
         :operatingsystem => 'Ubuntu',
         :lsbdistid       => 'Ubuntu',
         :osfamily        => 'Debian',
-        :puppetversion   => '3.5.0',
+        :puppetversion   => Puppet.version,
       }
     end
     let :params do
@@ -192,7 +192,7 @@ describe 'apt::ppa' do
         :operatingsystem => 'Ubuntu',
         :lsbdistid       => 'Ubuntu',
         :osfamily        => 'Debian',
-        :puppetversion   => '3.5.0',
+        :puppetversion   => Puppet.version,
       }
     end
     let :params do
@@ -226,7 +226,7 @@ describe 'apt::ppa' do
         :operatingsystem => 'Ubuntu',
         :lsbdistid       => 'Ubuntu',
         :osfamily        => 'Debian',
-        :puppetversion   => '3.5.0',
+        :puppetversion   => Puppet.version,
       }
     end
     let :params do
@@ -258,7 +258,7 @@ describe 'apt::ppa' do
         :operatingsystem => 'Ubuntu',
         :lsbdistid       => 'Ubuntu',
         :osfamily        => 'Debian',
-        :puppetversion   => '3.5.0',
+        :puppetversion   => Puppet.version,
       }
     end
     let(:title) { 'ppa:foo' }
@@ -282,7 +282,7 @@ describe 'apt::ppa' do
           :lsbdistid       => 'Ubuntu',
           :osfamily        => 'Debian',
           :lsbdistcodeanme => nil,
-          :puppetversion   => '3.5.0',
+          :puppetversion   => Puppet.version,
         }
       end
       let(:title) { 'ppa:foo' }
@@ -301,7 +301,7 @@ describe 'apt::ppa' do
           :operatingsystem => 'Debian',
           :lsbdistid       => 'debian',
           :osfamily        => 'Debian',
-          :puppetversion   => '3.5.0',
+          :puppetversion   => Puppet.version,
         }
       end
       let(:title) { 'ppa:foo' }

--- a/spec/defines/setting_spec.rb
+++ b/spec/defines/setting_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'apt::setting' do
   let(:pre_condition) { 'class { "apt": }' }
-  let(:facts) { { :lsbdistid => 'Debian', :osfamily => 'Debian', :lsbdistcodename => 'wheezy', :puppetversion   => '3.5.0', } }
+  let(:facts) { { :lsbdistid => 'Debian', :osfamily => 'Debian', :lsbdistcodename => 'wheezy', :puppetversion   => Puppet.version, } }
   let(:title) { 'conf-teddybear' }
 
   let(:default_params) { { :content => 'di' } }
@@ -61,7 +61,7 @@ describe 'apt::setting' do
       apt::setting { "list-teddybear": content => "foo" }
       '
     end
-    let(:facts) { { :lsbdistid => 'Debian', :osfamily => 'Debian', :lsbdistcodename => 'wheezy', :puppetversion   => '3.5.0', } }
+    let(:facts) { { :lsbdistid => 'Debian', :osfamily => 'Debian', :lsbdistcodename => 'wheezy', :puppetversion   => Puppet.version, } }
     let(:title) { 'conf-teddybear' }
     let(:default_params) { { :content => 'di' } }
 

--- a/spec/defines/source_spec.rb
+++ b/spec/defines/source_spec.rb
@@ -18,7 +18,7 @@ describe 'apt::source' do
           :lsbdistid       => 'Debian',
           :lsbdistcodename => 'wheezy',
           :osfamily        => 'Debian',
-          :puppetversion   => '3.5.0',
+          :puppetversion   => Puppet.version,
         }
       end
       it do
@@ -33,7 +33,7 @@ describe 'apt::source' do
           :lsbdistid       => 'Debian',
           :lsbdistcodename => 'wheezy',
           :osfamily        => 'Debian',
-          :puppetversion   => '3.5.0',
+          :puppetversion   => Puppet.version,
         }
       end
       let(:params) { { :location => 'hello.there', } }
@@ -51,7 +51,7 @@ describe 'apt::source' do
         :lsbdistid       => 'Debian',
         :lsbdistcodename => 'wheezy',
         :osfamily        => 'Debian',
-        :puppetversion   => '3.5.0',
+        :puppetversion   => Puppet.version,
       }
     end
 
@@ -190,7 +190,7 @@ describe 'apt::source' do
         :lsbdistid       => 'Debian',
         :lsbdistcodename => 'wheezy',
         :osfamily        => 'Debian',
-        :puppetversion   => '3.5.0',
+        :puppetversion   => Puppet.version,
       }
     end
     let :params do
@@ -212,7 +212,7 @@ describe 'apt::source' do
         :lsbdistid       => 'Debian',
         :lsbdistcodename => 'wheezy',
         :osfamily        => 'Debian',
-        :puppetversion   => '3.5.0',
+        :puppetversion   => Puppet.version,
       }
     end
     let :params do
@@ -235,7 +235,7 @@ describe 'apt::source' do
         :lsbdistid       => 'Debian',
         :lsbdistcodename => 'wheezy',
         :osfamily        => 'Debian',
-        :puppetversion   => '3.5.0',
+        :puppetversion   => Puppet.version,
       }
     end
     let :params do
@@ -256,7 +256,7 @@ describe 'apt::source' do
         {
           :lsbdistid       => 'Debian',
           :osfamily        => 'Debian',
-          :puppetversion   => '3.5.0',
+          :puppetversion   => Puppet.version,
         }
       end
       let(:params) { { :location => 'hello.there', } }
@@ -274,7 +274,7 @@ describe 'apt::source' do
           :lsbdistid       => 'Debian',
           :lsbdistcodename => 'wheezy',
           :osfamily        => 'Debian',
-          :puppetversion   => '3.5.0',
+          :puppetversion   => Puppet.version,
         }
       end
       let :params do


### PR DESCRIPTION
The puppetversion fact still needs to represent puppet's version that is being used to test