### PR TITLE
(MODULES-3210) set default apt::pin order

### DIFF
--- a/manifests/pin.pp
+++ b/manifests/pin.pp
@@ -4,7 +4,7 @@
 define apt::pin(
   $ensure          = present,
   $explanation     = undef,
-  $order           = undef,
+  $order           = 50,
   $packages        = '*',
   $priority        = 0,
   $release         = '', # a=


### PR DESCRIPTION
The order parameter of apt::pin is passed through to apt::setting's priority,
which defaults to 50, but the order itself defaults to undef, a invalid value,
all around.

This commit changes apt::pin's default order to 50 to match apt:setting, make
the param optional, and generally reduce confusion.