### PR TITLE
Add support for creating pins from main class

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,9 @@ Main class, includes all other classes.
 
 * `settings`: Creates new `apt::setting` resources. Valid options: a hash to be passed to the [`create_resources` function](https://docs.puppetlabs.com/references/latest/function.html#createresources). Default: {}.
 
-* `sources`: Creates new `apt::setting` resources. Valid options: a hash to be passed to the [`create_resources` function](https://docs.puppetlabs.com/references/latest/function.html#createresources). Default: {}.
+* `sources`: Creates new `apt::source` resources. Valid options: a hash to be passed to the [`create_resources` function](https://docs.puppetlabs.com/references/latest/function.html#createresources). Default: {}.
+
+* `pins`: Creates new `apt::pin` resources. Valid options: a hash to be passed to the [`create_resources` function](https://docs.puppetlabs.com/references/latest/function.html#createresources). Default: {}.
 
 * `update`: Configures various update settings. Valid options: a hash made up from the following keys:
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,6 +6,7 @@ class apt(
   $sources  = {},
   $keys     = {},
   $ppas     = {},
+  $pins     = {},
   $settings = {},
 ) inherits ::apt::params {
 
@@ -66,6 +67,7 @@ class apt(
   validate_hash($keys)
   validate_hash($settings)
   validate_hash($ppas)
+  validate_hash($pins)
 
   if $_proxy['ensure'] == 'absent' or $_proxy['host'] {
     apt::setting { 'conf-proxy':
@@ -152,5 +154,10 @@ class apt(
   # manage settings if present
   if $settings {
     create_resources('apt::setting', $settings)
+  }
+
+  # manage pins if present
+  if $pins {
+    create_resources('apt::pin', $pins)
   }
 }

--- a/spec/classes/apt_spec.rb
+++ b/spec/classes/apt_spec.rb
@@ -237,6 +237,23 @@ describe 'apt' do
     it { is_expected.to contain_apt__setting('pref-banana')}
   end
 
+  context 'with pins defined on valid osfamily' do
+    let :facts do
+      { :osfamily        => 'Debian',
+        :lsbdistcodename => 'precise',
+        :lsbdistid       => 'Debian',
+        :puppetversion   => Puppet.version,
+      }
+    end
+    let(:params) { { :pins => {
+      'stable' => { 'priority' => 600, 'order' => 50 },
+      'testing' =>  { 'priority' => 700, 'order' => 100 },
+    } } }
+
+    it { is_expected.to contain_apt__pin('stable') }
+    it { is_expected.to contain_apt__pin('testing') }
+  end
+
   describe 'failing tests' do
     context "purge['sources.list']=>'banana'" do
       let(:params) { { :purge => { 'sources.list' => 'banana' }, } }


### PR DESCRIPTION
This lets you create apt::pin resources as an apt param hash.  It also
supplies appropriate tests and documentation.