### PR TITLE
Simplify installation of optional software-properties

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -131,16 +131,12 @@ class apt::params {
         'repos'    => 'main universe multiverse restricted',
       }
 
-      case $xfacts['lsbdistcodename'] {
-        'lucid': {
+      case versioncmp($xfacts['lsbdistrelease'], '14.00') {
+        -1: {
           $ppa_options        = undef
           $ppa_package        = 'python-software-properties'
         }
-        'precise': {
-          $ppa_options        = '-y'
-          $ppa_package        = 'python-software-properties'
-        }
-        'trusty', 'utopic', 'vivid', 'wily': {
+        1: {
           $ppa_options        = '-y'
           $ppa_package        = 'software-properties-common'
         }


### PR DESCRIPTION
Simplify the case structure comparing the version of ubuntu using versioncmp instead of the codename. At present all version since the 14.04 use the same value.