### PR TITLE
Ignore subkeys in apt-key's output

### DIFF
--- a/lib/puppet/provider/apt_key/apt_key.rb
+++ b/lib/puppet/provider/apt_key/apt_key.rb
@@ -31,6 +31,8 @@ Puppet::Type.type(:apt_key).provide(:apt_key) do
     key_array = key_output.split("\n").collect do |line|
       if line.start_with?('pub')
           pub_line = line
+          # reset fpr_line, to skip any previous subkeys which were collected
+          fpr_line = nil
       elsif line.start_with?('fpr')
           fpr_line = line
       end


### PR DESCRIPTION
(#MODULES-4358)
The output of `apt-key adv --list-keys --with-colons --fingerprint --fixed-list-mode` is always a `pub` line followed by one of more `fpr` lines (for subkeys, if any). This can cause the wrong pairs of `pub` and `fpr` lines to be hashed, resulting in nonsense.

The ordering `pub`, `fpr`, `pub`, `fpr` is guaranteed by `apt-key`.

Therefore, this commit clears `fpr_line` when a `pub` line is encountered, to reset the grouping. The current code ignores subkeys anyway, so this is no more bad.