### PR TITLE
Avoid string comparison error

### DIFF
--- a/manifests/update.pp
+++ b/manifests/update.pp
@@ -13,7 +13,7 @@ class apt::update {
       #if we should kick apt_update.
       $daily_threshold = (strftime('%s') - 86400)
       if $::apt_update_last_success {
-        if $::apt_update_last_success < $daily_threshold {
+        if $::apt_update_last_success + 0 < $daily_threshold {
           $_kick_apt = true
         } else {
           $_kick_apt = false
@@ -28,7 +28,7 @@ class apt::update {
       #if we should kick apt_update.
       $weekly_threshold = (strftime('%s') - 604800)
       if $::apt_update_last_success {
-        if ( $::apt_update_last_success < $weekly_threshold ) {
+        if ( $::apt_update_last_success + 0 < $weekly_threshold ) {
           $_kick_apt = true
         } else {
           $_kick_apt = false


### PR DESCRIPTION
Evaluation Error: Comparison of: String < Integer, is not possible. Caused by 'A String is not comparable to a non String' . at /etc/puppet/modules/apt/manifests/update.pp:16:39