### PR TITLE
(maint) fix incorrect error message

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -119,7 +119,7 @@ class apt::params {
       }
     }
     undef: {
-      fail('Unable to determine full release number')
+      fail('Unable to determine value for fact os["name"]')
     }
     default: {
       $ppa_options = undef


### PR DESCRIPTION
this failure is related to os.name, not os.release.full