### PR TITLE
Proxy ensure parameter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,8 @@ Main class, includes all other classes.
 
   * 'https': Specifies whether to enable https proxies. Valid options: 'true' and 'false'. Default: 'false'.
 
+  * 'ensure': Optional parameter. Valid options: 'file', 'present', and 'absent'. Default: 'undef'. Prefer 'file' over 'present'.
+
 * `purge`: Specifies whether to purge any existing settings that aren't managed by Puppet. Valid options: a hash made up from the following keys:
 
   * 'sources.list': Specifies whether to purge any unmanaged entries from `sources.list`. Valid options: 'true' and 'false'. Default: 'false'.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -45,6 +45,9 @@ class apt(
   $_purge = merge($::apt::purge_defaults, $purge)
 
   validate_hash($proxy)
+  if $proxy['ensure'] {
+    validate_re($proxy['ensure'], ['file', 'present', 'absent'])
+  }
   if $proxy['host'] {
     validate_string($proxy['host'])
   }
@@ -64,8 +67,9 @@ class apt(
   validate_hash($settings)
   validate_hash($ppas)
 
-  if $proxy['host'] {
+  if $_proxy['ensure'] == 'absent' or $_proxy['host'] {
     apt::setting { 'conf-proxy':
+      ensure   => $_proxy['ensure'],
       priority => '01',
       content  => template('apt/_conf_header.erb', 'apt/proxy.erb'),
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -76,9 +76,10 @@ class apt::params {
   }
 
   $proxy_defaults = {
-    'host'  => undef,
-    'port'  => 8080,
-    'https' => false,
+    'ensure' => undef,
+    'host'   => undef,
+    'port'   => 8080,
+    'https'  => false,
   }
 
   $purge_defaults = {

--- a/spec/classes/apt_spec.rb
+++ b/spec/classes/apt_spec.rb
@@ -91,6 +91,14 @@ describe 'apt' do
         /Acquire::https::proxy "https:\/\/localhost:8080\/";/
       )}
     end
+
+    context 'ensure=absent' do
+      let(:params) { { :proxy => { 'ensure' => 'absent'} } }
+      it { is_expected.to contain_apt__setting('conf-proxy').with({
+        :ensure   => 'absent',
+        :priority => '01',
+      })}
+    end
   end
   context 'lots of non-defaults' do
     let :params do


### PR DESCRIPTION
Added an ensure parameter for user control of proxy presence. Defaults to undef to resist breaking any current setup.