### PR TITLE
Use $::serverversion instead of $::puppetversion.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,7 +6,7 @@ class apt::params {
 
   # prior to puppet 3.5.0, defined() couldn't test if a variable was defined.
   # strict_variables wasn't added until 3.5.0, so this should be fine.
-  if $::puppetversion and versioncmp($::puppetversion, '3.5.0') < 0 {
+  if $::serverversion and versioncmp($::serverversion, '3.5.0') < 0 {
     $xfacts = {
       'lsbdistcodename'     => $::lsbdistcodename,
       'lsbdistrelease'      => $::lsbdistrelease,


### PR DESCRIPTION
If the puppet master version is older than 3.5.0, but the client version
is newer than 3.5.0, then this will fail since the `defined` function does not
operate on variables prior to 3.5.0. This leads to the error

```
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Unable to determine lsbdistid, please install lsb-release first at /etc/puppet/environments/production/modules/apt/manifests/params.pp:137
```

Using the `$::serverversion` fact will ensure that the puppet version that evaluates the `defined` function succeeds.
