### PR TITLE
Extended apt-transport-https according to lsbdistcodename

### DIFF
--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -35,7 +35,7 @@ define apt::source(
   if $ensure == 'present' {
     if ! $location {
       fail('cannot create a source entry without specifying a location')
-    } elsif $_release in $_transport_https_releases {
+    } elsif $_release in $_transport_https_releases or $facts['lsbdistcodename'] in $_transport_https_releases {
       $method = split($location, '[:\/]+')[0]
       if $method == 'https' {
         ensure_packages('apt-transport-https')


### PR DESCRIPTION
the release parameter of an apt::source is not always equals to the agent distribution. For example, the kubernetes module add an apt::source using the release name "ubuntu-xenial" with an https location for docker. But as ubuntu-xenial is not a correct deb/ubu release name and not in the $_transport_https_releases array, the https transport is not installed. So I added the lsbdistcodename fact in the test to decide id we need it.