### PR TITLE
preferences.d fix

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -61,7 +61,7 @@ class apt::params {
     },
     'pref'   => {
       'path' => $preferences_d,
-      'ext'  => '',
+      'ext'  => '.pref',
     },
     'list'   => {
       'path' => $sources_list_d,

--- a/spec/defines/setting_spec.rb
+++ b/spec/defines/setting_spec.rb
@@ -22,7 +22,7 @@ describe 'apt::setting' do
     context 'with title=pref-teddybear' do
       let(:title) { 'pref-teddybear' }
       let(:params) { default_params }
-      it { is_expected.to contain_file('/etc/apt/preferences.d/50teddybear').that_notifies('Class[Apt::Update]') }
+      it { is_expected.to contain_file('/etc/apt/preferences.d/50teddybear.pref').that_notifies('Class[Apt::Update]') }
     end
 
     context 'with title=list-teddybear' do


### PR DESCRIPTION
If a file in /etc/apt/preferences.d has a period in its name, apt will ignore it:
```
N: Ignoring file '50hold_puppet_3.7.3-1puppetlabs1' in directory '/etc/apt/preferences.d/' as it has an invalid filename extension
```

The same file named `50asdfasfdasdf` would not be ignored, even though there is no extension.

Adding `.pref` to the filename keeps apt happy, even if there are periods earlier on in the filename.