### PR TITLE
Install apt-transport-https in Debian 8 if needed

### DIFF
--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -29,8 +29,15 @@ define apt::source(
     $_release = $release
   }
 
-  if $ensure == 'present' and ! $location {
-    fail('cannot create a source entry without specifying a location')
+  if $ensure == 'present' {
+    if ! $location {
+      fail('cannot create a source entry without specifying a location')
+    } elsif $_release == 'jessie' {
+      $method = split($location, '[:\/]+')[0]
+      if $method == 'https' {
+        ensure_packages('apt-transport-https')
+      }
+    }
   }
 
   $includes = merge($::apt::include_defaults, $include)


### PR DESCRIPTION
Without this package, the module fails to update a repository with a
location using the https method.