### PR TITLE
Backwards compatibility with older versions of puppet

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -72,13 +72,13 @@ class apt(
   }
 
   $sources_list_content = $_purge['sources.list'] ? {
-    false => undef,
-    true  => "# Repos managed by puppet.\n",
+    true    => "# Repos managed by puppet.\n",
+    default => undef,
   }
 
   $preferences_ensure = $_purge['preferences'] ? {
-    false => file,
-    true  => absent,
+    true    => absent,
+    default => file,
   }
 
   if $_update['frequency'] == 'always' {


### PR DESCRIPTION
What you'll find on older versions of Puppet is that if a hash has a key with a value that is false, the value will not get defined.  Consequently, when you try to match against true or false, an error will be triggered because the value is not defined.  The suggested fix is to match against true and then use default to catch the false case.

I would be happy to write tests/specs for this, but am unsure how to write tests that target specific versions of Puppet.  If you can provide pointers that would be great!
