### PR TITLE
(maint) - Addressing puppet-lint doc warnings

### DIFF
--- a/manifests/backports.pp
+++ b/manifests/backports.pp
@@ -1,3 +1,4 @@
+# Defining backports for the apt class
 class apt::backports (
   Optional[String] $location                    = undef,
   Optional[String] $release                     = undef,

--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -1,3 +1,4 @@
+# Defining apt config
 define apt::conf (
   Optional[String] $content          = undef,
   Enum['present', 'absent'] $ensure  = present,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,3 +1,4 @@
+# Setting params for the module
 class apt::params {
 
   if $::osfamily != 'Debian' {

--- a/manifests/setting.pp
+++ b/manifests/setting.pp
@@ -1,3 +1,4 @@
+# Defining apt settings
 define apt::setting (
   Variant[String, Integer, Array] $priority           = 50,
   Optional[Enum['file', 'present', 'absent']] $ensure = file,

--- a/manifests/update.pp
+++ b/manifests/update.pp
@@ -1,3 +1,4 @@
+# Defining apt update
 class apt::update {
   assert_private()
 


### PR DESCRIPTION
Carrying this out in order to prep for making this module PDK compliant.