### PR TITLE
fix documentation for parameter $proxy['port'] in class apt

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ Main class, includes all other classes.
 
   * 'host': Specifies a proxy host to be stored in `/etc/apt/apt.conf.d/01proxy`. Valid options: a string containing a hostname. Default: undef.
 
-  * 'port': Specifies a proxy port to be stored in `/etc/apt/apt.conf.d/01proxy`. Valid options: a string containing a port number. Default: '8080'.
+  * 'port': Specifies a proxy port to be stored in `/etc/apt/apt.conf.d/01proxy`. Valid options: an integer containing a port number. Default: 8080.
 
   * 'https': Specifies whether to enable https proxies. Valid options: 'true' and 'false'. Default: 'false'.
 


### PR DESCRIPTION
Documentation says 'port' should be a string.
https://github.com/puppetlabs/puppetlabs-apt/blob/a541b4ee32ea39f3eb23d4ffa3311daba61d1118/README.md#L282
init.pp checks for type integer.
https://github.com/puppetlabs/puppetlabs-apt/blob/a541b4ee32ea39f3eb23d4ffa3311daba61d1118/manifests/init.pp#L74-L76