### PR TITLE
Add 16.04 to list of distributions that should use software-properties-common.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -109,7 +109,7 @@ class apt::params {
           $ppa_options        = '-y'
           $ppa_package        = 'python-software-properties'
         }
-        '14.04', '14.10', '15.04', '15.10': {
+        '14.04', '14.10', '15.04', '15.10', '16.04': {
           $ppa_options        = '-y'
           $ppa_package        = 'software-properties-common'
         }


### PR DESCRIPTION
As discussed on Slack with Eric Puttnam this looks to have been accidentally been removed.

Thanks,
Trevor