### PR TITLE
remove port number from hostname

### DIFF
--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -124,8 +124,8 @@ define apt::source(
     if is_hash($pin) {
       $_pin = merge($pin, { 'ensure' => $ensure, 'before' => $_before })
     } elsif (is_numeric($pin) or is_string($pin)) {
-      $url_split = split($location, '/')
-      $host      = $url_split[2]
+      $url_split = split($location, '[:\/]+')
+      $host      = $url_split[1]
       $_pin = {
         'ensure'   => $ensure,
         'priority' => $pin,


### PR DESCRIPTION
Solve the issue reported in https://tickets.puppetlabs.com/browse/MODULES-4104 :  if present, remove the port number from repository location in order to get the host name of the repository.