### PR TITLE
debian-updates is not security-updates

### DIFF
--- a/lib/facter/apt_updates.rb
+++ b/lib/facter/apt_updates.rb
@@ -10,7 +10,6 @@ Facter.add('apt_has_updates') do
         package = line.gsub(%r{^Inst\s([^\s]+)\s.*}, '\1').strip
         apt_package_updates[0].push(package)
         security_matches = [
-          %r{ Debian[^\s]+-updates[, ]},
           %r{ Debian-Security:},
           %r{ Ubuntu[^\s]+-security[, ]},
           %r{ gNewSense[^\s]+-security[, ]},


### PR DESCRIPTION
Debian-updates contains pending packages between dot-releases, these packages are not security updates. When Debian has a dot-release, for example 8.7, debian-updates is empty. Between 8.7 and 8.8, updated packages will go to debian-updates, and on 8.8, all packages in debian-updates are moved to the main repo, leaving debian-updates empty again.

Security updates are managed outside of this.

A system running 8.3 can pull updates from debian-security and remain on 8.3. Adding the debian-updates apt-repo to such a system should _not_ trigger any alarm about lacking security updates, no more than pending packages because of system not being updated to latest dot-release.