### PR TITLE
Undef default for $notify_update in source.pp results in problem with Puppet 3.7.2

### DIFF
--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -18,7 +18,7 @@ define apt::source(
   $key_content       = undef,
   $key_source        = undef,
   $trusted_source    = undef,
-  $notify_update     = undef,
+  $notify_update     = true,
 ) {
   validate_string($architecture, $comment, $location, $repos)
   validate_bool($allow_unsigned)


### PR DESCRIPTION
Puppet master 3.7.2 (the default repo version for Debian) gives the following error:

> Error: "" is not a boolean.  It looks to be a String on node X

I have deduced the problem to the default _undef_ value for `$notify_update` in apt::source.pp. This pp relays the _undef_ to apt::settings at line 120 resulting in the default `$notify_update`'s value of _true_ being set to something weird resulting in the error mentioned above.

I can easily circumvent this by passing on an actual value of `$notify_update` to apt::source but just wanted to let you know... =D