### PR TITLE
Replace UTF-8 whitespace in comment

### DIFF
--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -29,7 +29,7 @@ define apt::source(
     $_release = $release
   }
 
-  # Some releases do not support https transport with default installation
+  # Some releases do not support https transport with default installation
   $_transport_https_releases = [ 'wheezy', 'jessie', 'stretch', 'trusty', 'xenial' ]
 
   if $ensure == 'present' {


### PR DESCRIPTION
There is an UTF-8 whitespace which blows up older puppet-lint versions. Replace with space character

```
./modules/apt/manifests/source.pp
/usr/lib/ruby/vendor_ruby/puppet-lint/checks.rb:23:in `split': invalid byte sequence in US-ASCII (ArgumentError)
	from /usr/lib/ruby/vendor_ruby/puppet-lint/checks.rb:23:in `load_data'
	from /usr/lib/ruby/vendor_ruby/puppet-lint/checks.rb:53:in `run'
	from /usr/lib/ruby/vendor_ruby/puppet-lint.rb:174:in `run'
	from /usr/lib/ruby/vendor_ruby/puppet-lint/bin.rb:59:in `block in run'
	from /usr/lib/ruby/vendor_ruby/puppet-lint/bin.rb:56:in `each'
	from /usr/lib/ruby/vendor_ruby/puppet-lint/bin.rb:56:in `run'
	from /usr/bin/puppet-lint:7:in `<main>'
Detected error
```