### PR TITLE
Do not treat debian stable-updates as security updates

### DIFF
--- a/lib/facter/apt_updates.rb
+++ b/lib/facter/apt_updates.rb
@@ -10,7 +10,6 @@ Facter.add('apt_has_updates') do
         package = line.gsub(%r{^Inst\s([^\s]+)\s.*}, '\1').strip
         apt_package_updates[0].push(package)
         security_matches = [
-          %r{ Debian[^\s]+-updates[, ]},
           %r{ Debian-Security:},
           %r{ Ubuntu[^\s]+-security[, ]},
           %r{ gNewSense[^\s]+-security[, ]},

--- a/spec/unit/facter/apt_package_security_updates_spec.rb
+++ b/spec/unit/facter/apt_package_security_updates_spec.rb
@@ -26,14 +26,16 @@ describe 'apt_package_security_updates fact' do
         "Inst tzdata [2015f-0+deb8u1] (2015g-0+deb8u1 Debian:stable-updates [all])\n" \
           "Conf tzdata (2015g-0+deb8u1 Debian:stable-updates [all])\n" \
           "Inst unhide.rb [13-1.1] (22-2~bpo8+1 Debian Backports:jessie-backports [all])\n" \
-          "Conf unhide.rb (22-2~bpo8+1 Debian Backports:jessie-backports [all])\n"
+          "Conf unhide.rb (22-2~bpo8+1 Debian Backports:jessie-backports [all])\n" \
+          "Inst curl [7.52.1-5] (7.52.1-5+deb9u2 Debian-Security:9/stable [amd64]) []\n" \
+          "Conf curl (7.52.1-5+deb9u2 Debian-Security:9/stable [amd64])\n" \
       end
 
       it {
         if Facter.version < '2.0.0'
-          is_expected.to eq('tzdata')
+          is_expected.to eq('curl')
         else
-          is_expected.to eq(['tzdata'])
+          is_expected.to eq(['curl'])
         end
       }
     end

--- a/spec/unit/facter/apt_security_updates_spec.rb
+++ b/spec/unit/facter/apt_security_updates_spec.rb
@@ -26,7 +26,9 @@ describe 'apt_security_updates fact' do
         "Inst tzdata [2015f-0+deb8u1] (2015g-0+deb8u1 Debian:stable-updates [all])\n" \
           "Conf tzdata (2015g-0+deb8u1 Debian:stable-updates [all])\n" \
           "Inst unhide.rb [13-1.1] (22-2~bpo8+1 Debian Backports:jessie-backports [all])\n" \
-          "Conf unhide.rb (22-2~bpo8+1 Debian Backports:jessie-backports [all])\n"
+          "Conf unhide.rb (22-2~bpo8+1 Debian Backports:jessie-backports [all])\n" \
+          "Inst curl [7.52.1-5] (7.52.1-5+deb9u2 Debian-Security:9/stable [amd64]) []\n" \
+          "Conf curl (7.52.1-5+deb9u2 Debian-Security:9/stable [amd64])\n" \
       end
 
       it { is_expected.to eq(1) }


### PR DESCRIPTION
Debian-updates are pending packages between dot-releases, they are not security updates.

When Debian has a dot-release, for example 8.7, debian-updates is empty. Between 8.7 and 8.8,
updates packages go to debian-updates, and on 8.8, all packages in debian-updates are moved (or replaced) by packages in the main repo, leaving debian-updates empty again.

Security updates are managed outside of this.

I recently added debian-updates to the apt repos on our Debian servers, with the result that all the systems had alarms about missing security updates. All these alarms were false, security updates had been installed, and it was packages in updates they were alarming about. The change to the puppet module was trivial, editing the spec tests was more time consuming :)
