### PR TITLE
(MODULES-3414) Limit non-strict parsing to pre-3.5.0 only

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,9 +4,9 @@ class apt::params {
     fail('This module only works on Debian or derivatives like Ubuntu')
   }
 
-  # prior to puppet 3.5.0, defined couldn't test if a variable was defined
-  # strict variables wasn't added until 3.5.0, so this should be fine.
-  if ! $::settings::strict_variables {
+  # prior to puppet 3.5.0, defined() couldn't test if a variable was defined.
+  # strict_variables wasn't added until 3.5.0, so this should be fine.
+  if $::puppetversion and versioncmp($::puppetversion, '3.5.0') < 0 {
     $xfacts = {
       'lsbdistcodename'     => $::lsbdistcodename,
       'lsbdistrelease'      => $::lsbdistrelease,

--- a/spec/defines/key_compat_spec.rb
+++ b/spec/defines/key_compat_spec.rb
@@ -4,6 +4,7 @@ describe 'apt::key', :type => :define do
   let(:facts) { {
     :lsbdistid => 'Debian',
     :osfamily => 'Debian',
+    :puppetversion => Puppet.version,
   } }
   GPG_KEY_ID = '47B320EB4C7C375AA9DAE1A01054B7A24BD6EC30'
 

--- a/spec/defines/source_compat_spec.rb
+++ b/spec/defines/source_compat_spec.rb
@@ -13,6 +13,7 @@ describe 'apt::source', :type => :define do
         :lsbdistid       => 'Debian',
         :lsbdistcodename => 'wheezy',
         :osfamily        => 'Debian',
+        :puppetversion   => Puppet.version,
       }
     end
 
@@ -34,6 +35,7 @@ describe 'apt::source', :type => :define do
         :lsbdistid       => 'Debian',
         :lsbdistcodename => 'wheezy',
         :osfamily        => 'Debian'
+        :puppetversion   => Puppet.version,
       }
     end
     let :params do
@@ -88,7 +90,8 @@ describe 'apt::source', :type => :define do
       {
         :lsbdistid       => 'Debian',
         :lsbdistcodename => 'wheezy',
-        :osfamily        => 'Debian'
+        :osfamily        => 'Debian',
+        :puppetversion   => Puppet.version,
       }
     end
     let :params do
@@ -107,7 +110,8 @@ describe 'apt::source', :type => :define do
       {
         :lsbdistid       => 'Debian',
         :lsbdistcodename => 'wheezy',
-        :osfamily        => 'Debian'
+        :osfamily        => 'Debian',
+        :puppetversion   => Puppet.version,
       }
     end
     let :params do
@@ -126,7 +130,8 @@ describe 'apt::source', :type => :define do
       {
         :lsbdistid       => 'Debian',
         :lsbdistcodename => 'wheezy',
-        :osfamily        => 'Debian'
+        :osfamily        => 'Debian',
+        :puppetversion   => Puppet.version,
       }
     end
     let :params do
@@ -146,7 +151,8 @@ describe 'apt::source', :type => :define do
       let :facts do
         {
           :lsbdistid       => 'Debian',
-          :osfamily        => 'Debian'
+          :osfamily        => 'Debian',
+          :puppetversion   => Puppet.version,
         }
       end
 


### PR DESCRIPTION
Puppet 3.5.0 introduced strict variables and the module handles strict
variables by using the defined() function. This does not work on prior
versions of puppet so we must gate based on that version.

Puppet 4 series has a new setting `strict` that may be set to enforce
strict variables while `strict_variables` remains unset (see PUP-6358)
which causes this conditional to erroniously use non-strict 3.5-era
parsing and fail.

The new conditional corrects the cases such that strict variable
behavior happens on versions 3.5.0 and later.