### PR TITLE
Install software-properties-common for xenial

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,8 +420,8 @@ Manages PPA repositories using `add-apt-repository`. Not supported on Debian.
 * `package_name`: Names the package that provides the `apt-add-repository` command. Valid options: a string. Defaults:
 
   * Lucid and Precise: 'python-software-properties'
-  * Trusty, Utopic, and Vivid: 'software-properties-common'
-  * All others: undef
+  * Trusty and newer: 'software-properties-common'
+  * All others: 'python-software-properties'
 
 * `release`: *Optional if lsb-release is installed (unless you're using a different release than indicated by lsb-release, e.g., Linux Mint).* Specifies the operating system of your node. Valid options: a string containing a valid LSB distribution codename. Default: "$lsbdistcodename".
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -131,23 +131,18 @@ class apt::params {
         'repos'    => 'main universe multiverse restricted',
       }
 
-      case $xfacts['lsbdistcodename'] {
-        'lucid': {
+      if $xfacts['lsbdistcodename'] == 'lucid' {
           $ppa_options        = undef
           $ppa_package        = 'python-software-properties'
-        }
-        'precise': {
+      } elsif $xfacts['lsbdistcodename'] == 'precise' {
           $ppa_options        = '-y'
           $ppa_package        = 'python-software-properties'
-        }
-        'trusty', 'utopic', 'vivid', 'wily': {
+      } elsif versioncmp($xfacts['lsbdistrelease'], '14.04') >= 0 {
           $ppa_options        = '-y'
           $ppa_package        = 'software-properties-common'
-        }
-        default: {
+      } else {
           $ppa_options        = '-y'
           $ppa_package        = 'python-software-properties'
-        }
       }
     }
     undef: {

--- a/spec/classes/apt_backports_spec.rb
+++ b/spec/classes/apt_backports_spec.rb
@@ -46,6 +46,7 @@ describe 'apt::backports', :type => :class do
           :lsbdistid       => 'Ubuntu',
           :osfamily        => 'Debian',
           :lsbdistcodename => 'trusty',
+          :lsbdistrelease  => '14.04',
           :puppetversion   => Puppet.version,
         }
       end
@@ -64,6 +65,7 @@ describe 'apt::backports', :type => :class do
           :lsbdistid       => 'Ubuntu',
           :osfamily        => 'Debian',
           :lsbdistcodename => 'trusty',
+          :lsbdistrelease  => '14.04',
           :puppetversion   => Puppet.version,
         }
       end
@@ -91,6 +93,7 @@ describe 'apt::backports', :type => :class do
           :lsbdistid       => 'Ubuntu',
           :osfamily        => 'Debian',
           :lsbdistcodename => 'trusty',
+          :lsbdistrelease  => '14.04',
           :puppetversion   => Puppet.version,
         }
       end
@@ -201,6 +204,7 @@ describe 'apt::backports', :type => :class do
         :lsbdistid       => 'Ubuntu',
         :osfamily        => 'Debian',
         :lsbdistcodename => 'trusty',
+        :lsbdistrelease  => '14.04',
         :puppetversion   => Puppet.version,
       }
     end


### PR DESCRIPTION
Instead of adding every newer release of Ubuntu, let's assume that the
package name that is used today will be used in the future, until the
next change is necessary.