### PR TITLE
Allow user to modify loglevel of apt-get update Exec resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,15 @@ class { 'apt':
   },
 }
 ```
+When `Exec['apt_update']` is triggered, it will generate a `Notice` message. Because the default [logging level for agents](https://docs.puppet.com/puppet/latest/configuration.html#loglevel) is `notice`, this will cause the repository update to appear in logs and agent reports. Some tools, such as [The Foreman](https://www.theforeman.org), report the update notice as a significant change. By setting the [loglevel](https://docs.puppet.com/puppet/latest/metaparameter.html#loglevel) metaparameter for `Exec['apt_update']` above the agent logging level, one can eliminate these updates from reports:
+```puppet
+class { 'apt':
+  update => {
+    frequency => 'daily',
+    loglevel  => 'debug',
+  },
+}
+```
 
 ### Pin a specific release
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -39,6 +39,7 @@ class apt::params {
 
   $update_defaults = {
     'frequency' => 'reluctantly',
+    'loglevel'  => undef,
     'timeout'   => undef,
     'tries'     => undef,
   }

--- a/manifests/update.pp
+++ b/manifests/update.pp
@@ -52,6 +52,7 @@ class apt::update {
   }
   exec { 'apt_update':
     command     => "${::apt::provider} update",
+    loglevel    => $::apt::_update['loglevel'],
     logoutput   => 'on_failure',
     refreshonly => $_refresh,
     timeout     => $::apt::_update['timeout'],


### PR DESCRIPTION
The goal of this PR is to optionally eliminate unnecessary `Notices` in the syslog and in agent reports. When the `apt_update` Exec resource runs successfully the Notice is interpreted by [Foreman](https://www.theforeman.org) as a "host modification performed without error." While this is, in some sense, true, it's not something I care to know about at the default level of logging and it's reasonable to optionally reduce it.

Confirmed to be a no-op with these hiera data:
```
apt::update:
  frequency: daily
```
Confirmed to eliminate logging at the default agent level of `notice` when these data are used:
```
apt::update:
  frequency: daily
  loglevel: debug
```