### PR TITLE
install apt-transport-https on Debian 7 as well

### DIFF
--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -30,7 +30,7 @@ define apt::source(
   }
 
   # Some releases do not support https transport with default installation
-  $_transport_https_releases = [ 'jessie', 'stretch', 'trusty', 'xenial' ]
+  $_transport_https_releases = [ 'wheezy', 'jessie', 'stretch', 'trusty', 'xenial' ]
 
   if $ensure == 'present' {
     if ! $location {


### PR DESCRIPTION
In my Beaker instance, Debian 78 appears to have apt-transport-https available from updates repo:

```
root@debian-78-x64:~# apt-cache  show apt-transport-https
Package: apt-transport-https
Source: apt
Version: 0.9.7.9+deb7u7
Installed-Size: 163
Maintainer: APT Development Team <deity@lists.debian.org>
Architecture: amd64
Depends: libapt-pkg4.12 (>= 0.8.16~exp9), libc6 (>= 2.4), libcurl3-gnutls (>= 7.16.2), libgcc1 (>= 1:4.1.1), libstdc++6 (>= 4.1.1)
Description-en: https download transport for APT
 This package enables the usage of 'deb https://foo distro main' lines
 in the /etc/apt/sources.list so that all package managers using the
 libapt-pkg library can access metadata and packages available in sources
 accessible over https (Hypertext Transfer Protocol Secure).
 .
 This transport supports server as well as client authentication
 with certificates.
Description-md5: 3365a6b50bd0e4eef6e176a80c735f43
Tag: admin::package-management, protocol::http, protocol::ssl,
 role::shared-lib, suite::debian
Section: admin
Priority: optional
Filename: pool/main/a/apt/apt-transport-https_0.9.7.9+deb7u7_amd64.deb
Size: 109262
MD5sum: b93e8396183252e8fea3f75d1b493425
SHA1: e3f294c095cea9e04b284d73e735126a9861d84e
SHA256: b5b51a04959d8876c1963d089259342dcaf7df057e9031f0420fd28591252764

```