### PR TITLE
Add fact apt_security_package_updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,8 @@ apt::source { "archive.ubuntu.com-${lsbdistcodename}-backports":
 
 * `apt_reboot_required`: Determines if a reboot is necessary after updates have been installed.
 
+* `apt_security_package_updates`: The names of all installed packages with available security updates. In Facter 2.0 and later this data is formatted as an array; in earlier versions it is a comma-delimited string.
+
 #### Class: `apt`
 
 Main class, includes all other classes.

--- a/lib/facter/apt_updates.rb
+++ b/lib/facter/apt_updates.rb
@@ -55,3 +55,14 @@ Facter.add("apt_security_updates") do
     Integer(apt_package_updates[1].length)
   end
 end
+
+Facter.add("apt_security_package_updates") do
+  confine :apt_has_updates => true
+  setcode do
+    if Facter.version < '2.0.0'
+      apt_package_updates[1].join(',')
+    else
+      apt_package_updates[1]
+    end
+  end
+end

--- a/spec/unit/facter/apt_security_package_updates_spec.rb
+++ b/spec/unit/facter/apt_security_package_updates_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+describe 'apt_security_package_updates fact' do
+  subject { Facter.fact(:apt_security_package_updates).value }
+  after(:each) { Facter.clear }
+
+  describe 'when apt has no security updates' do
+    before { 
+      Facter.fact(:apt_has_updates).stubs(:value).returns false
+    }
+    it { is_expected.to be nil }
+  end
+
+  describe 'when apt has security updates' do
+    before { 
+      Facter.fact(:osfamily).stubs(:value).returns 'Debian'
+      File.stubs(:executable?) # Stub all other calls
+      Facter::Util::Resolution.stubs(:exec) # Catch all other calls
+      File.expects(:executable?).with('/usr/bin/apt-get').returns true
+      Facter::Util::Resolution.expects(:exec).with('/usr/bin/apt-get -s upgrade 2>&1').returns ""+
+        "Inst tzdata [2015f-0+deb8u1] (2015g-0+deb8u1 Debian:stable-updates [all])\n"+
+        "Conf tzdata (2015g-0+deb8u1 Debian:stable-updates [all])\n"+
+        "Inst unhide.rb [13-1.1] (22-2~bpo8+1 Debian Backports:jessie-backports [all])\n"+
+        "Conf unhide.rb (22-2~bpo8+1 Debian Backports:jessie-backports [all])\n"
+    }
+    it {
+      if Facter.version < '2.0.0'
+        is_expected.to eq('tzdata')
+      else
+        is_expected.to eq(['tzdata'])
+      end
+    }
+  end
+end


### PR DESCRIPTION
This PR deals with : https://tickets.puppetlabs.com/browse/MODULES-5084. 

This PR adds a fact named "apt_security_package_updates", which lists the available security updates.

```
apt_security_package_updates => [
  "mysql-common",
  "libmysqlclient18"
]
```
