### PR TITLE
Remove .length from variable $pin_release in app

### DIFF
--- a/templates/pin.pref.epp
+++ b/templates/pin.pref.epp
@@ -1,7 +1,7 @@
 <%- | $name, $pin_release, $release, $codename, $release_version, $component, $originator, $label, $version, $origin, $explanation, $packages_string, $priority | -%>
 <%-
 $pin =
-if $pin_release.length > 0 {
+if $pin_release {
   $options = [
     if $release         { "a=${release}" },
     if $codename        { "n=${codename}" },

--- a/templates/pin.pref.epp
+++ b/templates/pin.pref.epp
@@ -1,7 +1,7 @@
 <%- | $name, $pin_release, $release, $codename, $release_version, $component, $originator, $label, $version, $origin, $explanation, $packages_string, $priority | -%>
 <%-
 $pin =
-if $pin_release {
+if $pin_release and $pin_release.length > 0
   $options = [
     if $release         { "a=${release}" },
     if $codename        { "n=${codename}" },

--- a/templates/pin.pref.epp
+++ b/templates/pin.pref.epp
@@ -1,7 +1,7 @@
 <%- | $name, $pin_release, $release, $codename, $release_version, $component, $originator, $label, $version, $origin, $explanation, $packages_string, $priority | -%>
 <%-
 $pin =
-if $pin_release and $pin_release.length > 0
+if $pin_release and $pin_release.length > 0 {
   $options = [
     if $release         { "a=${release}" },
     if $codename        { "n=${codename}" },

--- a/templates/pin.pref.epp
+++ b/templates/pin.pref.epp
@@ -1,14 +1,14 @@
 <%- | $name, $pin_release, $release, $codename, $release_version, $component, $originator, $label, $version, $origin, $explanation, $packages_string, $priority | -%>
 <%-
 $pin =
-if $pin_release and $pin_release.length > 0 {
+if $pin_release {
   $options = [
-    if $release         { "a=${release}" },
-    if $codename        { "n=${codename}" },
-    if $release_version { "v=${release_version}"},
-    if $component       { "c=${component}" },
-    if $originator      { "o=${originator}" },
-    if $label           { "l=${label}" },
+    if $release != ''         { "a=${release}" },
+    if $codename != ''        { "n=${codename}" },
+    if $release_version != '' { "v=${release_version}"},
+    if $component != ''       { "c=${component}" },
+    if $originator != ''      { "o=${originator}" },
+    if $label != ''           { "l=${label}" },
     ].filter |$x| { $x != undef }
    "release ${options.join(', ')}" }
 

--- a/templates/pin.pref.epp
+++ b/templates/pin.pref.epp
@@ -1,7 +1,7 @@
 <%- | $name, $pin_release, $release, $codename, $release_version, $component, $originator, $label, $version, $origin, $explanation, $packages_string, $priority | -%>
 <%-
 $pin =
-if $pin_release {
+if $pin_release != '' {
   $options = [
     if $release != ''         { "a=${release}" },
     if $codename != ''        { "n=${codename}" },


### PR DESCRIPTION
This causes 

Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Unknown function: 'length'. at /etc/puppet/environments/production/modules/apt/templates/pin.pref.epp:4:16 at /etc/puppet/environments/production/modules/apt/manifests/source.pp:92 on node xxx

downstream

We use puppet from Debian stretch