### PR TITLE
Install apt-transport-https if needed

### DIFF
--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -29,10 +29,13 @@ define apt::source(
     $_release = $release
   }
 
+  # Some releases do not support https transport with default installation
+  $_transport_https_releases = [ 'jessie', 'stretch', 'trusty', 'xenial' ]
+
   if $ensure == 'present' {
     if ! $location {
       fail('cannot create a source entry without specifying a location')
-    } elsif $_release == 'jessie' {
+    } elsif $_release in $_transport_https_releases {
       $method = split($location, '[:\/]+')[0]
       if $method == 'https' {
         ensure_packages('apt-transport-https')


### PR DESCRIPTION
Without this package, the module fails to update a repository with a
location using the https method.

This extends to Debian stretch, Ubuntu trusty and xenial.

https support has been moved into the apt package for future releases
of these distibutions, thus this change won't need to be updated.