### PR TITLE
Adding small documentation clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ apt::source { 'puppetlabs':
 ~~~
 
 ### Configure Apt from Hiera
+The apt class will automatically look for a hiera data value called apt::sources and there is 
+thus no need to call create_resources. Doing so will cause a duplicate resource declaration.
 
 ~~~yaml
 apt::sources:


### PR DESCRIPTION
Having spend some time wondering why I got a duplicate_resource definition, I thought it would be worth while to clarify the documentation a bit. It is important to know what the module will be doing in the background.