### PR TITLE
add safe handling of IPv6 address for APT proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,21 +192,21 @@ apt::source { "archive.ubuntu.com-${lsbdistcodename}":
   key      => '630239CC130E1A7FD81A27B140976EAF437D05B5',
   repos    => 'main universe multiverse restricted',
 }
- 
+
 apt::source { "archive.ubuntu.com-${lsbdistcodename}-security":
   location => 'http://archive.ubuntu.com/ubuntu',
   key      => '630239CC130E1A7FD81A27B140976EAF437D05B5',
   repos    => 'main universe multiverse restricted',
   release  => "${lsbdistcodename}-security"
 }
- 
+
 apt::source { "archive.ubuntu.com-${lsbdistcodename}-updates":
   location => 'http://archive.ubuntu.com/ubuntu',
   key      => '630239CC130E1A7FD81A27B140976EAF437D05B5',
   repos    => 'main universe multiverse restricted',
   release  => "${lsbdistcodename}-updates"
 }
- 
+
 apt::source { "archive.ubuntu.com-${lsbdistcodename}-backports":
  location => 'http://archive.ubuntu.com/ubuntu',
  key      => '630239CC130E1A7FD81A27B140976EAF437D05B5',
@@ -268,7 +268,7 @@ Main class, includes all other classes.
 
 * `proxy`: Configures Apt to connect to a proxy server. Valid options: a hash made up from the following keys:
 
-  * 'host': Specifies a proxy host to be stored in `/etc/apt/apt.conf.d/01proxy`. Valid options: a string containing a hostname. Default: undef.
+  * 'host': Specifies a proxy host to be stored in `/etc/apt/apt.conf.d/01proxy`. Valid options: a string containing a hostname, IPv4 or IPv6 address. Default: undef.
 
   * 'port': Specifies a proxy port to be stored in `/etc/apt/apt.conf.d/01proxy`. Valid options: a string containing a port number. Default: '8080'.
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -63,10 +63,10 @@ class apt (
   if $proxy['host'] and size($proxy['host']) > 3 {
     # '.' is an RFC-valid domain name, but not usable in this context
     if is_ipv4_address($proxy['host']) or is_domain_name($proxy['host']) {
-      $proxy['safehost'] = $proxy['host']
+      $safehost = $proxy['host']
     } elsif is_ipv6_address($proxy['host']) {
       # IPv6 needs to be enclosed in [] to be used properly in the template
-      $proxy['safehost'] = enclose_ipv6($proxy['host'])
+      $safehost = enclose_ipv6($proxy['host'])
     } else {
       # Invalid proxy host format
       fail("The proxy['host'] specified ( ${proxy['host']} ) is not a valid IP or hostname.")

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -53,26 +53,28 @@ class apt (
   if $proxy['ensure'] {
     validate_re($proxy['ensure'], ['file', 'present', 'absent'])
   }
-  if $proxy['host'] {
-    validate_string($proxy['host'])
-  }
   if $proxy['port'] {
-    unless is_integer($proxy['port']) {
-      fail('$proxy port must be an integer')
-    }
+    validate_integer($proxy['port'], 65535, 0)
   }
   if $proxy['https'] {
     validate_bool($proxy['https'])
   }
+  # Validate that $proxy['host'] is a valid, usable domain name or IP address
+  if $proxy['host'] and size($proxy['host']) > 3 {
+    # '.' is an RFC-valid domain name, but not usable in this context
+    if is_ipv4_address($proxy['host']) or is_domain_name($proxy['host']) {
+      $proxy['safehost'] = $proxy['host']
+    } elsif is_ipv6_address($proxy['host']) {
+      # IPv6 needs to be enclosed in [] to be used properly in the template
+      $proxy['safehost'] = enclose_ipv6($proxy['host'])
+    } else {
+      # Invalid proxy host format
+      fail("The proxy['host'] specified ( ${proxy['host']} ) is not a valid IP or hostname.")
+    }
+    fail("The proxy['host'] specified ( ${proxy['host']} ) is too small to be a valid IP or hostname.")
+  }
 
   $_proxy = merge($apt::proxy_defaults, $proxy)
-
-  validate_hash($confs)
-  validate_hash($sources)
-  validate_hash($keys)
-  validate_hash($settings)
-  validate_hash($ppas)
-  validate_hash($pins)
 
   if $_proxy['ensure'] == 'absent' or $_proxy['host'] {
     apt::setting { 'conf-proxy':
@@ -81,6 +83,13 @@ class apt (
       content  => template('apt/_conf_header.erb', 'apt/proxy.erb'),
     }
   }
+
+  validate_hash($confs)
+  validate_hash($sources)
+  validate_hash($keys)
+  validate_hash($settings)
+  validate_hash($ppas)
+  validate_hash($pins)
 
   $sources_list_content = $_purge['sources.list'] ? {
     true    => "# Repos managed by puppet.\n",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-apt",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "author": "Puppet Labs",
   "summary": "Provides an interface for managing Apt source, key, and definitions with Puppet",
   "license": "Apache-2.0",
@@ -8,7 +8,7 @@
   "project_page": "https://github.com/puppetlabs/puppetlabs-apt",
   "issues_url": "https://tickets.puppetlabs.com/browse/MODULES",
   "dependencies": [
-    {"name":"puppetlabs/stdlib","version_requirement":">= 4.5.0 < 5.0.0"}
+    {"name":"puppetlabs/stdlib","version_requirement":">= 4.12.0 < 5.0.0"}
   ],
   "operatingsystem_support": [
     {

--- a/spec/classes/apt_spec.rb
+++ b/spec/classes/apt_spec.rb
@@ -92,6 +92,16 @@ describe 'apt' do
       )}
     end
 
+    context 'host=2001:db8::21' do
+      let(:params) { { :proxy => { 'host' => '2001:db8::21'} } }
+      it { is_expected.to contain_apt__setting('conf-proxy').with({
+        :priority => '01',
+      }).with_content(
+        /Acquire::http::proxy "http:\/\/\[2001:db8::21\]:8080\/";/
+      ).without_content(
+        /Acquire::https::proxy/
+      )}
+    end
     context 'ensure=absent' do
       let(:params) { { :proxy => { 'ensure' => 'absent'} } }
       it { is_expected.to contain_apt__setting('conf-proxy').with({

--- a/templates/proxy.erb
+++ b/templates/proxy.erb
@@ -1,4 +1,4 @@
-Acquire::http::proxy "http://<%= @_proxy['safehost'] %>:<%= @_proxy['port'] %>/";
+Acquire::http::proxy "http://<%= @safehost %>:<%= @_proxy['port'] %>/";
 <%- if @_proxy['https'] %>
-Acquire::https::proxy "https://<%= @_proxy['safehost'] %>:<%= @_proxy['port'] %>/";
+Acquire::https::proxy "https://<%= @safehost %>:<%= @_proxy['port'] %>/";
 <%- end -%>

--- a/templates/proxy.erb
+++ b/templates/proxy.erb
@@ -1,4 +1,4 @@
-Acquire::http::proxy "http://<%= @_proxy['host'] %>:<%= @_proxy['port'] %>/";
+Acquire::http::proxy "http://<%= @_proxy['safehost'] %>:<%= @_proxy['port'] %>/";
 <%- if @_proxy['https'] %>
-Acquire::https::proxy "https://<%= @_proxy['host'] %>:<%= @_proxy['port'] %>/";
+Acquire::https::proxy "https://<%= @_proxy['safehost'] %>:<%= @_proxy['port'] %>/";
 <%- end -%>


### PR DESCRIPTION
* update required version of stdlib to get additional validation routines
* verify that proxy['host'] is a valid IPv4, IPv6, or domain name
* enclose IPv6 addresses in [ ] as needed
* move validate_hash() block in order to keep all of the proxy config stuff together
* ensure port number is a valid integer ( < 65536)
* add test for IPv6 address behavior