### PR TITLE
(maint) Update release merge back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ This release removes Data in Modules due to current compatibility issues and rei
 
 
 ## Supported Release 3.0.0 and 4.0.0
-###Summary
+### Summary
 
 This release adds new Puppet 4 features: data in modules, EPP templates, the $facts hash, and data types. This release is fully backwards compatible to existing Puppet 4 configurations and provides you with deprecation warnings for every argument that will not work as expected with the final 4.0.0 release. See the stdlib docs here for an in-depth discussion of this: https://github.com/puppetlabs/puppetlabs-stdlib#validate_legacy
 
@@ -21,12 +21,15 @@ If you want to learn more about the new features used or you wish to upgrade a m
 
 If you're still running Puppet 3, remain on the latest puppetlabs-apt 2.x release for now, and see the documentation to upgrade to Puppet 4.
 
-Changes
+#### Changes
 
 Data in modules: Moves all distribution and OS-dependent defaults into YAML files in data/, alleviating the need for a params class. Note that while this feature is currently still classed as experimental, the final implementation will support the changes here.
 EPP templating: Uses the Puppet language as a base for templates to create simpler and safer templates. No need for Ruby anymore!
 The $facts hash: Makes facts visibly distinct from other variables for more readable and maintainable code. This helps eliminate confusion if you use a local variable whose name happens to match that of a common fact.
 Data types for validation: Helps you find and replace deprecated code in existing validate functions with stricter, more readable data type notation. First upgrade to the 3.0.0 release of this module, and address all deprecation warnings before upgrading to the final 4.0.0 release. Please see the stdlib docs for an in-depth discussion of this process.
+
+#### Bugfixes
+- Fix apt::source epp template regression introduced in 3.0.0 for the architecture parameter
 
 ## Supported Release 2.4.0
 ### Summary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## Supported Release 4.1.0
+### Summary
+
+This release removes Data in Modules due to current compatibility issues and reinstates the params.pp file. Also includes a couple of bug fixes.
+
+#### Features
+- (MODULES-4973) Data in Modules which was introduced in the last release has now been reverted due to compatibility issues.
+
+#### Bugfixes
+- Now apt_key only sends the auth basic header when userinfo can be parsed from the URL.
+- Reverted the removal of Evolving Web's attribution in NOTICE file.
+- Test added to ensure empty string allowed for $release in apt::source.
+
+
 ## Supported Release 3.0.0 and 4.0.0
 ###Summary
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-apt",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "author": "Puppet Labs",
   "summary": "Provides an interface for managing Apt source, key, and definitions with Puppet",
   "license": "Apache-2.0",


### PR DESCRIPTION
Looks like there were two straggler commits that didn't make it back
into master in the merge back for the 4.1.0 release.