### PR TITLE
MODULES-4686: gpg keyserver import fails in Debian 9 (Stretch)

### DIFF
--- a/lib/puppet/provider/apt_key/apt_key.rb
+++ b/lib/puppet/provider/apt_key/apt_key.rb
@@ -26,15 +26,23 @@ Puppet::Type.type(:apt_key).provide(:apt_key) do
       key_output = apt_key(cli_args)
     end
 
-    pub_line, fpr_line = nil
+    pub_line, sub_line, fpr_line = nil
 
     key_array = key_output.split("\n").collect do |line|
       if line.start_with?('pub')
           pub_line = line
           # reset fpr_line, to skip any previous subkeys which were collected
           fpr_line = nil
+          sub_line = nil
+      elsif line.start_with?('sub')
+          sub_line = line
       elsif line.start_with?('fpr')
           fpr_line = line
+      end
+
+      if (sub_line and fpr_line)
+        sub_line, fpr_line = nil
+        next
       end
 
       next unless (pub_line and fpr_line)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -178,4 +178,19 @@ class apt (
   if $pins {
     create_resources('apt::pin', $pins)
   }
+
+  # required for adding GPG keys on Debian 9 (and derivatives)
+  case $facts['os']['name'] {
+    'Debian': {
+      if versioncmp($facts['os']['release']['full'], '9.0') >= 0 {
+        ensure_packages(['dirmngr'])
+      }
+    }
+    'Ubuntu': {
+      if versioncmp($facts['os']['release']['full'], '17.04') >= 0 {
+        ensure_packages(['dirmngr'])
+      }
+    }
+    default: { }
+  }
 }

--- a/manifests/key.pp
+++ b/manifests/key.pp
@@ -33,6 +33,24 @@ define apt::key (
           server  => $server,
           options => $options,
         } -> anchor { "apt_key ${id} present": }
+
+        case $facts['os']['name'] {
+          'Debian': {
+            if versioncmp($facts['os']['release']['full'], '9.0') >= 0 {
+              AptKey<| title == $title |> {
+                require => Package['dirmngr']
+              }
+            }
+          }
+          'Ubuntu': {
+            if versioncmp($facts['os']['release']['full'], '17.04') >= 0 {
+              AptKey<| title == $title |> {
+                require => Package['dirmngr']
+              }
+            }
+          }
+          default: { }
+        }
       }
     }
 

--- a/manifests/key.pp
+++ b/manifests/key.pp
@@ -37,14 +37,14 @@ define apt::key (
         case $facts['os']['name'] {
           'Debian': {
             if versioncmp($facts['os']['release']['full'], '9.0') >= 0 {
-              AptKey<| title == $title |> {
+              Apt::Key<| title == $title |> {
                 require => Package['dirmngr']
               }
             }
           }
           'Ubuntu': {
             if versioncmp($facts['os']['release']['full'], '17.04') >= 0 {
-              AptKey<| title == $title |> {
+              Apt::Key<| title == $title |> {
                 require => Package['dirmngr']
               }
             }

--- a/manifests/setting.pp
+++ b/manifests/setting.pp
@@ -49,5 +49,4 @@ define apt::setting (
     source  => $source,
     notify  => $_notify,
   }
-
 }

--- a/manifests/setting.pp
+++ b/manifests/setting.pp
@@ -50,13 +50,19 @@ define apt::setting (
     notify  => $_notify,
   }
 
-  case $::operatingsystem {
+  # required for adding apt GPG keys
+  case $facts['os']['name'] {
     'Debian': {
       if versioncmp($facts['os']['release']['full'], '9.0') >= 0 {
-        # require for adding apt GPG keys
         ensure_packages(['dirmngr'])
       }
     }
+    'Ubuntu': {
+      if versioncmp($facts['os']['release']['full'], '17.04') >= 0 {
+        ensure_packages(['dirmngr'])
+      }
+    }
+    default: { }
   }
 
 }

--- a/manifests/setting.pp
+++ b/manifests/setting.pp
@@ -50,19 +50,4 @@ define apt::setting (
     notify  => $_notify,
   }
 
-  # required for adding apt GPG keys
-  case $facts['os']['name'] {
-    'Debian': {
-      if versioncmp($facts['os']['release']['full'], '9.0') >= 0 {
-        ensure_packages(['dirmngr'])
-      }
-    }
-    'Ubuntu': {
-      if versioncmp($facts['os']['release']['full'], '17.04') >= 0 {
-        ensure_packages(['dirmngr'])
-      }
-    }
-    default: { }
-  }
-
 }

--- a/manifests/setting.pp
+++ b/manifests/setting.pp
@@ -49,4 +49,14 @@ define apt::setting (
     source  => $source,
     notify  => $_notify,
   }
+
+  case $::operatingsystem {
+    'Debian': {
+      if versioncmp($facts['os']['release']['full'], '9.0') >= 0 {
+        # require for adding apt GPG keys
+        ensure_packages(['dirmngr'])
+      }
+    }
+  }
+
 }

--- a/metadata.json
+++ b/metadata.json
@@ -16,7 +16,8 @@
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
         "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {


### PR DESCRIPTION
The command `apt-key adv --list-keys` on Debian 9 with argument `--with-fingerprint` prints the fingerprint for the subkeys too.

This patch fixes repeated apt keys imports during each Puppet run on Debian Stretch.

The patch comes from Alex P (alexpr) see discussion on Jira https://tickets.puppetlabs.com/browse/MODULES-4686