### PR TITLE
[WIP] Fixed apt::ppa path in Ubuntu Wily

### DIFF
--- a/manifests/ppa.pp
+++ b/manifests/ppa.pp
@@ -14,7 +14,7 @@ define apt::ppa(
     fail('apt::ppa is not currently supported on Debian.')
   }
 
-  $filename_without_slashes = regsubst($name, '/', '-', 'G')
+  $filename_without_slashes = regsubst($name, '/', '-ubuntu-', 'G')
   $filename_without_dots    = regsubst($filename_without_slashes, '\.', '_', 'G')
   $filename_without_pluses  = regsubst($filename_without_dots, '\+', '_', 'G')
   $filename_without_ppa     = regsubst($filename_without_pluses, '^ppa:', '', 'G')


### PR DESCRIPTION
No clue why, but the filenames that apt-add-repository produces seems to have changed in Wily. This update does the trick for me, but might not be backwards compatible.