### PR TITLE
Change behavior with port in URI location

### DIFF
--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -123,12 +123,12 @@ define apt::source(
       $_pin = merge($pin, { 'ensure' => $ensure, 'before' => $_before })
     } elsif (is_numeric($pin) or is_string($pin)) {
       $url_split = split($location, '/')
-      $host      = $url_split[2]
+      $host      = split($url_split[2], ':')
       $_pin = {
         'ensure'   => $ensure,
         'priority' => $pin,
         'before'   => $_before,
-        'origin'   => $host,
+        'origin'   => $host[0],
       }
     } else {
       fail('Received invalid value for pin parameter')

--- a/spec/defines/source_spec.rb
+++ b/spec/defines/source_spec.rb
@@ -81,6 +81,22 @@ describe 'apt::source' do
       }
     end
 
+    context 'with complex location' do
+      let :params do
+        {
+          :comment  => 'foo',
+          :location => 'http://10.0.0.1:8000/debian/',
+          :release  => 'sid',
+          :repos    => 'testing',
+          :pin      => '1050',
+        }
+      end
+      it { is_expected.to contain_apt__pin('my_source').with({
+        :origin   => '10.0.0.1',
+      })
+      }
+    end
+
     context 'with simple key' do
       let :params do
         {


### PR DESCRIPTION
When location contains port in URI, pinning policy are set to default
(500) even if config has higher value. This patch strips port from URI
leaving Host only.