### PR TITLE
Fix automatic coercion warning

### DIFF
--- a/manifests/update.pp
+++ b/manifests/update.pp
@@ -14,7 +14,7 @@ class apt::update {
     'daily': {
       #compare current date with the apt_update_last_success fact to determine
       #if we should kick apt_update.
-      $daily_threshold = (strftime('%s') - 86400)
+      $daily_threshold = (Integer(strftime('%s')) - 86400)
       if $::apt_update_last_success {
         if $::apt_update_last_success + 0 < $daily_threshold {
           $_kick_apt = true
@@ -29,7 +29,7 @@ class apt::update {
     'weekly':{
       #compare current date with the apt_update_last_success fact to determine
       #if we should kick apt_update.
-      $weekly_threshold = (strftime('%s') - 604800)
+      $weekly_threshold = (Integer(strftime('%s')) - 604800)
       if $::apt_update_last_success {
         if ( $::apt_update_last_success + 0 < $weekly_threshold ) {
           $_kick_apt = true

--- a/manifests/update.pp
+++ b/manifests/update.pp
@@ -14,7 +14,7 @@ class apt::update {
     'daily': {
       #compare current date with the apt_update_last_success fact to determine
       #if we should kick apt_update.
-      $daily_threshold = (Integer(strftime('%s')) - 86400)
+      $daily_threshold = (Integer(Timestamp().strftime('%s')) - 86400)
       if $::apt_update_last_success {
         if $::apt_update_last_success + 0 < $daily_threshold {
           $_kick_apt = true
@@ -29,7 +29,7 @@ class apt::update {
     'weekly':{
       #compare current date with the apt_update_last_success fact to determine
       #if we should kick apt_update.
-      $weekly_threshold = (Integer(strftime('%s')) - 604800)
+      $weekly_threshold = (Integer(Timestamp().strftime('%s')) - 604800)
       if $::apt_update_last_success {
         if ( $::apt_update_last_success + 0 < $weekly_threshold ) {
           $_kick_apt = true


### PR DESCRIPTION
Explicitly cast the return value of `strftime()` to an `Integer` to avoid spamming the puppet server log file with warning messages:

```
Jan 26 14:19:13 <daemon.warn> marvin puppet-master[27147]: The string '1516972753' was automatically coerced to the numerical value 1516972753 at /usr/local/etc/puppet/environments/production/modules/apt/manifests/update.pp:17:27
Jan 26 14:19:25 <daemon.warn> marvin puppet-master[27147]: The string '1516972765' was automatically coerced to the numerical value 1516972765 at /usr/local/etc/puppet/environments/production/modules/apt/manifests/update.pp:17:27
Jan 26 14:19:55 <daemon.warn> marvin puppet-master[27147]: The string '1516972795' was automatically coerced to the numerical value 1516972795 at /usr/local/etc/puppet/environments/production/modules/apt/manifests/update.pp:17:27
Jan 26 14:20:15 <daemon.warn> marvin puppet-master[27147]: The string '1516972815' was automatically coerced to the numerical value 1516972815 at /usr/local/etc/puppet/environments/production/modules/apt/manifests/update.pp:17:27
```