### PR TITLE
Fix use of $::apt::params::backports and $::apt::params::xfacts.

### DIFF
--- a/manifests/backports.pp
+++ b/manifests/backports.pp
@@ -4,7 +4,7 @@ class apt::backports (
   $repos    = undef,
   $key      = undef,
   $pin      = 200,
-){
+) inherits apt::params {
   if $location {
     validate_string($location)
     $_location = $location
@@ -29,18 +29,18 @@ class apt::backports (
     }
   }
 
-  if ($::apt::xfacts['lsbdistid'] == 'debian' or $::apt::xfacts['lsbdistid'] == 'ubuntu') {
+  if ($::apt::params::xfacts['lsbdistid'] == 'debian' or $::apt::params::xfacts['lsbdistid'] == 'ubuntu') {
     unless $location {
-      $_location = $::apt::backports['location']
+      $_location = $::apt::params::backports['location']
     }
     unless $release {
-      $_release = "${::apt::xfacts['lsbdistcodename']}-backports"
+      $_release = "${::apt::params::xfacts['lsbdistcodename']}-backports"
     }
     unless $repos {
-      $_repos = $::apt::backports['repos']
+      $_repos = $::apt::params::backports['repos']
     }
     unless $key {
-      $_key =  $::apt::backports['key']
+      $_key =  $::apt::params::backports['key']
     }
   } else {
     unless $location and $release and $repos and $key {

--- a/manifests/ppa.pp
+++ b/manifests/ppa.pp
@@ -2,15 +2,17 @@
 define apt::ppa(
   $ensure         = 'present',
   $options        = $::apt::ppa_options,
-  $release        = $::apt::xfacts['lsbdistcodename'],
+  $release        = $::apt::params::xfacts['lsbdistcodename'],
   $package_name   = $::apt::ppa_package,
   $package_manage = false,
 ) {
+  include 'apt::params'
+
   unless $release {
     fail('lsbdistcodename fact not available: release parameter required')
   }
 
-  if $::apt::xfacts['lsbdistid'] == 'Debian' {
+  if $::apt::params::xfacts['lsbdistid'] == 'Debian' {
     fail('apt::ppa is not currently supported on Debian.')
   }
 


### PR DESCRIPTION
This commit fixes the usage of 2 default parameters which were misnamed $::apt::backports and $apt::xfacts and adds missing "inherits apt::params" or "include apt::params".
