### PR TITLE
(#4913) apt_key now does not always send auth basic

### DIFF
--- a/lib/puppet/provider/apt_key/apt_key.rb
+++ b/lib/puppet/provider/apt_key/apt_key.rb
@@ -127,9 +127,15 @@ Puppet::Type.type(:apt_key).provide(:apt_key) do
       f
     else
       begin
-        user_pass = parsedValue.userinfo.nil? ? nil : parsedValue.userinfo.split(':')
-        parsedValue.userinfo = ''
-        key = open(parsedValue, :http_basic_authentication => user_pass).read
+        # Only send basic auth if URL contains userinfo
+        # Some webservers (e.g. Amazon S3) return code 400 if empty basic auth is sent
+        if parsedValue.userinfo.nil?
+          key = parsedValue.read
+        else
+          user_pass = parsedValue.userinfo.split(':')
+          parsedValue.userinfo = ''
+          key = open(parsedValue, :http_basic_authentication => user_pass).read
+        end
       rescue OpenURI::HTTPError, Net::FTPPermError => e
         fail("#{e.message} for #{resource[:source]}")
       rescue SocketError


### PR DESCRIPTION
https://tickets.puppetlabs.com/browse/MODULES-4913

Prior to this commit, apt_key always sent auth basic header when source
came from http(s). This might fail for some webservers (e.g. Amazon S3)
when empty auth basic is sent.

Now apt_key only sends the auth basic header when userinfo can
be parsed from the URL.

Please backport this to 2.4.x, since this is the release before incompatibility changes are made. 