### PR TITLE
(FM-6273) - Removing Debian 6

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -15,7 +15,6 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "6",
         "7",
         "8"
       ]


### PR DESCRIPTION
This is not supported any longer according to the following
documentation: https://docs.puppet.com/pe/latest/sys_req_os.html