### PR TITLE
(maint) Fix for different versions

### DIFF
--- a/spec/classes/apt_backports_spec.rb
+++ b/spec/classes/apt_backports_spec.rb
@@ -224,7 +224,7 @@ describe 'apt::backports', :type => :class do
       it do
         expect {
           subject.call
-        }.to raise_error(Puppet::Error, /expects a value of type Undef or String/)
+        }.to raise_error(Puppet::Error, /expects a/)
       end
     end
     context 'invalid release' do
@@ -236,7 +236,7 @@ describe 'apt::backports', :type => :class do
       it do
         expect {
           subject.call
-        }.to raise_error(Puppet::Error, /expects a value of type Undef or String/)
+        }.to raise_error(Puppet::Error, /expects a/)
       end
     end
     context 'invalid repos' do
@@ -248,7 +248,7 @@ describe 'apt::backports', :type => :class do
       it do
         expect {
           subject.call
-        }.to raise_error(Puppet::Error, /expects a value of type Undef or String/)
+        }.to raise_error(Puppet::Error, /expects a/)
       end
     end
     context 'invalid key' do
@@ -260,7 +260,7 @@ describe 'apt::backports', :type => :class do
       it do
         expect {
           subject.call
-        }.to raise_error(Puppet::Error, /expects a value of type Undef, String, or Hash, got Boolean/)
+        }.to raise_error(Puppet::Error, /expects a/)
       end
     end
     context 'invalid pin' do
@@ -272,7 +272,7 @@ describe 'apt::backports', :type => :class do
       it do
         expect {
           subject.call
-        }.to raise_error(Puppet::Error, /expects a value of type Undef, Integer, String, or Hash, got Boolean/)
+        }.to raise_error(Puppet::Error, /expects a/)
       end
     end
   end

--- a/spec/defines/key_compat_spec.rb
+++ b/spec/defines/key_compat_spec.rb
@@ -246,7 +246,7 @@ describe 'apt::key', :type => :define do
         :content => [],
       } end
       it 'fails' do
-        expect { subject.call }.to raise_error(/expects a value of type Undef or String/)
+        expect { subject.call }.to raise_error(/expects a/)
       end
     end
 
@@ -264,7 +264,7 @@ describe 'apt::key', :type => :define do
         :options => {},
       } end
       it 'fails' do
-        expect { subject.call }.to raise_error(/expects a value of type Undef or String/)
+        expect { subject.call }.to raise_error(/expects a/)
       end
     end
 

--- a/spec/defines/key_spec.rb
+++ b/spec/defines/key_spec.rb
@@ -251,7 +251,7 @@ describe 'apt::key' do
         :content => [],
       } end
       it 'fails' do
-        expect { subject.call }.to raise_error(/expects a value of type Undef or String/)
+        expect { subject.call }.to raise_error(/expects a/)
       end
     end
 
@@ -269,7 +269,7 @@ describe 'apt::key' do
         :options => {},
       } end
       it 'fails' do
-        expect { subject.call }.to raise_error(/expects a value of type Undef or String/)
+        expect { subject.call }.to raise_error(/expects a/)
       end
     end
 


### PR DESCRIPTION
The error messages changed between 4.7 and 4.10, so we don't need to match on the whole thing.