### PR TITLE
Add a check for Puppet version to task helper

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -88,6 +88,6 @@ RSpec.configure do |c|
 
   # Configure all nodes in nodeset
   c.before :suite do
-    run_puppet_access_login(user: 'admin') if pe_install?
+    run_puppet_access_login(user: 'admin') if pe_install? && puppet_version =~ %r{(5\.\d\.\d)}
   end
 end


### PR DESCRIPTION
This commit will add a check for Puppet version being 5 or greater
around the task test helper. This ensures that is it not attempted
pre-task versions of puppet.