### PR TITLE
https proxy bypass fix

### DIFF
--- a/spec/classes/apt_spec.rb
+++ b/spec/classes/apt_spec.rb
@@ -72,8 +72,8 @@ describe 'apt' do
         :priority => '01',
       }).with_content(
         /Acquire::http::proxy "http:\/\/localhost:8080\/";/
-      ).without_content(
-        /Acquire::https::proxy/
+      ).with_content(
+        /Acquire::https::proxy "DIRECT";/
       )}
     end
 
@@ -83,8 +83,8 @@ describe 'apt' do
         :priority => '01',
       }).with_content(
         /Acquire::http::proxy "http:\/\/localhost:8180\/";/
-      ).without_content(
-        /Acquire::https::proxy/
+      ).with_content(
+        /Acquire::https::proxy "DIRECT";/
       )}
     end
 

--- a/templates/proxy.epp
+++ b/templates/proxy.epp
@@ -2,4 +2,6 @@
 Acquire::http::proxy "http://<%= $proxies['host'] %>:<%= $proxies['port'] %>/";
 <%- if $proxies['https'] { %>
 Acquire::https::proxy "https://<%= $proxies['host'] %>:<%= $proxies['port'] %>/";
+<%- } else { -%>
+ Acquire::https::proxy "DIRECT";
 <%- } -%>


### PR DESCRIPTION
* if http proxy is set without an https proxy apt will still attempt to
proxy those https sources, resulting in errors.  This fix will allow
direct connect to the https urls, bypassing the http proxy.  This is the
most simple fix for this problem, a more complex fix would be to have an
https_direct setting.

An example error can be found for any https repo, here is an error for the varnish repo on packagecould:
```Ign https://packagecloud.io trusty InRelease
Ign https://packagecloud.io trusty Release.gpg
Ign https://packagecloud.io trusty Release
Ign https://packagecloud.io trusty/main amd64 Packages/DiffIndex
Ign https://packagecloud.io trusty/main i386 Packages/DiffIndex
Ign https://packagecloud.io trusty/main Translation-en_US
Ign https://packagecloud.io trusty/main Translation-en
Err https://packagecloud.io trusty/main amd64 Packages
  Received HTTP code 403 from proxy after CONNECT
Err https://packagecloud.io trusty/main i386 Packages
  Received HTTP code 403 from proxy after CONNECT
W: Failed to fetch https://packagecloud.io/varnishcache/varnish41/ubuntu/dists/trusty/main/binary-amd64/Packages  Received HTTP code 403 from proxy after CONNECT

W: Failed to fetch https://packagecloud.io/varnishcache/varnish41/ubuntu/dists/trusty/main/binary-i386/Packages  Received HTTP code 403 from proxy after CONNECT

E: Some index files failed to download. They have been ignored, or old ones used instead.```
