### PR TITLE
Fix "E: Unable to locate package  -y"

### DIFF
--- a/tasks/init.rb
+++ b/tasks/init.rb
@@ -5,7 +5,7 @@ require 'puppet'
 
 def apt_get(action)
   cmd = ['apt-get', action]
-  cmd << ' -y' if action == 'upgrade'
+  cmd << '-y' if action == 'upgrade'
   stdout, stderr, status = Open3.capture3(*cmd)
   raise Puppet::Error, stderr if status != 0
   { status: stdout.strip }


### PR DESCRIPTION
Due to the extra space, apt complained with "Unable to locate package  -y". Without the extra space, the task runs fine.