### PR TITLE
apt_key now really works with userinfo for http(s)

### DIFF
--- a/lib/puppet/provider/apt_key/apt_key.rb
+++ b/lib/puppet/provider/apt_key/apt_key.rb
@@ -127,7 +127,9 @@ Puppet::Type.type(:apt_key).provide(:apt_key) do
       f
     else
       begin
-        key = parsedValue.read
+        user_pass = parsedValue.userinfo.nil? ? nil : parsedValue.userinfo.split(':')
+        parsedValue.userinfo = ''
+        key = open(parsedValue, :http_basic_authentication => user_pass).read
       rescue OpenURI::HTTPError, Net::FTPPermError => e
         fail("#{e.message} for #{resource[:source]}")
       rescue SocketError

--- a/spec/acceptance/apt_key_provider_spec.rb
+++ b/spec/acceptance/apt_key_provider_spec.rb
@@ -482,6 +482,20 @@ ZTQcCD53HcBLvKX6RJ4ByYawKaQqMa27WK/YWVmFXqVDVk12iKrQW6zktDdGInnD
         shell(PUPPETLABS_KEY_CHECK_COMMAND)
       end
 
+      it 'works with userinfo' do
+        pp = <<-EOS
+        apt_key { 'puppetlabs':
+          id     => '#{PUPPETLABS_GPG_KEY_LONG_ID}',
+          ensure => 'present',
+          source => 'http://dummyuser:dummypassword@#{PUPPETLABS_APT_URL}/#{PUPPETLABS_GPG_KEY_FILE}',
+        }
+        EOS
+
+        apply_manifest(pp, :catch_failures => true)
+        apply_manifest(pp, :catch_failures => true)
+        shell(PUPPETLABS_KEY_CHECK_COMMAND)
+      end
+
       it 'fails with a 404' do
         pp = <<-EOS
         apt_key { 'puppetlabs':
@@ -567,6 +581,20 @@ ZTQcCD53HcBLvKX6RJ4ByYawKaQqMa27WK/YWVmFXqVDVk12iKrQW6zktDdGInnD
           id     => '#{PUPPETLABS_GPG_KEY_LONG_ID}',
           ensure => 'present',
           source => 'https://#{PUPPETLABS_APT_URL}/#{PUPPETLABS_GPG_KEY_FILE}',
+        }
+        EOS
+
+        apply_manifest(pp, :catch_failures => true)
+        apply_manifest(pp, :catch_failures => true)
+        shell(PUPPETLABS_KEY_CHECK_COMMAND)
+      end
+
+      it 'works with userinfo' do
+        pp = <<-EOS
+        apt_key { 'puppetlabs':
+          id     => '#{PUPPETLABS_GPG_KEY_LONG_ID}',
+          ensure => 'present',
+          source => 'https://dummyuser:dummypassword@#{PUPPETLABS_APT_URL}/#{PUPPETLABS_GPG_KEY_FILE}',
         }
         EOS
 

--- a/spec/unit/puppet/type/apt_key_spec.rb
+++ b/spec/unit/puppet/type/apt_key_spec.rb
@@ -136,6 +136,13 @@ describe Puppet::Type::type(:apt_key) do
       )}.to_not raise_error
     end
 
+    it 'allows the http URI with username and password' do
+      expect { Puppet::Type.type(:apt_key).new(
+          :id      => '4BD6EC30',
+          :source  => 'http://testme:Password2@pgp.mit.edu'
+      )}.to_not raise_error
+    end
+
     it 'allows the https URI scheme in source' do
       expect { Puppet::Type.type(:apt_key).new(
         :id      => '4BD6EC30',


### PR DESCRIPTION
now http and https sources for apt_key can take a userinfo
as it should be already since #384

```
apt_key { '...':
  source => 'https://username:password@myhost.com/mypath/key.gpg'
  ..
}
```