### PR TITLE
(PUP-6856) Always define facts

### DIFF
--- a/spec/classes/apt_backports_spec.rb
+++ b/spec/classes/apt_backports_spec.rb
@@ -65,6 +65,7 @@ describe 'apt::backports', :type => :class do
     context 'set everything' do
       let(:facts) do
         {
+          :os => { :family => 'Debian', :name => 'Ubuntu', :release => { :major => '14', :full => '14.04' }},
           :lsbdistid       => 'Ubuntu',
           :osfamily        => 'Debian',
           :lsbdistcodename => 'trusty',
@@ -121,6 +122,7 @@ describe 'apt::backports', :type => :class do
   describe 'mint tests' do
     let(:facts) do
       {
+        :os => { :family => 'Debian', :name => 'Linuxmint', :release => { :major => '17', :full => '17' }},
         :lsbdistid       => 'linuxmint',
         :osfamily        => 'Debian',
         :lsbdistcodename => 'qiana',
@@ -205,6 +207,7 @@ describe 'apt::backports', :type => :class do
   describe 'validation' do
     let(:facts) do
       {
+        :os => { :family => 'Debian', :name => 'Ubuntu', :release => { :major => '14', :full => '14.04' }},
         :lsbdistid       => 'Ubuntu',
         :osfamily        => 'Debian',
         :lsbdistcodename => 'trusty',

--- a/spec/classes/apt_spec.rb
+++ b/spec/classes/apt_spec.rb
@@ -1,7 +1,9 @@
 require 'spec_helper'
 describe 'apt' do
   let(:facts) do
-  { :lsbdistid       => 'Debian',
+  {
+    :os => { :family => 'Debian', :name => 'Debian', :release => { :major => '7', :full => '7.0' }},
+    :lsbdistid       => 'Debian',
     :osfamily        => 'Debian',
     :lsbdistcodename => 'wheezy',
     :puppetversion   => Puppet.version,
@@ -186,7 +188,9 @@ describe 'apt' do
 
   context 'with confs defined on valid osfamily' do
     let :facts do
-      { :osfamily        => 'Debian',
+      {
+        :os => { :family => 'Debian', :name => 'Ubuntu', :release => { :major => '12', :full => '12.04.5' }},
+        :osfamily        => 'Debian',
         :lsbdistcodename => 'precise',
         :lsbdistid       => 'Debian',
         :puppetversion   => Puppet.version,
@@ -212,7 +216,9 @@ describe 'apt' do
 
   context 'with keys defined on valid osfamily' do
     let :facts do
-      { :osfamily        => 'Debian',
+      {
+        :os => { :family => 'Debian', :name => 'Ubuntu', :release => { :major => '12', :full => '12.04.5' }},
+        :osfamily        => 'Debian',
         :lsbdistcodename => 'precise',
         :lsbdistid       => 'Debian',
         :puppetversion   => Puppet.version,
@@ -238,7 +244,9 @@ describe 'apt' do
 
   context 'with ppas defined on valid osfamily' do
     let :facts do
-      { :osfamily        => 'Debian',
+      {
+        :os => { :family => 'Debian', :name => 'Ubuntu', :release => { :major => '12', :full => '12.04.5' }},
+        :osfamily        => 'Debian',
         :lsbdistcodename => 'precise',
         :lsbdistid       => 'ubuntu',
         :lsbdistrelease  => '12.04',
@@ -256,7 +264,9 @@ describe 'apt' do
 
   context 'with settings defined on valid osfamily' do
     let :facts do
-      { :osfamily        => 'Debian',
+      {
+        :os => { :family => 'Debian', :name => 'Ubuntu', :release => { :major => '12', :full => '12.04.5' }},
+        :osfamily        => 'Debian',
         :lsbdistcodename => 'precise',
         :lsbdistid       => 'Debian',
         :puppetversion   => Puppet.version,
@@ -273,7 +283,9 @@ describe 'apt' do
 
   context 'with pins defined on valid osfamily' do
     let :facts do
-      { :osfamily        => 'Debian',
+      {
+        :os => { :family => 'Debian', :name => 'Ubuntu', :release => { :major => '12', :full => '12.04.5' }},
+        :osfamily        => 'Debian',
         :lsbdistcodename => 'precise',
         :lsbdistid       => 'Debian',
         :puppetversion   => Puppet.version,
@@ -322,18 +334,6 @@ describe 'apt' do
         expect {
           subject.call
         }.to raise_error(Puppet::Error)
-      end
-    end
-
-    context 'with unsupported osfamily' do
-      let :facts do
-        { :osfamily => 'Darwin', :puppetversion   => Puppet.version,}
-      end
-
-      it do
-        expect {
-          subject.call
-        }.to raise_error(Puppet::Error, /This module only works on Debian or derivatives like Ubuntu/)
       end
     end
   end

--- a/spec/classes/apt_update_spec.rb
+++ b/spec/classes/apt_update_spec.rb
@@ -3,10 +3,23 @@ require 'spec_helper'
 
 describe 'apt::update', :type => :class do
   context "and apt::update['frequency']='always'" do
-    { 'a recent run' => Time.now.to_i, 'we are due for a run' => 1406660561,'the update-success-stamp file does not exist' => -1 }.each_pair do |desc, factval|
+    {
+      'a recent run'                                 => Time.now.to_i,
+      'we are due for a run'                         => 1406660561,
+      'the update-success-stamp file does not exist' => -1,
+    }.each_pair do |desc, factval|
       context "and $::apt_update_last_success indicates #{desc}" do
-        let(:facts) { { :lsbdistid => 'Debian', :osfamily => 'Debian', :apt_update_last_success => factval, :lsbdistcodename => 'wheezy', :puppetversion   => Puppet.version, } }
-        let (:pre_condition) { "class{'::apt': update => {'frequency' => 'always' },}" }
+        let(:facts) { {
+          :os                      => { :family => 'Debian', :name => 'Debian', :release => { :major => '7', :full => '7.0' }},
+          :lsbdistid               => 'Debian',
+          :osfamily                => 'Debian',
+          :apt_update_last_success => factval,
+          :lsbdistcodename         => 'wheezy',
+          :puppetversion           => Puppet.version,
+        } }
+        let (:pre_condition) {
+          "class{'::apt': update => {'frequency' => 'always' },}"
+        }
         it 'should trigger an apt-get update run' do
           #set the apt_update exec's refreshonly attribute to false
           is_expected.to contain_exec('apt_update').with({'refreshonly' => false})
@@ -14,7 +27,13 @@ describe 'apt::update', :type => :class do
       end
     end
     context 'when $::apt_update_last_success is nil' do
-      let(:facts) { { :lsbdistid => 'Debian', :osfamily => 'Debian', :lsbdistcodename => 'wheezy', :puppetversion   => Puppet.version, } }
+      let(:facts) { {
+        :os              => { :family => 'Debian', :name => 'Debian', :release => { :major => '7', :full => '7.0' }},
+        :lsbdistid       => 'Debian',
+        :osfamily        => 'Debian',
+        :lsbdistcodename => 'wheezy',
+        :puppetversion   => Puppet.version,
+      } }
       let (:pre_condition) { "class{ '::apt': update => {'frequency' => 'always' },}" }
       it 'should trigger an apt-get update run' do
         #set the apt_update exec\'s refreshonly attribute to false
@@ -23,9 +42,20 @@ describe 'apt::update', :type => :class do
     end
   end
   context "and apt::update['frequency']='reluctantly'" do
-    {'a recent run' => Time.now.to_i, 'we are due for a run' => 1406660561,'the update-success-stamp file does not exist' => -1 }.each_pair do |desc, factval|
+    {
+      'a recent run'                                 => Time.now.to_i,
+      'we are due for a run'                         => 1406660561,
+      'the update-success-stamp file does not exist' => -1,
+    }.each_pair do |desc, factval|
       context "and $::apt_update_last_success indicates #{desc}" do
-        let(:facts) { { :lsbdistid => 'Debian', :osfamily => 'Debian', :apt_update_last_success => factval, :lsbdistcodename => 'wheezy', :puppetversion   => Puppet.version,} }
+        let(:facts) { {
+          :os                      => { :family => 'Debian', :name => 'Debian', :release => { :major => '7', :full => '7.0' }},
+          :lsbdistid               => 'Debian',
+          :osfamily                => 'Debian',
+          :apt_update_last_success => factval,
+          :lsbdistcodename         => 'wheezy',
+          :puppetversion           => Puppet.version,
+        } }
         let (:pre_condition) { "class{ '::apt': update => {'frequency' => 'reluctantly' },}" }
         it 'should not trigger an apt-get update run' do
           #don't change the apt_update exec's refreshonly attribute. (it should be true)
@@ -34,7 +64,13 @@ describe 'apt::update', :type => :class do
       end
     end
     context 'when $::apt_update_last_success is nil' do
-      let(:facts) { { :lsbdistid => 'Debian', :osfamily => 'Debian', :lsbdistcodename => 'wheezy', :puppetversion   => Puppet.version, } }
+      let(:facts) { {
+        :os => { :family => 'Debian', :name => 'Debian', :release => { :major => '7', :full => '7.0' }},
+        :lsbdistid       => 'Debian',
+        :osfamily        => 'Debian',
+        :lsbdistcodename => 'wheezy',
+        :puppetversion   => Puppet.version,
+      } }
       let (:pre_condition) { "class{ '::apt': update => {'frequency' => 'reluctantly' },}" }
       it 'should not trigger an apt-get update run' do
         #don't change the apt_update exec's refreshonly attribute. (it should be true)
@@ -46,7 +82,14 @@ describe 'apt::update', :type => :class do
     context "and apt::update['frequency'] has the value of #{update_frequency}" do
       { 'we are due for a run' => 1406660561,'the update-success-stamp file does not exist' => -1 }.each_pair do |desc, factval|
         context "and $::apt_update_last_success indicates #{desc}" do
-          let(:facts) { { :lsbdistid => 'Debian', :osfamily => 'Debian', :apt_update_last_success => factval, :lsbdistcodename => 'wheezy', :puppetversion   => Puppet.version, } }
+          let(:facts) { {
+            :os => { :family => 'Debian', :name => 'Debian', :release => { :major => '7', :full => '7.0' }},
+            :lsbdistid               => 'Debian',
+            :osfamily                => 'Debian',
+            :apt_update_last_success => factval,
+            :lsbdistcodename         => 'wheezy',
+            :puppetversion           => Puppet.version,
+          } }
           let (:pre_condition) { "class{ '::apt': update => {'frequency' => '#{update_frequency}',} }" }
           it 'should trigger an apt-get update run' do
             #set the apt_update exec\'s refreshonly attribute to false
@@ -55,7 +98,14 @@ describe 'apt::update', :type => :class do
         end
       end
       context 'when the $::apt_update_last_success fact has a recent value' do
-        let(:facts) { { :lsbdistid => 'Debian', :osfamily => 'Debian', :lsbdistcodename => 'wheezy', :apt_update_last_success => Time.now.to_i, :puppetversion   => Puppet.version, } }
+        let(:facts) { {
+          :os => { :family => 'Debian', :name => 'Debian', :release => { :major => '7', :full => '7.0' }},
+          :lsbdistid               => 'Debian',
+          :osfamily                => 'Debian',
+          :lsbdistcodename         => 'wheezy',
+          :apt_update_last_success => Time.now.to_i,
+          :puppetversion           => Puppet.version,
+        } }
         let (:pre_condition) { "class{ '::apt': update => {'frequency' => '#{update_frequency}',} }" }
         it 'should not trigger an apt-get update run' do
           #don't change the apt_update exec\'s refreshonly attribute. (it should be true)
@@ -63,7 +113,14 @@ describe 'apt::update', :type => :class do
         end
       end
       context 'when $::apt_update_last_success is nil' do
-        let(:facts) { { :lsbdistid => 'Debian', :osfamily => 'Debian', :lsbdistcodename => 'wheezy', :apt_update_last_success => nil, :puppetversion   => Puppet.version, } }
+        let(:facts) { {
+          :os => { :family => 'Debian', :name => 'Debian', :release => { :major => '7', :full => '7.0' }},
+          :lsbdistid               => 'Debian',
+          :osfamily                => 'Debian',
+          :lsbdistcodename         => 'wheezy',
+          :apt_update_last_success => nil,
+          :puppetversion           => Puppet.version,
+        } }
         let (:pre_condition) { "class{ '::apt': update => {'frequency' => '#{update_frequency}',} }" }
         it 'should trigger an apt-get update run' do
           #set the apt_update exec\'s refreshonly attribute to false

--- a/spec/defines/conf_spec.rb
+++ b/spec/defines/conf_spec.rb
@@ -3,7 +3,13 @@ describe 'apt::conf', :type => :define do
   let :pre_condition do
     'class { "apt": }'
   end
-  let(:facts) { { :lsbdistid => 'Debian', :osfamily => 'Debian', :lsbdistcodename => 'wheezy', :puppetversion   => Puppet.version, } }
+  let(:facts) { {
+    :os => { :family => 'Debian', :name => 'Debian', :release => { :major => '7', :full => '7.0' }},
+    :lsbdistid       => 'Debian',
+    :osfamily        => 'Debian',
+    :lsbdistcodename => 'wheezy',
+    :puppetversion   => Puppet.version,
+  } }
   let :title do
     'norecommends'
   end

--- a/spec/defines/key_compat_spec.rb
+++ b/spec/defines/key_compat_spec.rb
@@ -2,8 +2,9 @@ require 'spec_helper'
 
 describe 'apt::key', :type => :define do
   let(:facts) { {
-    :lsbdistid => 'Debian',
-    :osfamily => 'Debian',
+    :os => { :family => 'Debian', :name => 'Debian', :release => { :major => '7', :full => '7.0' }},
+    :lsbdistid     => 'Debian',
+    :osfamily      => 'Debian',
     :puppetversion => Puppet.version,
   } }
   GPG_KEY_ID = '6F6B15509CF8E59E6E469F327F438280EF8D349F'

--- a/spec/defines/key_spec.rb
+++ b/spec/defines/key_spec.rb
@@ -5,7 +5,13 @@ describe 'apt::key' do
     'class { "apt": }'
   end
 
-  let(:facts) { { :lsbdistid => 'Debian', :osfamily => 'Debian', :lsbdistcodename => 'wheezy', :puppetversion   => Puppet.version, } }
+  let(:facts) { {
+    :os => { :family => 'Debian', :name => 'Debian', :release => { :major => '7', :full => '7.0' }},
+    :lsbdistid       => 'Debian',
+    :osfamily        => 'Debian',
+    :lsbdistcodename => 'wheezy',
+    :puppetversion   => Puppet.version,
+  } }
 
   GPG_KEY_ID = '6F6B15509CF8E59E6E469F327F438280EF8D349F'
 

--- a/spec/defines/pin_spec.rb
+++ b/spec/defines/pin_spec.rb
@@ -3,7 +3,13 @@ describe 'apt::pin', :type => :define do
   let :pre_condition do
     'class { "apt": }'
   end
-  let(:facts) { { :lsbdistid => 'Debian', :osfamily => 'Debian', :lsbdistcodename => 'wheezy', :puppetversion   => Puppet.version, } }
+  let(:facts) { {
+    :os => { :family => 'Debian', :name => 'Debian', :release => { :major => '7', :full => '7.0' }},
+    :lsbdistid       => 'Debian',
+    :osfamily        => 'Debian',
+    :lsbdistcodename => 'wheezy',
+    :puppetversion   => Puppet.version,
+  } }
   let(:title) { 'my_pin' }
 
   context 'defaults' do

--- a/spec/defines/ppa_spec.rb
+++ b/spec/defines/ppa_spec.rb
@@ -325,6 +325,7 @@ describe 'apt::ppa' do
     end
     let :facts do
       {
+        :os => { :family => 'Debian', :name => 'Ubuntu', :release => { :major => '14', :full => '14.04' }},
         :lsbdistrelease  => '14.04',
         :lsbdistcodename => 'trusty',
         :operatingsystem => 'Ubuntu',
@@ -349,6 +350,7 @@ describe 'apt::ppa' do
     describe 'no release' do
       let :facts do
         {
+          :os => { :family => 'Debian', :name => 'Ubuntu', :release => { :major => '14', :full => '14.04' }},
           :lsbdistrelease  => '14.04',
           :operatingsystem => 'Ubuntu',
           :lsbdistid       => 'Ubuntu',
@@ -368,6 +370,7 @@ describe 'apt::ppa' do
     describe 'not ubuntu' do
       let :facts do
         {
+          :os => { :family => 'Debian', :name => 'Debian', :release => { :major => '6', :full => '6.0.7' }},
           :lsbdistrelease  => '6.0.7',
           :lsbdistcodename => 'wheezy',
           :operatingsystem => 'Debian',

--- a/spec/defines/setting_spec.rb
+++ b/spec/defines/setting_spec.rb
@@ -71,7 +71,13 @@ describe 'apt::setting' do
       apt::setting { "list-teddybear": content => "foo" }
       '
     end
-    let(:facts) { { :lsbdistid => 'Debian', :osfamily => 'Debian', :lsbdistcodename => 'wheezy', :puppetversion   => Puppet.version, } }
+    let(:facts) { {
+      :os => { :family => 'Debian', :name => 'Debian', :release => { :major => '7', :full => '7.0' }},
+      :lsbdistid       => 'Debian',
+      :osfamily        => 'Debian',
+      :lsbdistcodename => 'wheezy',
+      :puppetversion   => Puppet.version,
+    } }
     let(:title) { 'conf-teddybear' }
     let(:default_params) { { :content => 'di' } }
 

--- a/spec/defines/source_compat_spec.rb
+++ b/spec/defines/source_compat_spec.rb
@@ -10,6 +10,7 @@ describe 'apt::source', :type => :define do
   context 'mostly defaults' do
     let :facts do
       {
+        :os => { :family => 'Debian', :name => 'Debian', :release => { :major => '7', :full => '7.0' }},
         :lsbdistid       => 'Debian',
         :lsbdistcodename => 'wheezy',
         :osfamily        => 'Debian',
@@ -32,6 +33,7 @@ describe 'apt::source', :type => :define do
   context 'no defaults' do
     let :facts do
       {
+        :os => { :family => 'Debian', :name => 'Debian', :release => { :major => '7', :full => '7.0' }},
         :lsbdistid       => 'Debian',
         :lsbdistcodename => 'wheezy',
         :osfamily        => 'Debian',
@@ -88,6 +90,7 @@ describe 'apt::source', :type => :define do
   context 'trusted_source true' do
     let :facts do
       {
+        :os => { :family => 'Debian', :name => 'Debian', :release => { :major => '7', :full => '7.0' }},
         :lsbdistid       => 'Debian',
         :lsbdistcodename => 'wheezy',
         :osfamily        => 'Debian',
@@ -108,6 +111,7 @@ describe 'apt::source', :type => :define do
   context 'architecture equals x86_64' do
     let :facts do
       {
+        :os => { :family => 'Debian', :name => 'Debian', :release => { :major => '7', :full => '7.0' }},
         :lsbdistid       => 'Debian',
         :lsbdistcodename => 'wheezy',
         :osfamily        => 'Debian',
@@ -128,6 +132,7 @@ describe 'apt::source', :type => :define do
   context 'ensure => absent' do
     let :facts do
       {
+        :os => { :family => 'Debian', :name => 'Debian', :release => { :major => '7', :full => '7.0' }},
         :lsbdistid       => 'Debian',
         :lsbdistcodename => 'wheezy',
         :osfamily        => 'Debian',
@@ -150,6 +155,7 @@ describe 'apt::source', :type => :define do
     context 'no release' do
       let :facts do
         {
+          :os => { :family => 'Debian', :name => 'Debian', :release => { :major => '7', :full => '7.0' }},
           :lsbdistid       => 'Debian',
           :osfamily        => 'Debian',
           :puppetversion   => Puppet.version,

--- a/spec/defines/source_spec.rb
+++ b/spec/defines/source_spec.rb
@@ -15,7 +15,7 @@ describe 'apt::source' do
     context 'without location' do
       let :facts do
         {
-          :os => { :family => 'Debian' },
+          :os => { :family => 'Debian', :name => 'Debian', :release => { :major => '7', :full => '7.0' }},
           :osfamily        => 'Debian',
           :lsbdistcodename => 'wheezy',
           :puppetversion   => Puppet.version,
@@ -30,6 +30,7 @@ describe 'apt::source' do
     context 'with location' do
       let :facts do
         {
+          :os => { :family => 'Debian', :name => 'Debian', :release => { :major => '7', :full => '7.0' }},
           :lsbdistid       => 'Debian',
           :lsbdistcodename => 'wheezy',
           :osfamily        => 'Debian',
@@ -192,6 +193,7 @@ describe 'apt::source' do
   context 'allow_unsigned true' do
     let :facts do
       {
+        :os => { :family => 'Debian', :name => 'Debian', :release => { :major => '7', :full => '7.0' }},
         :lsbdistid       => 'Debian',
         :lsbdistcodename => 'wheezy',
         :osfamily        => 'Debian',
@@ -214,6 +216,7 @@ describe 'apt::source' do
   context 'architecture equals x86_64' do
     let :facts do
       {
+        :os => { :family => 'Debian', :name => 'Debian', :release => { :major => '7', :full => '7.0' }},
         :lsbdistid       => 'Debian',
         :lsbdistcodename => 'wheezy',
         :osfamily        => 'Debian',
@@ -237,6 +240,7 @@ describe 'apt::source' do
   context 'include_src => true' do
     let :facts do
       {
+        :os => { :family => 'Debian', :name => 'Debian', :release => { :major => '7', :full => '7.0' }},
         :lsbdistid       => 'Debian',
         :lsbdistcodename => 'wheezy',
         :osfamily        => 'Debian',
@@ -259,6 +263,7 @@ describe 'apt::source' do
   context 'include_deb => false' do
     let :facts do
       {
+        :os => { :family => 'Debian', :name => 'Debian', :release => { :major => '7', :full => '7.0' }},
         :lsbdistid       => 'debian',
         :lsbdistcodename => 'wheezy',
         :osfamily        => 'debian',
@@ -282,6 +287,7 @@ describe 'apt::source' do
   context 'include_src => true and include_deb => false' do
     let :facts do
       {
+        :os => { :family => 'Debian', :name => 'Debian', :release => { :major => '7', :full => '7.0' }},
         :lsbdistid       => 'debian',
         :lsbdistcodename => 'wheezy',
         :osfamily        => 'debian',
@@ -306,6 +312,7 @@ describe 'apt::source' do
   context 'include precedence' do
     let :facts do
       {
+        :os => { :family => 'Debian', :name => 'Debian', :release => { :major => '7', :full => '7.0' }},
         :lsbdistid       => 'debian',
         :lsbdistcodename => 'wheezy',
         :osfamily        => 'debian',
@@ -331,6 +338,7 @@ describe 'apt::source' do
   context 'ensure => absent' do
     let :facts do
       {
+        :os => { :family => 'Debian', :name => 'Debian', :release => { :major => '7', :full => '7.0' }},
         :lsbdistid       => 'Debian',
         :lsbdistcodename => 'wheezy',
         :osfamily        => 'Debian',
@@ -353,6 +361,7 @@ describe 'apt::source' do
     context 'no release' do
       let :facts do
         {
+          :os => { :family => 'Debian', :name => 'Debian', :release => { :major => '7', :full => '7.0' }},
           :lsbdistid       => 'Debian',
           :osfamily        => 'Debian',
           :puppetversion   => Puppet.version,
@@ -370,6 +379,7 @@ describe 'apt::source' do
     context 'invalid pin' do
       let :facts do
         {
+          :os => { :family => 'Debian', :name => 'Debian', :release => { :major => '7', :full => '7.0' }},
           :lsbdistid       => 'Debian',
           :lsbdistcodename => 'wheezy',
           :osfamily        => 'Debian',
@@ -393,6 +403,7 @@ describe 'apt::source' do
     context "with notify_update = undef (default)" do
       let :facts do
         {
+          :os => { :family => 'Debian', :name => 'Debian', :release => { :major => '7', :full => '7.0' }},
           :lsbdistid       => 'Debian',
           :lsbdistcodename => 'wheezy',
           :osfamily        => 'Debian',
@@ -410,6 +421,7 @@ describe 'apt::source' do
     context "with notify_update = true" do
       let :facts do
         {
+          :os => { :family => 'Debian', :name => 'Debian', :release => { :major => '7', :full => '7.0' }},
           :lsbdistid       => 'Debian',
           :lsbdistcodename => 'wheezy',
           :osfamily        => 'Debian',
@@ -428,6 +440,7 @@ describe 'apt::source' do
     context "with notify_update = false" do
       let :facts do
         {
+          :os => { :family => 'Debian', :name => 'Debian', :release => { :major => '7', :full => '7.0' }},
           :lsbdistid       => 'Debian',
           :lsbdistcodename => 'wheezy',
           :osfamily        => 'Debian',


### PR DESCRIPTION
If facts are not defined for hiera lookups, the lookup will fail instead
of falling back to common on puppet < 4.9.0