### PR TITLE
(MODULES-4118) Set dpkg option NoLocking in apt_updates fact

### DIFF
--- a/lib/facter/apt_updates.rb
+++ b/lib/facter/apt_updates.rb
@@ -2,7 +2,7 @@ apt_package_updates = nil
 Facter.add("apt_has_updates") do
   confine :osfamily => 'Debian'
   if File.executable?("/usr/bin/apt-get")
-    apt_get_result = Facter::Util::Resolution.exec('/usr/bin/apt-get -s upgrade 2>&1')
+    apt_get_result = Facter::Util::Resolution.exec('/usr/bin/apt-get -s -o Debug::NoLocking=true upgrade 2>&1')
     if not apt_get_result.nil?
       apt_package_updates = [[], []]
       apt_get_result.each_line do |line|


### PR DESCRIPTION
Although the man page for apt-get indicates the --simluate means locking
will be disabled, testing indicates it isn't.
Indeed, regulary collecting facts causes it to clash with the apt_update
Exec occasionally, resulting in failures to lock /var/lib/dpkg
Spefically setting the NoLocking option fixes the issue.