### PR TITLE
fix invalid setting priority error message

### DIFF
--- a/manifests/setting.pp
+++ b/manifests/setting.pp
@@ -24,11 +24,6 @@ define apt::setting (
 
   validate_re($setting_type, ['\Aconf\z', '\Apref\z', '\Alist\z'], "apt::setting resource name/title must start with either 'conf-', 'pref-' or 'list-'")
 
-  unless is_integer($priority) {
-    # need this to allow zero-padded priority.
-    validate_re($priority, '^\d+$', 'apt::setting priority must be an integer or a zero-padded integer')
-  }
-
   if $source {
     validate_string($source)
   }
@@ -38,8 +33,13 @@ define apt::setting (
   }
 
   if ($setting_type == 'list') or ($setting_type == 'pref') {
-    $_priority = ''
+    $_priority = undef
   } else {
+    unless is_integer($priority) {
+      # need this to allow zero-padded priority.
+      validate_re($priority, '^\d+$', 'apt::setting priority must be an integer or a zero-padded integer')
+    }
+
     $_priority = $priority
   }
 

--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -18,7 +18,7 @@ define apt::source(
   $key_content       = undef,
   $key_source        = undef,
   $trusted_source    = undef,
-  $notify_update     = undef,
+  $notify_update     = true,
 ) {
   validate_string($architecture, $comment, $location, $repos)
   validate_bool($allow_unsigned)


### PR DESCRIPTION
This commit fixes an invalid error, because priority parameter may be
undef for list and pref type setting files.
