### PR TITLE
Remove tasks acceptance test for non-Debian builds

### DIFF
--- a/spec/acceptance/init_task_spec.rb
+++ b/spec/acceptance/init_task_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper_acceptance'
 
 describe 'apt tasks' do
-  describe 'update and upgrade', if: pe_install? && puppet_version =~ %r{(5\.\d\.\d)} do
+  describe 'update and upgrade', if: pe_install? && puppet_version =~ %r{(5\.\d\.\d)} && fact_on(master, 'osfamily') == 'Debian' do
     it 'execute arbitary sql' do
       result = run_task(task_name: 'apt', params: 'action=update')
       expect_multiple_regexes(result: result, regexes: [%r{Reading package lists}, %r{Job completed. 1/1 nodes succeeded}])


### PR DESCRIPTION
This commit will disable the task test on non-Debian/Ubuntu based masters.