### PR TITLE
(maint) updates spec.opts in prep for parallel_spec

### DIFF
--- a/spec/spec.opts
+++ b/spec/spec.opts
@@ -1,6 +1,0 @@
---format
-s
---colour
---loadby
-mtime
---backtrace


### PR DESCRIPTION
this file is no longer necessary and only gets in the way of `parallel_spec`. at the very least, this file needs to be edited. for example, the `--loadby` option no longer exists for rspec.