### PR TITLE
Ensure release allows empty strings

### DIFF
--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -19,7 +19,7 @@ define apt::source(
 
   $_before = Apt::Setting["list-${title}"]
 
-  if ! $release {
+  if !$release {
     if $facts['lsbdistcodename'] {
       $_release = $facts['lsbdistcodename']
     } else {

--- a/spec/defines/source_spec.rb
+++ b/spec/defines/source_spec.rb
@@ -373,6 +373,20 @@ describe 'apt::source' do
       end
     end
 
+    context 'release is empty string' do
+      let :facts do
+        {
+          :os => { :family => 'Debian', :name => 'Debian', :release => { :major => '7', :full => '7.0' }},
+          :lsbdistid       => 'Debian',
+          :osfamily        => 'Debian',
+          :puppetversion   => Puppet.version,
+        }
+      end
+      let(:params) { { :location => 'hello.there', :release => '' } }
+
+      it { is_expected.to contain_apt__setting('list-my_source').with_content(/hello\.there  main/) }
+    end
+
     context 'invalid pin' do
       let :facts do
         {


### PR DESCRIPTION
Ensures $release now accepts empty strings as a value without failing and addition of test 

