### PR TITLE
This class should be private

### DIFF
--- a/manifests/update.pp
+++ b/manifests/update.pp
@@ -1,5 +1,5 @@
 class apt::update {
-  assert_private
+  assert_private()
 
   #TODO: to catch if $::apt_update_last_success has the value of -1 here. If we
   #opt to do this, a info/warn would likely be all you'd need likely to happen

--- a/manifests/update.pp
+++ b/manifests/update.pp
@@ -1,6 +1,6 @@
 class apt::update {
-  assert_private 
-  
+  assert_private
+
   #TODO: to catch if $::apt_update_last_success has the value of -1 here. If we
   #opt to do this, a info/warn would likely be all you'd need likely to happen
   #on the first run, but if it's not run in awhile something is likely borked

--- a/manifests/update.pp
+++ b/manifests/update.pp
@@ -1,4 +1,6 @@
 class apt::update {
+  assert_private 
+  
   #TODO: to catch if $::apt_update_last_success has the value of -1 here. If we
   #opt to do this, a info/warn would likely be all you'd need likely to happen
   #on the first run, but if it's not run in awhile something is likely borked


### PR DESCRIPTION
Provides a more useful error message when users try to use this class by itself. Without this fix, you'll get something like

```
Error: Evaluation Error: Operator '[]' is not applicable to an Undef Value. at /etc/puppetlabs/code/environments/production/modules/apt/manifests/update.pp:7:8"?
```