### PR TITLE
 add support for pins class parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,8 @@ Main class, includes all other classes.
 
 * `sources`: Creates new `apt::source` resources. Valid options: a hash to be passed to the [`create_resources` function](https://docs.puppetlabs.com/references/latest/function.html#createresources). Default: {}.
 
+* `pins`: Creates new `apt::pin` resources. Valid options: a hash to be passed to the [`create_resources` function](https://docs.puppetlabs.com/references/latest/function.html#createresources). Default: {}.
+
 * `update`: Configures various update settings. Valid options: a hash made up from the following keys:
 
   * 'frequency': Specifies how often to run `apt-get update`. If the exec resource `apt_update` is notified, `apt-get update` runs regardless of this value. Valid options: 'always' (at every Puppet run); 'daily' (if the value of `apt_update_last_success` is less than current epoch time minus 86400); 'weekly' (if the value of `apt_update_last_success` is less than current epoch time minus 604800); and 'reluctantly' (only if the exec resource `apt_update` is notified). Default: 'reluctantly'.

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ Main class, includes all other classes.
 
 * `settings`: Creates new `apt::setting` resources. Valid options: a hash to be passed to the [`create_resources` function](https://docs.puppetlabs.com/references/latest/function.html#createresources). Default: {}.
 
-* `sources`: Creates new `apt::setting` resources. Valid options: a hash to be passed to the [`create_resources` function](https://docs.puppetlabs.com/references/latest/function.html#createresources). Default: {}.
+* `sources`: Creates new `apt::source` resources. Valid options: a hash to be passed to the [`create_resources` function](https://docs.puppetlabs.com/references/latest/function.html#createresources). Default: {}.
 
 * `update`: Configures various update settings. Valid options: a hash made up from the following keys:
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,6 +6,7 @@ class apt(
   $sources  = {},
   $keys     = {},
   $ppas     = {},
+  $pins     = {},
   $settings = {},
 ) inherits ::apt::params {
 
@@ -66,6 +67,7 @@ class apt(
   validate_hash($keys)
   validate_hash($settings)
   validate_hash($ppas)
+  validate_hash($pins)
 
   if $_proxy['ensure'] == 'absent' or $_proxy['host'] {
     apt::setting { 'conf-proxy':
@@ -152,5 +154,10 @@ class apt(
   # manage settings if present
   if $settings {
     create_resources('apt::setting', $settings)
+  }
+
+  # manage pins if present
+  if $pins {
+    create_resources('apt::pin', $pins)
   }
 }

--- a/manifests/pin.pp
+++ b/manifests/pin.pp
@@ -4,7 +4,7 @@
 define apt::pin(
   $ensure          = present,
   $explanation     = undef,
-  $order           = undef,
+  $order           = 50,
   $packages        = '*',
   $priority        = 0,
   $release         = '', # a=

--- a/manifests/pin.pp
+++ b/manifests/pin.pp
@@ -4,7 +4,7 @@
 define apt::pin(
   $ensure          = present,
   $explanation     = undef,
-  $order           = 50,
+  $order           = undef,
   $packages        = '*',
   $priority        = 0,
   $release         = '', # a=

--- a/spec/classes/apt_spec.rb
+++ b/spec/classes/apt_spec.rb
@@ -237,6 +237,23 @@ describe 'apt' do
     it { is_expected.to contain_apt__setting('pref-banana')}
   end
 
+  context 'with pins defined on valid osfamily' do
+    let :facts do
+      { :osfamily        => 'Debian',
+        :lsbdistcodename => 'precise',
+        :lsbdistid       => 'Debian',
+        :puppetversion   => Puppet.version,
+      }
+    end
+    let(:params) { { :pins => {
+      'stable' => { 'priority' => 600, 'order' => 50 },
+      'testing' =>  { 'priority' => 700, 'order' => 100 },
+    } } }
+
+    it { is_expected.to contain_apt__pin('stable') }
+    it { is_expected.to contain_apt__pin('testing') }
+  end
+
   describe 'failing tests' do
     context "purge['sources.list']=>'banana'" do
       let(:params) { { :purge => { 'sources.list' => 'banana' }, } }


### PR DESCRIPTION
This lets you send apt::pin resources as an apt param hash.  This is a
very simple change that is just like sources, ppa, settings and other
options.

This is mainly to make supporting pins in foreman easier.