### PR TITLE
Correct an issue where an extra linebreak is added to a source list

### DIFF
--- a/templates/source.list.erb
+++ b/templates/source.list.erb
@@ -1,9 +1,7 @@
 # <%= @comment %>
 <%- if @_include['deb'] then -%>
-deb <%- if @architecture or @_allow_unsigned -%>
-[<%- if @architecture %>arch=<%= @architecture %><% end %><%if @architecture and @_allow_unsigned %> <% end%><% if @_allow_unsigned %>trusted=yes<% end %>] <%- end %><%= @location %> <%= @_release %> <%= @repos %>
+deb <%- if @architecture or @_allow_unsigned -%> [<%- if @architecture %>arch=<%= @architecture %><% end %><%if @architecture and @_allow_unsigned %> <% end%><% if @_allow_unsigned %>trusted=yes<% end %>] <%- end %><%= @location %> <%= @_release %> <%= @repos %>
 <%- end -%>
 <%- if @_include['src'] then -%>
-deb-src <%- if @architecture or @_allow_unsigned -%>
-[<%- if @architecture %>arch=<%= @architecture %><% end %><%if @architecture and @_allow_unsigned %> <% end%><% if @_allow_unsigned %>trusted=yes<% end %>] <%- end %><%= @location %> <%= @_release %> <%= @repos %>
+deb-src <%- if @architecture or @_allow_unsigned -%> [<%- if @architecture %>arch=<%= @architecture %><% end %><%if @architecture and @_allow_unsigned %> <% end%><% if @_allow_unsigned %>trusted=yes<% end %>] <%- end %><%= @location %> <%= @_release %> <%= @repos %>
 <%- end -%>


### PR DESCRIPTION
When specifying the architecture for a source, an extra linebreak is added to the source list file, which apt reports as invalid. This change removes the extra linebreak.