### PR TITLE
Expose notify_update to apt::conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,8 @@ Specifies a custom Apt configuration file.
 
 * `priority`: *Optional.* Determines the order in which Apt processes the configuration file. Files with lower priority numbers are loaded first. Valid options: a string containing an integer. Default: '50'.
 
+* `notify_update`: *Optional.* Specifies whether to trigger an `apt-get update` run. Valid options: 'true' and 'false'. Default: 'true'.
+
 #### Define: `apt::key`
 
 Manages the GPG keys that Apt uses to authenticate packages.
@@ -323,7 +325,7 @@ The `apt::key` define makes use of the `apt_key` type, but includes extra functi
 
 #### Define: `apt::pin`
 
-Manages Apt pins.
+Manages Apt pins. Does not trigger an `apt-get update` run.
 
 **Note:** For context on these parameters, we recommend reading the man page ['apt_preferences(5)'](http://linux.die.net/man/5/apt_preferences)
 

--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -1,7 +1,8 @@
 define apt::conf (
-  $content  = undef,
-  $ensure   = present,
-  $priority = '50',
+  $content       = undef,
+  $ensure        = present,
+  $priority      = '50',
+  $notify_update = undef,
 ) {
 
   unless $ensure == 'absent' {
@@ -11,8 +12,9 @@ define apt::conf (
   }
 
   apt::setting { "conf-${name}":
-    ensure   => $ensure,
-    priority => $priority,
-    content  => template('apt/_conf_header.erb', 'apt/conf.erb'),
+    ensure        => $ensure,
+    priority      => $priority,
+    content       => template('apt/_conf_header.erb', 'apt/conf.erb'),
+    notify_update => $notify_update,
   }
 }

--- a/manifests/pin.pp
+++ b/manifests/pin.pp
@@ -72,8 +72,9 @@ define apt::pin(
   $file_name = regsubst($title, '[^0-9a-z\-_\.]', '_', 'IG')
 
   apt::setting { "pref-${file_name}":
-    ensure   => $ensure,
-    priority => $order,
-    content  => template('apt/_header.erb', 'apt/pin.pref.erb'),
+    ensure        => $ensure,
+    priority      => $order,
+    content       => template('apt/_header.erb', 'apt/pin.pref.erb'),
+    notify_update => false,
   }
 }

--- a/spec/defines/conf_spec.rb
+++ b/spec/defines/conf_spec.rb
@@ -9,11 +9,14 @@ describe 'apt::conf', :type => :define do
   end
 
   describe "when creating an apt preference" do
-    let :params do
+    let :default_params do
       {
         :priority => '00',
         :content  => "Apt::Install-Recommends 0;\nApt::AutoRemove::InstallRecommends 1;\n"
       }
+    end
+    let :params do
+      default_params
     end
 
     let :filename do
@@ -28,6 +31,22 @@ describe 'apt::conf', :type => :define do
           'mode'      => '0644',
         })
       }
+
+    context "with notify_update = true (default)" do
+      let :params do
+        default_params
+      end
+      it { is_expected.to contain_apt__setting("conf-#{title}").with_notify_update(true) }
+    end
+
+    context "with notify_update = false" do
+      let :params do
+        default_params.merge({
+          :notify_update => false
+        })
+      end
+      it { is_expected.to contain_apt__setting("conf-#{title}").with_notify_update(false) }
+    end
   end
 
   describe "when creating a preference without content" do


### PR DESCRIPTION
Created ticket: https://tickets.puppetlabs.com/browse/MODULES-2269

This pull request simply exposes notify_update parameter of underlying apt::setting defined type to the apt::conf defined type as it isn't always appropriate to trigger an update for a specific configuration file.

I don't believe apt::pin shouldn't trigger an update either (set notify_update to false) - however willing to rework this if people disagree and simply expose notify_update as for apt::conf.

Happy to discuss further.
Thanks