### PR TITLE
Allow empty string for release in apt::source

### DIFF
--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -4,7 +4,7 @@ define apt::source(
   $location          = undef,
   $comment           = $name,
   $ensure            = present,
-  $release           = undef,
+  $release           = 'UNDEF',
   $repos             = 'main',
   $include           = {},
   $key               = undef,
@@ -68,7 +68,7 @@ define apt::source(
     $_allow_unsigned = $allow_unsigned
   }
 
-  if ! $release {
+  if $release == 'UNDEF' {
     $_release = $::apt::params::xfacts['lsbdistcodename']
     unless $_release {
       fail('lsbdistcodename fact not available: release parameter required')

--- a/spec/defines/source_spec.rb
+++ b/spec/defines/source_spec.rb
@@ -364,6 +364,19 @@ describe 'apt::source' do
       end
     end
 
+    context 'release is empty string' do
+      let :facts do
+        {
+          :lsbdistid       => 'Debian',
+          :osfamily        => 'Debian',
+          :puppetversion   => Puppet.version,
+        }
+      end
+      let(:params) { { :location => 'hello.there', :release => '' } }
+
+      it { is_expected.to contain_apt__setting('list-my_source').with_content(/hello\.there  main/) }
+    end
+
     context 'invalid pin' do
       let :facts do
         {


### PR DESCRIPTION
This fixes a regression from commit 0a178c33.

Some repos don't have a release. This allows using such repos.

Tests added to make sure when release is set to an empty string the
source file is rendered correctly.

All other tests are passing.