### PR TITLE
Puppet 2.7 fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ matrix:
   fast_finish: true
   include:
   - rvm: 1.8.7
+    env: PUPPET_GEM_VERSION="~> 2.7"
+  - rvm: 1.8.7
     env: PUPPET_GEM_VERSION="~> 3.0"
   - rvm: 1.9.3
     env: PUPPET_GEM_VERSION="~> 3.0"

--- a/manifests/backports.pp
+++ b/manifests/backports.pp
@@ -14,7 +14,7 @@
 #
 # == Examples
 #
-#   include apt::backports
+#   include ::apt::backports
 #
 #   class { 'apt::backports':
 #     release => 'natty',
@@ -31,7 +31,7 @@
 class apt::backports(
   $release      = $::lsbdistcodename,
   $location     = $::apt::params::backports_location,
-  $pin_priority = 200,
+  $pin_priority = 200
 ) inherits apt::params {
 
   if ! is_integer($pin_priority) {

--- a/manifests/builddep.pp
+++ b/manifests/builddep.pp
@@ -1,7 +1,7 @@
 # builddep.pp
 
 define apt::builddep() {
-  include apt::update
+  include ::apt::update
 
   exec { "apt-builddep-${name}":
     command   => "/usr/bin/apt-get -y --force-yes build-dep ${name}",

--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -4,7 +4,7 @@ define apt::conf (
   $priority = '50'
 ) {
 
-  include apt::params
+  include ::apt::params
 
   $apt_conf_d = $apt::params::apt_conf_d
 

--- a/manifests/debian/testing.pp
+++ b/manifests/debian/testing.pp
@@ -1,7 +1,7 @@
 # testing.pp
 
 class apt::debian::testing {
-  include apt
+  include ::apt
 
   # deb http://debian.mirror.iweb.ca/debian/ testing main contrib non-free
   # deb-src http://debian.mirror.iweb.ca/debian/ testing main contrib non-free

--- a/manifests/debian/unstable.pp
+++ b/manifests/debian/unstable.pp
@@ -1,7 +1,7 @@
 # unstable.pp
 
 class apt::debian::unstable {
-  include apt
+  include ::apt
 
   # deb http://debian.mirror.iweb.ca/debian/ unstable main contrib non-free
   # deb-src http://debian.mirror.iweb.ca/debian/ unstable main contrib non-free

--- a/manifests/force.pp
+++ b/manifests/force.pp
@@ -6,7 +6,7 @@ define apt::force(
   $version     = false,
   $timeout     = 300,
   $cfg_files   = 'none',
-  $cfg_missing = false,
+  $cfg_missing = false
 ) {
 
   validate_re($cfg_files, ['^new', '^old', '^unchanged', '^none'])

--- a/manifests/hold.pp
+++ b/manifests/hold.pp
@@ -27,7 +27,7 @@ define apt::hold(
   $version,
   $ensure   = 'present',
   $package  = $title,
-  $priority = 1001,
+  $priority = 1001
 ){
 
   validate_string($title)

--- a/manifests/key.pp
+++ b/manifests/key.pp
@@ -56,7 +56,7 @@ define apt::key (
   $key_content = undef,
   $key_source  = undef,
   $key_server  = undef,
-  $key_options = undef,
+  $key_options = undef
 ) {
 
   validate_re($key, ['\A(0x)?[0-9a-fA-F]{8}\Z', '\A(0x)?[0-9a-fA-F]{16}\Z', '\A(0x)?[0-9a-fA-F]{40}\Z'])

--- a/manifests/ppa.pp
+++ b/manifests/ppa.pp
@@ -5,7 +5,7 @@ define apt::ppa(
   $release        = $::lsbdistcodename,
   $options        = $::apt::params::ppa_options,
   $package_name   = $::apt::params::ppa_package,
-  $package_manage = true,
+  $package_manage = true
 ) {
   include apt::params
   include apt::update

--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -16,7 +16,7 @@ define apt::source(
   $key_source        = undef,
   $pin               = false,
   $architecture      = undef,
-  $trusted_source    = false,
+  $trusted_source    = false
 ) {
 
   include apt::params

--- a/manifests/unattended_upgrades.pp
+++ b/manifests/unattended_upgrades.pp
@@ -37,7 +37,7 @@ class apt::unattended_upgrades (
   $min_age             = '0',
   $max_size            = '0',
   $download_delta      = '0',
-  $verbose             = '0',
+  $verbose             = '0'
 ) inherits ::apt::params {
 
   validate_bool(
@@ -52,7 +52,7 @@ class apt::unattended_upgrades (
   validate_array($origins)
 
   if $randomsleep {
-    unless is_numeric($randomsleep) {
+    if ! is_numeric($randomsleep) {
       fail('randomsleep must be numeric')
     }
   }


### PR DESCRIPTION
Various fixes required to get the legacy 1.8.x release working with Puppet 2.7