### PR TITLE
change url keyserver

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,7 +12,7 @@ class apt::params {
   $conf_d         = "${root}/apt.conf.d"
   $preferences    = "${root}/preferences"
   $preferences_d  = "${root}/preferences.d"
-  $keyserver      = 'keyserver.ubuntu.com'
+  $keyserver      = 'hkp://keyserver.ubuntu.com:80'
   $confs          = {}
   $update         = {}
   $purge          = {}


### PR DESCRIPTION
Only host of keyserver dont work with puppetlabs-apt, i fix this with: hkp://keyserver.ubuntu.com:80