### PR TITLE
Detect pending upgrades using `dist-upgrade`

### DIFF
--- a/lib/facter/apt_updates.rb
+++ b/lib/facter/apt_updates.rb
@@ -2,7 +2,7 @@ apt_package_updates = nil
 Facter.add("apt_has_updates") do
   confine :osfamily => 'Debian'
   if File.executable?("/usr/bin/apt-get")
-    apt_get_result = Facter::Util::Resolution.exec('/usr/bin/apt-get -s -o Debug::NoLocking=true upgrade 2>&1')
+    apt_get_result = Facter::Util::Resolution.exec('/usr/bin/apt-get -s -o Debug::NoLocking=true dist-upgrade 2>&1')
     if not apt_get_result.nil?
       apt_package_updates = [[], []]
       apt_get_result.each_line do |line|

--- a/spec/unit/facter/apt_has_updates_spec.rb
+++ b/spec/unit/facter/apt_has_updates_spec.rb
@@ -26,7 +26,7 @@ describe 'apt_has_updates fact' do
       File.stubs(:executable?) # Stub all other calls
       Facter::Util::Resolution.stubs(:exec) # Catch all other calls
       File.expects(:executable?).with('/usr/bin/apt-get').returns true
-      Facter::Util::Resolution.expects(:exec).with('/usr/bin/apt-get -s -o Debug::NoLocking=true upgrade 2>&1').returns ""+
+      Facter::Util::Resolution.expects(:exec).with('/usr/bin/apt-get -s -o Debug::NoLocking=true dist-upgrade 2>&1').returns ""+
         "Inst tzdata [2015f-0+deb8u1] (2015g-0+deb8u1 Debian:stable-updates [all])\n"+
         "Conf tzdata (2015g-0+deb8u1 Debian:stable-updates [all])\n"+
         "Inst unhide.rb [13-1.1] (22-2~bpo8+1 Debian Backports:jessie-backports [all])\n"+

--- a/spec/unit/facter/apt_package_updates_spec.rb
+++ b/spec/unit/facter/apt_package_updates_spec.rb
@@ -17,7 +17,7 @@ describe 'apt_package_updates fact' do
       File.stubs(:executable?) # Stub all other calls
       Facter::Util::Resolution.stubs(:exec) # Catch all other calls
       File.expects(:executable?).with('/usr/bin/apt-get').returns true
-      Facter::Util::Resolution.expects(:exec).with('/usr/bin/apt-get -s -o Debug::NoLocking=true upgrade 2>&1').returns ""+
+      Facter::Util::Resolution.expects(:exec).with('/usr/bin/apt-get -s -o Debug::NoLocking=true dist-upgrade 2>&1').returns ""+
         "Inst tzdata [2015f-0+deb8u1] (2015g-0+deb8u1 Debian:stable-updates [all])\n"+
         "Conf tzdata (2015g-0+deb8u1 Debian:stable-updates [all])\n"+
         "Inst unhide.rb [13-1.1] (22-2~bpo8+1 Debian Backports:jessie-backports [all])\n"+

--- a/spec/unit/facter/apt_security_updates_spec.rb
+++ b/spec/unit/facter/apt_security_updates_spec.rb
@@ -17,7 +17,7 @@ describe 'apt_security_updates fact' do
       File.stubs(:executable?) # Stub all other calls
       Facter::Util::Resolution.stubs(:exec) # Catch all other calls
       File.expects(:executable?).with('/usr/bin/apt-get').returns true
-      Facter::Util::Resolution.expects(:exec).with('/usr/bin/apt-get -s -o Debug::NoLocking=true upgrade 2>&1').returns ""+
+      Facter::Util::Resolution.expects(:exec).with('/usr/bin/apt-get -s -o Debug::NoLocking=true dist-upgrade 2>&1').returns ""+
         "Inst tzdata [2015f-0+deb8u1] (2015g-0+deb8u1 Debian:stable-updates [all])\n"+
         "Conf tzdata (2015g-0+deb8u1 Debian:stable-updates [all])\n"+
         "Inst unhide.rb [13-1.1] (22-2~bpo8+1 Debian Backports:jessie-backports [all])\n"+

--- a/spec/unit/facter/apt_updates_spec.rb
+++ b/spec/unit/facter/apt_updates_spec.rb
@@ -17,7 +17,7 @@ describe 'apt_updates fact' do
       File.stubs(:executable?) # Stub all other calls
       Facter::Util::Resolution.stubs(:exec) # Catch all other calls
       File.expects(:executable?).with('/usr/bin/apt-get').returns true
-      Facter::Util::Resolution.expects(:exec).with('/usr/bin/apt-get -s -o Debug::NoLocking=true upgrade 2>&1').returns ""+
+      Facter::Util::Resolution.expects(:exec).with('/usr/bin/apt-get -s -o Debug::NoLocking=true dist-upgrade 2>&1').returns ""+
         "Inst tzdata [2015f-0+deb8u1] (2015g-0+deb8u1 Debian:stable-updates [all])\n"+
         "Conf tzdata (2015g-0+deb8u1 Debian:stable-updates [all])\n"+
         "Inst unhide.rb [13-1.1] (22-2~bpo8+1 Debian Backports:jessie-backports [all])\n"+


### PR DESCRIPTION
After changing some `apt::source` and `apt::pin`'ing some packages, I was surprised to not see any upgrades in the `$::apt_package_updates` fact.

Relying on `dist-upgrade` instead of a bare `upgrade` made them visible.

| Before | After |
| --- | --- |
| ['linux-libc-dev'] | ['e2fslibs', 'e2fsprogs', 'libapparmor1', 'libseccomp2', 'libsystemd0', 'libudev1', 'systemd', 'ifupdown', 'udev', 'libfuse2', 'fuse2fs', 'linux-libc-dev', 'ruby-rgen', 'ruby-safe-yaml', 'puppet', 'puppet-common'] |
|  | ['libapr1', 'libconfuse-common', 'libconfuse0', 'libhiredis0.10', 'libvarnishapi1', 'linux-image-3.16.0-4-amd64', 'libserialport0', 'libzip2', 'libsigrok2', 'collectd-core', 'collectd', 'libganglia1', 'librdkafka1', 'linux-compiler-gcc-4.8-x86', 'linux-headers-3.16.0-4-amd64', 'linux-headers-3.16.0-4-common', 'linux-libc-dev', 'ruby-rgen', 'ruby-safe-yaml', 'puppet', 'puppet-common'] |
