### PR TITLE
Fix travis.yml for puppet 4

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -7,8 +7,9 @@
     env: PUPPET_GEM_VERSION="~> 3.0" STRICT_VARIABLES="yes" ORDERING="random"
   - rvm: 2.0.0
     env: PUPPET_GEM_VERSION="~> 3.0" STRICT_VARIABLES="yes" ORDERING="random"
-  - rvm: 2.0.0
+  - rvm: 2.1.6
     env: PUPPET_GEM_VERSION="~> 4.0" STRICT_VARIABLES="yes" ORDERING="random"
+    allow_failures:
 Gemfile:
   required:
     ':development, :unit_tests':

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,7 @@ matrix:
     env: PUPPET_GEM_VERSION="~> 3.0" STRICT_VARIABLES="yes" ORDERING="random"
   - rvm: 2.0.0
     env: PUPPET_GEM_VERSION="~> 3.0" STRICT_VARIABLES="yes" ORDERING="random"
-  - rvm: 2.0.0
+  - rvm: 2.1.6
     env: PUPPET_GEM_VERSION="~> 4.0" STRICT_VARIABLES="yes" ORDERING="random"
-  allow_failures:
-    - rvm: 2.1.6
-      env: PUPPET_GEM_VERSION="~> 4.0" STRICT_VARIABLES="yes"
 notifications:
   email: false


### PR DESCRIPTION
I accidentally pushed a commit with modulesync that made puppet 4 a
non-voting job. This should make it more in line with modulesync.

Also, we should look at bumping these ORDERING="random" changes back to
msync if they are valuable.