### PR TITLE
Using ensure_resource to avoid multiple package resource declarations

### DIFF
--- a/manifests/ppa.pp
+++ b/manifests/ppa.pp
@@ -21,7 +21,7 @@ define apt::ppa(
 
   if $ensure == 'present' {
     if $package_manage {
-      package { $package_name: }
+      ensure_resource('package', $package_name, {})
 
       $_require = [File['sources.list.d'], Package[$package_name]]
     } else {


### PR DESCRIPTION
When you specify `package_manage => true` on two or more `apt::ppa` resources, the current code causes multiple `Package[$package_name]` resources to be declared - and things break.

This module already depends on forge module `puppetlabs/stdlib` `>= 4.5.0 < 5.0.0`, so it's quite easy to leverage the `ensure_resource()` function which was introduced in `4.1.0`.