### PR TITLE
apt/params: Remove unused LSB facts

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,9 +10,6 @@ class apt::params {
     $xfacts = {
       'lsbdistcodename'     => $::lsbdistcodename,
       'lsbdistrelease'      => $::lsbdistrelease,
-      'lsbmajdistrelease'   => $::lsbmajdistrelease,
-      'lsbdistdescription'  => $::lsbdistdescription,
-      'lsbminordistrelease' => $::lsbminordistrelease,
       'lsbdistid'           => $::lsbdistid,
     }
   } else {
@@ -24,18 +21,6 @@ class apt::params {
       },
       'lsbdistrelease' => defined('$lsbdistrelease') ? {
         true    => $::lsbdistrelease,
-        default => undef,
-      },
-      'lsbmajdistrelease' => defined('$lsbmajdistrelease') ? {
-        true    => $::lsbmajdistrelease,
-        default => undef,
-      },
-      'lsbdistdescription' => defined('$lsbdistdescription') ? {
-        true    => $::lsbdistdescription,
-        default => undef,
-      },
-      'lsbminordistrelease' => defined('$lsbminordistrelease') ? {
-        true    => $::lsbminordistrelease,
         default => undef,
       },
       'lsbdistid' => defined('$lsbdistid') ? {


### PR DESCRIPTION
These facts aren't used anywhere in the APT module and at least `lsbminordistrelease` doesn't seem to be set at all anymore in recent versions of Puppet. This causes the following warning to show up on Puppet 4.3:

```
Warning: Undefined variable 'lsbminordistrelease';
   (file & line not available)
```

On 4.5 we get the slightly more helpful:

```
Warning: Unknown variable: '::lsbminordistrelease'. at /etc/puppetlabs/code/environments/production/modules/apt/manifests/params.pp:15:32
```