### PR TITLE
Make apt_updates facts use /usr/bin/apt-get.

### DIFF
--- a/lib/facter/apt_updates.rb
+++ b/lib/facter/apt_updates.rb
@@ -1,16 +1,32 @@
 apt_package_updates = nil
 Facter.add("apt_has_updates") do
   confine :osfamily => 'Debian'
-  if File.executable?("/usr/lib/update-notifier/apt-check")
-    apt_check_result = Facter::Util::Resolution.exec('/usr/lib/update-notifier/apt-check 2>&1')
-    if not apt_check_result.nil? and apt_check_result =~ /^\d+;\d+$/
-      apt_package_updates = apt_check_result.split(';')
+  if File.executable?("/usr/bin/apt-get")
+    apt_get_result = Facter::Util::Resolution.exec('/usr/bin/apt-get -s upgrade 2>&1')
+    if not apt_get_result.nil?
+      apt_package_updates = [[], []]
+      apt_get_result.each_line do |line|
+        if line =~ /^Inst\s/
+          package = line.gsub(/^Inst\s([^\s]+)\s.*/, '\1').strip
+          apt_package_updates[0].push(package)
+          security_matches = [
+            / Debian[^\s]+-updates /,
+            / Debian-Security:/,
+            / Ubuntu[^\s]+-security /,
+            / gNewSense[^\s]+-security /
+          ]
+          re = Regexp.union(security_matches)
+          if line.match(re)
+            apt_package_updates[1].push(package)
+          end
+        end
+      end
     end
   end
 
   setcode do
     if not apt_package_updates.nil? and apt_package_updates.length == 2
-      apt_package_updates != ['0', '0']
+      apt_package_updates != [[], []]
     end
   end
 end
@@ -18,11 +34,10 @@ end
 Facter.add("apt_package_updates") do
   confine :apt_has_updates => true
   setcode do
-    packages = Facter::Util::Resolution.exec('/usr/lib/update-notifier/apt-check -p 2>&1').split("\n")
     if Facter.version < '2.0.0'
-      packages.join(',')
+      apt_package_updates[0].join(',')
     else
-      packages
+      apt_package_updates[0]
     end
   end
 end
@@ -30,13 +45,13 @@ end
 Facter.add("apt_updates") do
   confine :apt_has_updates => true
   setcode do
-    Integer(apt_package_updates[0])
+    Integer(apt_package_updates[0].length)
   end
 end
 
 Facter.add("apt_security_updates") do
   confine :apt_has_updates => true
   setcode do
-    Integer(apt_package_updates[1])
+    Integer(apt_package_updates[1].length)
   end
 end

--- a/spec/unit/facter/apt_has_updates_spec.rb
+++ b/spec/unit/facter/apt_has_updates_spec.rb
@@ -11,33 +11,11 @@ describe 'apt_has_updates fact' do
     it { is_expected.to be_nil }
   end
 
-  describe 'on Debian based distro missing update-notifier-common' do
+  describe 'on Debian based distro missing apt-get' do
     before {
       Facter.fact(:osfamily).expects(:value).at_least(1).returns 'Debian'
       File.stubs(:executable?) # Stub all other calls
-      File.expects(:executable?).with('/usr/lib/update-notifier/apt-check').returns false
-    }
-    it { is_expected.to be_nil }
-  end
-
-  describe 'on Debian based distro with broken packages' do
-    before {
-      Facter.fact(:osfamily).expects(:value).at_least(1).returns 'Debian'
-      File.stubs(:executable?) # Stub all other calls
-      Facter::Util::Resolution.stubs(:exec) # Catch all other calls
-      File.expects(:executable?).with('/usr/lib/update-notifier/apt-check').returns true
-      Facter::Util::Resolution.expects(:exec).with('/usr/lib/update-notifier/apt-check 2>&1').returns "E: Error: BrokenCount > 0"
-    }
-    it { is_expected.to be_nil }
-  end
-
-  describe 'on Debian based distro with unknown error with semicolons' do
-    before {
-      Facter.fact(:osfamily).expects(:value).at_least(1).returns 'Debian'
-      File.stubs(:executable?) # Stub all other calls
-      Facter::Util::Resolution.stubs(:exec) # Catch all other calls
-      File.expects(:executable?).with('/usr/lib/update-notifier/apt-check').returns true
-      Facter::Util::Resolution.expects(:exec).with('/usr/lib/update-notifier/apt-check 2>&1').returns "E: Unknown Error: 'This error contains something that could be parsed like 4;3' (10)"
+      File.expects(:executable?).with('/usr/bin/apt-get').returns false
     }
     it { is_expected.to be_nil }
   end
@@ -47,8 +25,12 @@ describe 'apt_has_updates fact' do
       Facter.fact(:osfamily).expects(:value).at_least(1).returns 'Debian'
       File.stubs(:executable?) # Stub all other calls
       Facter::Util::Resolution.stubs(:exec) # Catch all other calls
-      File.expects(:executable?).with('/usr/lib/update-notifier/apt-check').returns true
-      Facter::Util::Resolution.expects(:exec).with('/usr/lib/update-notifier/apt-check 2>&1').returns "4;3"
+      File.expects(:executable?).with('/usr/bin/apt-get').returns true
+      Facter::Util::Resolution.expects(:exec).with('/usr/bin/apt-get -s upgrade 2>&1').returns ""+
+        "Inst tzdata [2015f-0+deb8u1] (2015g-0+deb8u1 Debian:stable-updates [all])\n"+
+        "Conf tzdata (2015g-0+deb8u1 Debian:stable-updates [all])\n"+
+        "Inst unhide.rb [13-1.1] (22-2~bpo8+1 Debian Backports:jessie-backports [all])\n"+
+        "Conf unhide.rb (22-2~bpo8+1 Debian Backports:jessie-backports [all])\n"
     }
     it { is_expected.to be true }
   end

