### PR TITLE
Add dpkg_statoverride defined type based on work originally by example42

### DIFF
--- a/manifests/dpkg_statoverride.pp
+++ b/manifests/dpkg_statoverride.pp
@@ -1,0 +1,62 @@
+# = Define: apt::dpkg_statoverride
+#
+# Override ownership and mode of files
+#
+#
+# == Parameters
+#
+# [*name*]
+#   Implicit parameter.
+#   File path.
+#
+# [*user*]
+#   User name (or user id if prepended with '#').
+#
+# [*group*]
+#   Group name (or group id if prepended with '#').
+#
+# [*mode*]
+#   File mode, in octal
+#
+# [*ensure*]
+#   Whether to add or delete this configuration
+#
+#
+# == Examples
+#
+# Usage:
+# apt::dpkg_statoverride { '/var/log/puppet':
+#   user  => 'puppet',
+#   group => 'puppet',
+#   mode  => '750',
+# }
+#
+#
+define apt::dpkg_statoverride(
+  $user,
+  $group,
+  $mode,
+  $ensure = present
+) {
+  Exec {
+    path => '/usr/sbin:/usr/bin:/sbin:/bin',
+  }
+
+  case $ensure {
+    present: {
+      exec { "dpkg_statoverride_${name}-add":
+        command => "dpkg-statoverride --update --force --add '${user}' '${group}' '${mode}' '${name}'",
+        unless  => "dpkg-statoverride --list '${name}' | grep '${user} ${group} ${mode} ${name}'",
+      }
+    }
+    absent: {
+      exec { "dpkg_statoverride_${name}-remove":
+        command => "dpkg-statoverride --remove '${name}'",
+        onlyif  => "dpkg-statoverride --list '${name}'",
+      }
+    }
+    default: {
+      fail("Unknown value for \$ensure: '${ensure}'")
+    }
+  }
+}


### PR DESCRIPTION
This adds a defined type for dpkg_statoverride initially copied from example42-apt, but with some changes (from the version in example42's module):

1) There's a default path set
2) The add uses --force
3) The removal uses "remove" in the title

There are probably more improvements that can be made, but here's a first crack at it.  I probably need to write some tests, for one thing. ;)  But if this feels like a useful feature, I would be happy to finish it out.

If this PR is merged, I'll submit a similar change to the example42 module.