### PR TITLE
Fix version check on 16.04.

### DIFF
--- a/manifests/ppa.pp
+++ b/manifests/ppa.pp
@@ -14,10 +14,7 @@ define apt::ppa(
     fail('apt::ppa is not currently supported on Debian.')
   }
 
-  $ubuntu_release_year  = regsubst($::apt::xfacts['lsbdistrelease'], '\.\d+$', '', 'G') + 0
-  $ubuntu_release_month = regsubst($::apt::xfacts['lsbdistrelease'], '^\d+\.', '', 'G') + 0
-
-  if $ubuntu_release_year >= 15 and $ubuntu_release_month >= 10 {
+  if versioncmp($::apt::xfacts['lsbdistrelease'], '15.10') >= 0 {
     $distid = downcase($::apt::xfacts['lsbdistid'])
     $filename = regsubst($name, '^ppa:([^/]+)/(.+)$', "\\1-${distid}-\\2-${release}")
   } else {


### PR DESCRIPTION
The old test obviously broke on 16.04. Switch to using versioncmp since it does the right thing for us.