### PR TITLE
Add parameters for hiera merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,11 @@ Main class, includes all other classes.
 
 * `keys`: Creates new `apt::key` resources. Valid options: a hash to be passed to the [`create_resources` function](https://docs.puppetlabs.com/references/latest/function.html#createresources). Default: {}.
 
+* 'keys_hiera_merge': Configure apt to merge apt::keys from all hiera levels. Default: false.
+
 * `ppas`: Creates new `apt::ppa` resources. Valid options: a hash to be passed to the [`create_resources` function](https://docs.puppetlabs.com/references/latest/function.html#createresources). Default: {}.
+
+* 'ppas_hiera_merge': Configure apt to merge apt::ppas from all hiera levels. Default: false.
 
 * `proxy`: Configures Apt to connect to a proxy server. Valid options: a hash made up from the following keys:
 
@@ -286,9 +290,15 @@ Main class, includes all other classes.
 
 * `settings`: Creates new `apt::setting` resources. Valid options: a hash to be passed to the [`create_resources` function](https://docs.puppetlabs.com/references/latest/function.html#createresources). Default: {}.
 
+* 'settings_hiera_merge': Configure apt to merge apt::settings from all hiera levels. Default: false.
+
 * `sources`: Creates new `apt::source` resources. Valid options: a hash to be passed to the [`create_resources` function](https://docs.puppetlabs.com/references/latest/function.html#createresources). Default: {}.
 
+* 'sources_hiera_merge': Configure apt to merge apt::sources from all hiera levels. Default: false.
+
 * `pins`: Creates new `apt::pin` resources. Valid options: a hash to be passed to the [`create_resources` function](https://docs.puppetlabs.com/references/latest/function.html#createresources). Default: {}.
+
+* 'pins_hiera_merge': Configure apt to merge apt::pins from all hiera levels. Default: false.
 
 * `update`: Configures various update settings. Valid options: a hash made up from the following keys:
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,13 +1,18 @@
 #
 class apt(
-  $update   = {},
-  $purge    = {},
-  $proxy    = {},
-  $sources  = {},
-  $keys     = {},
-  $ppas     = {},
-  $pins     = {},
-  $settings = {},
+  $update               = {},
+  $purge                = {},
+  $proxy                = {},
+  $sources              = {},
+  $sources_hiera_merge  = false,
+  $keys                 = {},
+  $keys_hiera_merge     = false,
+  $ppas                 = {},
+  $ppas_hiera_merge     = false,
+  $pins                 = {},
+  $pins_hiera_merge     = false,
+  $settings             = {},
+  $settings_hiera_merge = false,
 ) inherits ::apt::params {
 
   $frequency_options = ['always','daily','weekly','reluctantly']
@@ -63,11 +68,37 @@ class apt(
 
   $_proxy = merge($apt::proxy_defaults, $proxy)
 
-  validate_hash($sources)
-  validate_hash($keys)
-  validate_hash($settings)
-  validate_hash($ppas)
-  validate_hash($pins)
+  if is_string($sources_hiera_merge) {
+    $_sources_hiera_merge = str2bool($sources_hiera_merge)
+  } else {
+    $_sources_hiera_merge = $sources_hiera_merge
+  }
+  if is_string($keys_hiera_merge) {
+    $_keys_hiera_merge = str2bool($keys_hiera_merge)
+  } else {
+    $_keys_hiera_merge = $keys_hiera_merge
+  }
+  if is_string($settings_hiera_merge) {
+    $_settings_hiera_merge = str2bool($settings_hiera_merge)
+  } else {
+    $_settings_hiera_merge = $settings_hiera_merge
+  }
+  if is_string($ppas_hiera_merge) {
+    $_ppas_hiera_merge = str2bool($ppas_hiera_merge)
+  } else {
+    $_ppas_hiera_merge = $ppas_hiera_merge
+  }
+  if is_string($pins_hiera_merge) {
+    $_pins_hiera_merge = str2bool($pins_hiera_merge)
+  } else {
+    $_pins_hiera_merge = $pins_hiera_merge
+  }
+
+  validate_bool($_sources_hiera_merge)
+  validate_bool($_keys_hiera_merge)
+  validate_bool($_settings_hiera_merge)
+  validate_bool($_ppas_hiera_merge)
+  validate_bool($_pins_hiera_merge)
 
   if $_proxy['ensure'] == 'absent' or $_proxy['host'] {
     apt::setting { 'conf-proxy':
@@ -141,23 +172,53 @@ class apt(
 
   # manage sources if present
   if $sources {
-    create_resources('apt::source', $sources)
+    if $_sources_hiera_merge {
+      $_sources = hiera_hash(apt::sources)
+    } else {
+      $_sources = $sources
+    }
+    validate_hash($_sources)
+    create_resources('apt::source', $_sources)
   }
   # manage keys if present
   if $keys {
-    create_resources('apt::key', $keys)
+    if $_keys_hiera_merge {
+      $_keys = hiera_hash(apt::keys)
+    } else {
+      $_keys = $keys
+    }
+    validate_hash($_keys)
+    create_resources('apt::key', $_keys)
   }
   # manage ppas if present
   if $ppas {
-    create_resources('apt::ppa', $ppas)
+    if $_ppas_hiera_merge {
+      $_ppas = hiera_hash(apt::ppas)
+    } else {
+      $_ppas = $ppas
+    }
+    validate_hash($_ppas)
+    create_resources('apt::ppa', $_ppas)
   }
   # manage settings if present
   if $settings {
-    create_resources('apt::setting', $settings)
+    if $_settings_hiera_merge {
+      $_settings = hiera_hash(apt::settings)
+    } else {
+      $_settings = $settings
+    }
+    validate_hash($_settings)
+    create_resources('apt::setting', $_settings)
   }
 
   # manage pins if present
   if $pins {
-    create_resources('apt::pin', $pins)
+    if $_pins_hiera_merge {
+      $_pins = hiera_hash(apt::pins)
+    } else {
+      $_pins = $pins
+    }
+    validate_hash($_pins)
+    create_resources('apt::pin', $_pins)
   }
 }

--- a/spec/fixtures/hiera/fqdn/hieramerge.example.com.yaml
+++ b/spec/fixtures/hiera/fqdn/hieramerge.example.com.yaml
@@ -1,0 +1,31 @@
+---
+
+apt::sources_hiera_merge: true
+apt::keys_hiera_merge: true
+apt::ppas_hiera_merge: true
+apt::pins_hiera_merge: true
+apt::settings_hiera_merge: true
+
+apt::sources:
+  "archive.ubuntu.com-%{lsbdistcodename}-backports":
+    location: 'http://archive.ubuntu.com/ubuntu'
+    key: '630239CC130E1A7FD81A27B140976EAF437D05B5'
+    repos: 'main restricted universe'
+    release: "%{lsbdistcodename}-backports"
+
+apt::keys:
+  '4BD6EC30':
+    server: 'pgp.mit.edu'
+
+apt::settings:
+  'pref-banana':
+    content: 'banana'
+
+apt::pins:
+  'testing':
+    priority: 700
+    order: 100
+
+apt::ppas:
+  'ppa:nginx/stable':
+    ensure: present

--- a/spec/fixtures/hiera/fqdn/nohieramerge.example.com.yaml
+++ b/spec/fixtures/hiera/fqdn/nohieramerge.example.com.yaml
@@ -1,0 +1,31 @@
+---
+
+apt::sources_hiera_merge: false
+apt::keys_hiera_merge: false
+apt::ppas_hiera_merge: false
+apt::pins_hiera_merge: false
+apt::settings_hiera_merge: false
+
+apt::sources:
+  "archive.ubuntu.com-%{lsbdistcodename}-backports":
+    location: 'http://archive.ubuntu.com/ubuntu'
+    key: '630239CC130E1A7FD81A27B140976EAF437D05B5'
+    repos: 'main restricted universe'
+    release: "%{lsbdistcodename}-backports"
+
+apt::keys:
+  '4BD6EC30':
+    server: 'pgp.mit.edu'
+
+apt::settings:
+  'pref-banana':
+    content: 'banana'
+
+apt::pins:
+  'testing':
+    priority: 700
+    order: 100
+
+apt::ppas:
+  'ppa:nginx/stable':
+    ensure: present

--- a/spec/fixtures/hiera/hiera.yaml
+++ b/spec/fixtures/hiera/hiera.yaml
@@ -1,0 +1,8 @@
+---
+:backends:
+  - yaml
+:yaml:
+  :datadir: 'spec/fixtures/hiera'
+:hierarchy:
+  - 'fqdn/%{fqdn}'
+  - 'specific/%{specific}'

--- a/spec/fixtures/hiera/specific/hiera.yaml
+++ b/spec/fixtures/hiera/specific/hiera.yaml
@@ -1,0 +1,34 @@
+---
+
+apt::sources:
+  "archive.ubuntu.com-%{lsbdistcodename}":
+    location: 'http://archive.ubuntu.com/ubuntu'
+    key: '630239CC130E1A7FD81A27B140976EAF437D05B5'
+    repos: 'main universe multiverse restricted'
+  "archive.ubuntu.com-%{lsbdistcodename}-security":
+    location: 'http://archive.ubuntu.com/ubuntu'
+    key: '630239CC130E1A7FD81A27B140976EAF437D05B5'
+    repos: 'main universe multiverse restricted'
+    release: "%{lsbdistcodename}-security"
+  "archive.ubuntu.com-%{lsbdistcodename}-updates":
+    location: 'http://archive.ubuntu.com/ubuntu'
+    key: '630239CC130E1A7FD81A27B140976EAF437D05B5'
+    repos: 'main universe multiverse restricted'
+    release: "%{lsbdistcodename}-updates"
+
+apt::keys:
+  '55BE302B':
+    server: 'subkeys.pgp.net'
+
+apt::settings:
+  'conf-banana':
+    content: 'banana'
+
+apt::pins:
+  'stable':
+    priority: 600
+    order: 50
+
+apt::ppas:
+  'ppa:drizzle-developers/ppa':
+    ensure: present

--- a/spec/spec_helper_local.rb
+++ b/spec/spec_helper_local.rb
@@ -1,0 +1,5 @@
+# Include hiera configuration
+
+RSpec.configure do |c|
+    c.hiera_config = 'spec/fixtures/hiera/hiera.yaml'
+end


### PR DESCRIPTION
Add hiera merge functionality for sources, keys, ppas, pins and settings.
When hiera_merge parameter is set to true the corresponding parameters' value will be merged from from all hiera levels.