### PR TITLE
Use hkps.pool.sks-keyservers.net instead of pgp.mit.edu

### DIFF
--- a/examples/backports.pp
+++ b/examples/backports.pp
@@ -6,6 +6,6 @@ apt::backports { 'qiana':
   repos    => 'main universe multiverse restricted',
   key      => {
     id     => '630239CC130E1A7FD81A27B140976EAF437D05B5',
-    server => 'pgp.mit.edu',
+    server => 'hkps.pool.sks-keyservers.net',
   },
 }

--- a/examples/key.pp
+++ b/examples/key.pp
@@ -1,6 +1,6 @@
 # Declare Apt key for apt.puppetlabs.com source
 apt::key { 'puppetlabs':
   id      => '47B320EB4C7C375AA9DAE1A01054B7A24BD6EC30',
-  server  => 'pgp.mit.edu',
+  server  => 'hkps.pool.sks-keyservers.net',
   options => 'http-proxy="http://proxyuser:proxypass@example.org:3128"',
 }

--- a/examples/source.pp
+++ b/examples/source.pp
@@ -8,7 +8,7 @@ apt::source { 'puppetlabs':
   repos    => 'main',
   key      => {
     id     => '47B320EB4C7C375AA9DAE1A01054B7A24BD6EC30',
-    server => 'pgp.mit.edu',
+    server => 'hkps.pool.sks-keyservers.net',
   },
 }
 
@@ -19,7 +19,7 @@ apt::source { 'debian_testing':
   repos    => 'main contrib non-free',
   key      => {
     id     => 'A1BD8E9D78F7FE5C3E65D8AF8B48AD6246925553',
-    server => 'subkeys.pgp.net',
+    server => 'hkps.pool.sks-keyservers.net',
   },
   pin      => '-10',
 }
@@ -29,7 +29,7 @@ apt::source { 'debian_unstable':
   repos    => 'main contrib non-free',
   key      => {
     id     => 'A1BD8E9D78F7FE5C3E65D8AF8B48AD6246925553',
-    server => 'subkeys.pgp.net',
+    server => 'hkps.pool.sks-keyservers.net',
   },
   pin      => '-10',
 }

--- a/spec/acceptance/apt_key_provider_spec.rb
+++ b/spec/acceptance/apt_key_provider_spec.rb
@@ -401,13 +401,13 @@ ZTQcCD53HcBLvKX6RJ4ByYawKaQqMa27WK/YWVmFXqVDVk12iKrQW6zktDdGInnD
   end
 
   describe 'server =>' do
-    context 'pgp.mit.edu' do
+    context 'hkps.pool.sks-keyservers.net' do
       it 'works' do
         pp = <<-EOS
         apt_key { 'puppetlabs':
           id     => '#{PUPPETLABS_GPG_KEY_LONG_ID}',
           ensure => 'present',
-          server => 'pgp.mit.edu',
+          server => 'hkps.pool.sks-keyservers.net',
         }
         EOS
 
@@ -417,13 +417,13 @@ ZTQcCD53HcBLvKX6RJ4ByYawKaQqMa27WK/YWVmFXqVDVk12iKrQW6zktDdGInnD
       end
     end
 
-    context 'hkp://pgp.mit.edu:80' do
+    context 'hkp://hkps.pool.sks-keyservers.net:80' do
       it 'works' do
         pp = <<-EOS
         apt_key { 'puppetlabs':
           id     => '#{PUPPETLABS_GPG_KEY_FINGERPRINT}',
           ensure => 'present',
-          server => 'hkp://pgp.mit.edu:80',
+          server => 'hkp://hkps.pool.sks-keyservers.net:80',
         }
         EOS
 

--- a/spec/acceptance/apt_spec.rb
+++ b/spec/acceptance/apt_spec.rb
@@ -21,7 +21,7 @@ describe 'apt class' do
             'repos'    => 'main',
             'key'      => {
               'id'     => '47B320EB4C7C375AA9DAE1A01054B7A24BD6EC30',
-              'server' => 'pgp.mit.edu',
+              'server' => 'hkps.pool.sks-keyservers.net',
             },
           },
         }

--- a/spec/classes/params_spec.rb
+++ b/spec/classes/params_spec.rb
@@ -1,9 +1,6 @@
 require 'spec_helper'
 describe 'apt::params', :type => :class do
-  let(:facts) { { :lsbdistid => 'Debian', :osfamily => 'Debian', :lsbdistcodename => 'wheezy', :puppetversion   => Puppet.version, } }
-  let (:title) { 'my_package' }
-
-  it { is_expected.to contain_apt__params }
+  let(:facts) { { :lsbdistid => 'Debian', :osfamily => 'Debian', :lsbdistcodename => 'wheezy', :puppetversion => Puppet.version, } }
 
   # There are 4 resources in this class currently
   # there should not be any more resources because it is a params class
@@ -13,7 +10,7 @@ describe 'apt::params', :type => :class do
   end
 
   describe "With lsb-release not installed" do
-    let(:facts) { { :osfamily => 'Debian', :puppetversion   => Puppet.version, } }
+    let(:facts) { { :osfamily => 'Debian', :puppetversion => Puppet.version, } }
     let (:title) { 'my_package' }
 
     it do


### PR DESCRIPTION
The MIT server is sometimes unreliable during tests. The pool should
provide a much stabler service.