### PR TITLE
Fix architecture fact overriding unset `architecture` source option

### DIFF
--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -99,13 +99,13 @@ define apt::source(
   $header = epp('apt/_header.epp')
 
   $sourcelist = epp('apt/source.list.epp', {
-    'comment'        => $comment,
-    'includes'       => $includes,
-    'architecture'   => $architecture,
-    'allow_unsigned' => $_allow_unsigned,
-    'location'       => $location,
-    'release'        => $_release,
-    'repos'          => $repos,
+    'comment'          => $comment,
+    'includes'         => $includes,
+    'opt_architecture' => $architecture,
+    'allow_unsigned'   => $_allow_unsigned,
+    'location'         => $location,
+    'release'          => $_release,
+    'repos'            => $repos,
   })
 
   apt::setting { "list-${name}":

--- a/spec/defines/source_spec.rb
+++ b/spec/defines/source_spec.rb
@@ -237,6 +237,30 @@ describe 'apt::source' do
     }
   end
 
+  context 'with architecture fact and unset architecture parameter' do
+    let :facts do
+      {
+        :architecture    => 'amd64',
+        :os => { :family => 'Debian', :name => 'Debian', :release => { :major => '7', :full => '7.0' }},
+        :lsbdistid       => 'Debian',
+        :lsbdistcodename => 'wheezy',
+        :osfamily        => 'Debian',
+        :puppetversion   => Puppet.version,
+      }
+    end
+    let :params do
+      {
+        :location => 'hello.there',
+        :include  => {'deb' => false, 'src' => true,},
+      }
+    end
+
+    it { is_expected.to contain_apt__setting('list-my_source').with({
+      :ensure => 'present',
+    }).with_content(/# my_source\ndeb-src hello.there wheezy main\n/)
+    }
+  end
+
   context 'include_src => true' do
     let :facts do
       {

--- a/templates/source.list.epp
+++ b/templates/source.list.epp
@@ -1,10 +1,10 @@
-<%- | String $comment, Hash $includes, $architecture, Boolean $allow_unsigned, $location, $release, String $repos | -%>
+<%- | String $comment, Hash $includes, $opt_architecture, Boolean $allow_unsigned, $location, $release, String $repos | -%>
 # <%= $comment %>
 <%- if $includes['deb'] { -%>
-deb <%- if ($architecture or $allow_unsigned) {-%>
- [<%- if ($architecture) {%>arch=<%= $architecture %><% } %><%if ($architecture and $allow_unsigned) {%> <% }%><% if ($allow_unsigned) {%>trusted=yes<% } %>] <%- } %> <%= $location %> <%= $release %> <%= $repos %>
+deb <%- if ($opt_architecture or $allow_unsigned) {-%>
+ [<%- if ($opt_architecture) {%>arch=<%= $opt_architecture %><% } %><%if ($opt_architecture and $allow_unsigned) {%> <% }%><% if ($allow_unsigned) {%>trusted=yes<% } %>] <%- } %> <%= $location %> <%= $release %> <%= $repos %>
 <%- } -%>
 <%- if $includes['src'] { -%>
-deb-src <%- if $architecture or $allow_unsigned { -%>
- [<%- if ($architecture) {%>arch=<%= $architecture %><% } %><%if ($architecture and $allow_unsigned) {%> <% }%><% if ($allow_unsigned) {%>trusted=yes<% } %>] <%- } %> <%= $location %> <%= $release %> <%= $repos %>
+deb-src <%- if $opt_architecture or $allow_unsigned { -%>
+ [<%- if ($opt_architecture) {%>arch=<%= $opt_architecture %><% } %><%if ($opt_architecture and $allow_unsigned) {%> <% }%><% if ($allow_unsigned) {%>trusted=yes<% } %>] <%- } %> <%= $location %> <%= $release %> <%= $repos %>
 <%- } -%>


### PR DESCRIPTION
When the `architecture` parameter to apt::source wasn't set, the
`architecture` fact would be used instead, causing the source to always
be limited by the architecture of the host.

The EPP variable has been renamed to avoid clashing with the fact name.

---

Regression in 3.0.0 vs previous release, introduced by b87e1af3.