### PR TITLE
Fix regexp for $ensure params

### DIFF
--- a/manifests/key.pp
+++ b/manifests/key.pp
@@ -49,7 +49,7 @@ define apt::key (
   }
 
   validate_re($_id, ['\A(0x)?[0-9a-fA-F]{8}\Z', '\A(0x)?[0-9a-fA-F]{16}\Z', '\A(0x)?[0-9a-fA-F]{40}\Z'])
-  validate_re($ensure, ['\Aabsent|present\Z',])
+  validate_re($ensure, ['\A(absent|present)\Z',])
 
   if $_content {
     validate_string($_content)

--- a/spec/defines/key_spec.rb
+++ b/spec/defines/key_spec.rb
@@ -268,13 +268,15 @@ describe 'apt::key' do
     end
 
     context 'invalid ensure' do
-      let :params do
-        {
-          :ensure => 'foo',
-        }
-      end
-      it 'fails' do
-        expect { subject.call }.to raise_error(/does not match/)
+      %w(foo aabsent absenta apresent presenta).each do |param|
+        let :params do
+          {
+            :ensure => param,
+          }
+          end
+        it 'fails' do
+          expect { subject.call }.to raise_error(/does not match/)
+        end
       end
     end
 


### PR DESCRIPTION
`\Aabsent|present\Z` match wrong values like 'absentaaa' or 'aaapresent'.