### PR TITLE
Corrected regression with preference files name (since 2.0.0)

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -61,7 +61,7 @@ class apt::params {
     },
     'pref'   => {
       'path' => $preferences_d,
-      'ext'  => '',
+      'ext'  => '.pref',
     },
     'list'   => {
       'path' => $sources_list_d,

--- a/manifests/setting.pp
+++ b/manifests/setting.pp
@@ -37,7 +37,7 @@ define apt::setting (
     validate_string($content)
   }
 
-  if $setting_type == 'list' {
+  if ($setting_type == 'list') or ($setting_type == 'pref') {
     $_priority = ''
   } else {
     $_priority = $priority

--- a/spec/defines/setting_spec.rb
+++ b/spec/defines/setting_spec.rb
@@ -22,7 +22,7 @@ describe 'apt::setting' do
     context 'with title=pref-teddybear' do
       let(:title) { 'pref-teddybear' }
       let(:params) { default_params }
-      it { is_expected.to contain_file('/etc/apt/preferences.d/50teddybear').that_notifies('Class[Apt::Update]') }
+      it { is_expected.to contain_file('/etc/apt/preferences.d/teddybear.pref').that_notifies('Class[Apt::Update]') }
     end
 
     context 'with title=list-teddybear' do


### PR DESCRIPTION
Corrected a regression introduced by https://github.com/puppetlabs/puppetlabs-apt/commit/351c8d5941f6bd02304df6b4185dea8c8104aefa
(Default value of 50 was used for priority param when apt::setting is called inside pin.pp)

Added changes from https://github.com/puppetlabs/puppetlabs-apt/pull/554