### PR TITLE
apt::setting expects priority to be an integer, set defaults accordingly

### DIFF
--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -1,7 +1,7 @@
 define apt::conf (
   $content       = undef,
   $ensure        = present,
-  $priority      = '50',
+  $priority      = 50,
   $notify_update = undef,
 ) {
 

--- a/manifests/pin.pp
+++ b/manifests/pin.pp
@@ -4,7 +4,7 @@
 define apt::pin(
   $ensure          = present,
   $explanation     = undef,
-  $order           = undef,
+  $order           = 50,
   $packages        = '*',
   $priority        = 0,
   $release         = '', # a=


### PR DESCRIPTION
Using apt::pin without specifying `order` results in:
```
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: apt::setting priority must be an integer or a zero-padded integer on node
```

The same thing happens when using apt::conf with the default `priority`.