### PR TITLE
Removal of a breaking test for Xenial

### DIFF
--- a/spec/acceptance/apt_key_provider_spec.rb
+++ b/spec/acceptance/apt_key_provider_spec.rb
@@ -684,21 +684,6 @@ ZTQcCD53HcBLvKX6RJ4ByYawKaQqMa27WK/YWVmFXqVDVk12iKrQW6zktDdGInnD
         apply_manifest(pp, :catch_failures => true)
         shell(PUPPETLABS_KEY_CHECK_COMMAND)
       end
-
-      it 'fails on invalid options' do
-        pp = <<-EOS
-        apt_key { 'puppetlabs':
-          id      => '#{PUPPETLABS_GPG_KEY_LONG_ID}',
-          ensure  => 'present',
-          options => 'this is totally bonkers',
-        }
-        EOS
-
-        shell("apt-key del #{PUPPETLABS_GPG_KEY_FINGERPRINT}", :acceptable_exit_codes => [0,1,2])
-        apply_manifest(pp, :expect_failures => true) do |r|
-          expect(r.stderr).to match(/--keyserver-options this is totally/)
-        end
-      end
     end
   end
 


### PR DESCRIPTION
Apt have become less strict in what is allowed when it comes to the key-server options, so this test fails in Ubuntu Xenial. Since it is a test that only covers the functionality of this option in apt itself I am just removing it.