### PR TITLE
Class to support using HTTPS repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,22 @@ apt::source { 'puppetlabs':
 },
 ~~~
 
+### Add an Apt source served over HTTPS
+
+~~~puppet
+include apt::transport_https
+
+apt::source { 'nodesource':
+  location => "https://deb.nodesource.com/node_0.10",
+  release  => $::lsbdistcodename,
+  repos    => 'main',
+  key      => {
+    'id'     => '9FD3B784BC1C6FC31A8A0A1C1655A0AB68576280',
+    'source' => 'https://deb.nodesource.com/gpgkey/nodesource.gpg.key',
+  }
+}
+~~~
+
 ### Configure Apt from Hiera
 
 ~~~yaml
@@ -180,6 +196,7 @@ apt::sources:
 
 * [`apt`](#class-apt)
 * [`apt::backports`](#class-aptbackports)
+* [`apt::transport_https`](#class-apttransport_https)
 
 #### Private Classes
 
@@ -278,6 +295,14 @@ Manages backports.
 
   * Debian: 'main contrib non-free'
   * Ubuntu: 'main universe multiverse restricted'
+
+#### Class: `apt::transport_https`
+
+Enables APT sources served over HTTPS.
+
+##### Parameters (all optional)
+
+* `ensure`: The installed state of the necessary packages. Valid options: 'present', 'absent', 'purged', 'held', and 'latest'. Default: 'present'.
 
 #### Define: `apt::conf`
 

--- a/manifests/transport_https.pp
+++ b/manifests/transport_https.pp
@@ -1,0 +1,12 @@
+# Allow APT to use repos served over HTTPS
+class apt::transport_https (
+  $ensure = 'present'
+) {
+  if $ensure !~ /^(present|absent|purged|held|latest)$/ {
+    fail('ensure must be either present, absent, purged, held, or latest')
+  }
+
+  package { ['apt-transport-https', 'ca-certificates']:
+    ensure => $ensure,
+  }
+}

--- a/spec/classes/apt_transport_https.rb
+++ b/spec/classes/apt_transport_https.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+describe 'apt::transport_https', :type => :class do
+  let(:facts) {
+    {
+      :lsbdistid       => 'Debian',
+      :osfamily        => 'Debian',
+      :lsbdistcodename => 'wheezy',
+      :puppetversion   => Puppet.version,
+    }
+  }
+  let (:title) { 'my_package' }
+
+  it { is_expected.to contain_apt__transport_https }
+
+  # This only installs two packages
+  it 'Should contain two resources' do
+    expect(subject.call.resources.size).to eq(2)
+  end
+
+  it { is_expected.to contain_package('apt-transport-https') }
+  it { is_expected.to contain_package('ca-certificates') }
+
+  context 'invalid ensure' do
+    let(:params) do
+      {
+        :ensure => true
+      }
+    end
+    it do
+      expect {
+        subject.call
+      }.to raise_error(Puppet::Error, /ensure must be either present, absent, purged, held, or latest/)
+    end
+  end
+end


### PR DESCRIPTION
This changes allows the use of repos served over HTTPS by just adding

~~~puppet
include ::apt::transport_https
~~~

The class is not automatically included when a HTTPS source is detected so that it doesn't cause conflicts for people already installing the necessary packages.