### PR TITLE
Fixed typo in "Configuring Apt from hiera example"

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ include the `apt` class, which will pick up the values automatically from
 hiera.
 
 ```yaml
-apt::source:
+apt::sources:
   'debian_unstable':
     comment: 'This is the iWeb Debian unstable mirror'
     location: 'http://debian.mirror.iweb.ca/debian/'


### PR DESCRIPTION
This fixes 09fe368ae25afca684b75e87d81486252ccb6822, which should originally fix the problem that the class is named `apt::source`.

To actually configure repositories, you need to use `apt::sources` as `init.pp` hands this down to `source.pp`.

