### PR TITLE
Handle PPA names that contain a plus character.

### DIFF
--- a/manifests/ppa.pp
+++ b/manifests/ppa.pp
@@ -16,7 +16,8 @@ define apt::ppa(
 
   $filename_without_slashes = regsubst($name, '/', '-', 'G')
   $filename_without_dots    = regsubst($filename_without_slashes, '\.', '_', 'G')
-  $filename_without_ppa     = regsubst($filename_without_dots, '^ppa:', '', 'G')
+  $filename_without_pluses  = regsubst($filename_without_dots, '\+', '_', 'G')
+  $filename_without_ppa     = regsubst($filename_without_pluses, '^ppa:', '', 'G')
   $sources_list_d_filename  = "${filename_without_ppa}-${release}.list"
 
   if $ensure == 'present' {

--- a/spec/defines/ppa_spec.rb
+++ b/spec/defines/ppa_spec.rb
@@ -16,12 +16,12 @@ describe 'apt::ppa' do
       }
     end
 
-    let(:title) { 'ppa:needs/such.substitution/wow' }
+    let(:title) { 'ppa:needs/such.substitution/wow+type' }
     it { is_expected.to_not contain_package('python-software-properties') }
-    it { is_expected.to contain_exec('add-apt-repository-ppa:needs/such.substitution/wow').that_notifies('Class[Apt::Update]').with({
+    it { is_expected.to contain_exec('add-apt-repository-ppa:needs/such.substitution/wow+type').that_notifies('Class[Apt::Update]').with({
       :environment => [],
-      :command     => '/usr/bin/add-apt-repository -y ppa:needs/such.substitution/wow',
-      :unless      => '/usr/bin/test -s /etc/apt/sources.list.d/needs-such_substitution-wow-natty.list',
+      :command     => '/usr/bin/add-apt-repository -y ppa:needs/such.substitution/wow+type',
+      :unless      => '/usr/bin/test -s /etc/apt/sources.list.d/needs-such_substitution-wow_type-natty.list',
       :user        => 'root',
       :logoutput   => 'on_failure',
     })


### PR DESCRIPTION
It looks like add-apt-repository changes pluses to underscores when creating the sources.list.d file. So the name it creates doesn't match what Puppet expects, and the resource keeps applying on every Puppet run.

This works around that problem.