--- a/spec/unit/facter/apt_package_updates_spec.rb
+++ b/spec/unit/facter/apt_package_updates_spec.rb
@@ -16,15 +16,18 @@ describe 'apt_package_updates fact' do
       Facter.fact(:osfamily).stubs(:value).returns 'Debian'
       File.stubs(:executable?) # Stub all other calls
       Facter::Util::Resolution.stubs(:exec) # Catch all other calls
-      File.expects(:executable?).with('/usr/lib/update-notifier/apt-check').returns true
-      Facter::Util::Resolution.expects(:exec).with('/usr/lib/update-notifier/apt-check 2>&1').returns "1;2"
-      Facter::Util::Resolution.expects(:exec).with('/usr/lib/update-notifier/apt-check -p 2>&1').returns "puppet-common\nlinux-generic\nlinux-image-generic"
+      File.expects(:executable?).with('/usr/bin/apt-get').returns true
+      Facter::Util::Resolution.expects(:exec).with('/usr/bin/apt-get -s upgrade 2>&1').returns ""+
+        "Inst tzdata [2015f-0+deb8u1] (2015g-0+deb8u1 Debian:stable-updates [all])\n"+
+        "Conf tzdata (2015g-0+deb8u1 Debian:stable-updates [all])\n"+
+        "Inst unhide.rb [13-1.1] (22-2~bpo8+1 Debian Backports:jessie-backports [all])\n"+
+        "Conf unhide.rb (22-2~bpo8+1 Debian Backports:jessie-backports [all])\n"
     }
     it {
       if Facter.version < '2.0.0'
-        is_expected.to eq('puppet-common,linux-generic,linux-image-generic')
+        is_expected.to eq('tzdata,unhide.rb')
       else
-        is_expected.to eq(['puppet-common', 'linux-generic', 'linux-image-generic'])
+        is_expected.to eq(['tzdata','unhide.rb'])
       end
     }
   end

--- a/spec/unit/facter/apt_security_updates_spec.rb
+++ b/spec/unit/facter/apt_security_updates_spec.rb
@@ -16,10 +16,14 @@ describe 'apt_security_updates fact' do
       Facter.fact(:osfamily).stubs(:value).returns 'Debian'
       File.stubs(:executable?) # Stub all other calls
       Facter::Util::Resolution.stubs(:exec) # Catch all other calls
-      File.expects(:executable?).with('/usr/lib/update-notifier/apt-check').returns true
-      Facter::Util::Resolution.expects(:exec).with('/usr/lib/update-notifier/apt-check 2>&1').returns "14;7"
+      File.expects(:executable?).with('/usr/bin/apt-get').returns true
+      Facter::Util::Resolution.expects(:exec).with('/usr/bin/apt-get -s upgrade 2>&1').returns ""+
+        "Inst tzdata [2015f-0+deb8u1] (2015g-0+deb8u1 Debian:stable-updates [all])\n"+
+        "Conf tzdata (2015g-0+deb8u1 Debian:stable-updates [all])\n"+
+        "Inst unhide.rb [13-1.1] (22-2~bpo8+1 Debian Backports:jessie-backports [all])\n"+
+        "Conf unhide.rb (22-2~bpo8+1 Debian Backports:jessie-backports [all])\n"
     }
-    it { is_expected.to eq(7) }
+    it { is_expected.to eq(1) }
   end
 
 end

--- a/spec/unit/facter/apt_updates_spec.rb
+++ b/spec/unit/facter/apt_updates_spec.rb
@@ -16,10 +16,14 @@ describe 'apt_updates fact' do
       Facter.fact(:osfamily).stubs(:value).returns 'Debian'
       File.stubs(:executable?) # Stub all other calls
       Facter::Util::Resolution.stubs(:exec) # Catch all other calls
-      File.expects(:executable?).with('/usr/lib/update-notifier/apt-check').returns true
-      Facter::Util::Resolution.expects(:exec).with('/usr/lib/update-notifier/apt-check 2>&1').returns "14;7"
+      File.expects(:executable?).with('/usr/bin/apt-get').returns true
+      Facter::Util::Resolution.expects(:exec).with('/usr/bin/apt-get -s upgrade 2>&1').returns ""+
+        "Inst tzdata [2015f-0+deb8u1] (2015g-0+deb8u1 Debian:stable-updates [all])\n"+
+        "Conf tzdata (2015g-0+deb8u1 Debian:stable-updates [all])\n"+
+        "Inst unhide.rb [13-1.1] (22-2~bpo8+1 Debian Backports:jessie-backports [all])\n"+
+        "Conf unhide.rb (22-2~bpo8+1 Debian Backports:jessie-backports [all])\n"
     }
-    it { is_expected.to eq(14) }
+    it { is_expected.to eq(2) }
   end
 
 end


### PR DESCRIPTION
apt_updates.rb currently uses /usr/lib/update-notifier/apt-check to check for available updates.
This is part of update-notifier-common, which is not available on all systems.