### PR TITLE
Added additional header template for apt.conf style comments

### DIFF
--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -13,6 +13,6 @@ define apt::conf (
   apt::setting { "conf-${name}":
     ensure   => $ensure,
     priority => $priority,
-    content  => template('apt/_header.erb', 'apt/conf.erb'),
+    content  => template('apt/_conf_header.erb', 'apt/conf.erb'),
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -67,7 +67,7 @@ class apt(
   if $proxy['host'] {
     apt::setting { 'conf-proxy':
       priority => '01',
-      content  => template('apt/_header.erb', 'apt/proxy.erb'),
+      content  => template('apt/_conf_header.erb', 'apt/proxy.erb'),
     }
   }
 
@@ -89,7 +89,7 @@ class apt(
 
   apt::setting { 'conf-update-stamp':
     priority => 15,
-    content  => template('apt/_header.erb', 'apt/15update-stamp.erb'),
+    content  => template('apt/_conf_header.erb', 'apt/15update-stamp.erb'),
   }
 
   file { 'sources.list':

--- a/templates/_conf_header.erb
+++ b/templates/_conf_header.erb
@@ -1,0 +1,1 @@
+// This file is managed by Puppet. DO NOT EDIT.


### PR DESCRIPTION
Added additional header comment file for apt.conf files.

apt.conf does not use # as the comment character.  Using # as the comment character can cause errors like this:
"Error: /Stage[main]/base::Install/Package[bash]/ensure: change from 3.2-4 to latest failed: Could not get latest version: Execution of '/usr/bin/apt-cache policy bash' returned 100: E: Syntax error /etc/apt/apt.conf.d/15update-stamp:2: Extra junk after value"

From the apt.conf man page:
"Lines starting with // are treated as comments (ignored), as well as all text between /* and */, just like C/C++ comments."
http://manpages.ubuntu.com/manpages/vivid/man5/apt.conf.5.html#contenttoc2