### PR TITLE
MODULES-2446 - Fix pinning for backports

### DIFF
--- a/manifests/backports.pp
+++ b/manifests/backports.pp
@@ -23,12 +23,6 @@ class apt::backports (
     }
     $_key = $key
   }
-  unless is_hash($pin) {
-    unless (is_numeric($pin) or is_string($pin)) {
-      fail('pin must be either a string, number or hash')
-    }
-  }
-
   if ($::apt::xfacts['lsbdistid'] == 'debian' or $::apt::xfacts['lsbdistid'] == 'ubuntu') {
     unless $location {
       $_location = $::apt::backports['location']
@@ -48,12 +42,24 @@ class apt::backports (
     }
   }
 
+  if is_hash($pin) {
+    $_pin = $pin
+  } elsif is_numeric($pin) or is_string($pin) {
+    # apt::source defaults to pinning to origin, but we should pin to release
+    # for backports
+    $_pin = {
+      'priority' => $pin,
+      'release'  => $_release,
+    }
+  } else {
+    fail('pin must be either a string, number or hash')
+  }
+
   apt::source { 'backports':
     location => $_location,
     release  => $_release,
     repos    => $_repos,
     key      => $_key,
-    pin      => $pin,
+    pin      => $_pin,
   }
-
 }

--- a/spec/classes/apt_backports_spec.rb
+++ b/spec/classes/apt_backports_spec.rb
@@ -18,7 +18,7 @@ describe 'apt::backports', :type => :class do
         :key      => 'A1BD8E9D78F7FE5C3E65D8AF8B48AD6246925553',
         :repos    => 'main contrib non-free',
         :release  => 'wheezy-backports',
-        :pin      => 200,
+        :pin      => { 'priority' => 200, 'release' => 'wheezy-backports' },
       })
       }
     end
@@ -36,7 +36,7 @@ describe 'apt::backports', :type => :class do
         :key      => 'A1BD8E9D78F7FE5C3E65D8AF8B48AD6246925553',
         :repos    => 'main contrib non-free',
         :release  => 'squeeze-backports',
-        :pin      => 200,
+        :pin      => { 'priority' => 200, 'release' => 'squeeze-backports' },
       })
       }
     end
@@ -54,7 +54,7 @@ describe 'apt::backports', :type => :class do
         :key      => '630239CC130E1A7FD81A27B140976EAF437D05B5',
         :repos    => 'main universe multiverse restricted',
         :release  => 'trusty-backports',
-        :pin      => 200,
+        :pin      => { 'priority' => 200, 'release' => 'trusty-backports' },
       })
       }
     end
@@ -81,7 +81,7 @@ describe 'apt::backports', :type => :class do
         :key      => 'A1BD8E9D78F7FE5C3E65D8AF8B48AD6246925553',
         :repos    => 'main',
         :release  => 'vivid',
-        :pin      => 90,
+        :pin      => { 'priority' => 90, 'release' => 'vivid' },
       })
       }
     end
@@ -134,7 +134,7 @@ describe 'apt::backports', :type => :class do
         :key      => '630239CC130E1A7FD81A27B140976EAF437D05B5',
         :repos    => 'main universe multiverse restricted',
         :release  => 'trusty-backports',
-        :pin      => 200,
+        :pin      => { 'priority' => 200, 'release' => 'trusty-backports' },
       })
       }
     end


### PR DESCRIPTION
The 2.x series added a changed behavior for backport pinning to pin to
origin instead of release. Pinning to release is the correct behavior
for backports though.