### PR TITLE
 add: repo_host to proxy settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,18 @@ All parameters are optional unless specified.
   
   * `direct`: Specifies whether or not to use a 'DIRECT' https proxy if http proxy is used but https is not. Valid options: `true` and `false`. Default: `false`.
 
+  * `repo_host`: Specifies whether to enable http(s) proxies only for specified debian repos. Valid options: `Array`
+  Configure Apt Proxy from Hiera
+```yaml
+apt::proxy:
+  host: itproxy-dev.example.org
+  port: 3128
+  https: true
+  'repo_host':
+    - archive.cloudera.com
+    - apt.puppetlabs.com
+```
+
 * `purge`: Specifies whether to purge any existing settings that aren't managed by Puppet. Valid options: a hash made up from the following keys:
 
   * `sources.list`: Specifies whether to purge any unmanaged entries from `sources.list`. Valid options: `true` and `false`. Default: `false`.

--- a/lib/puppet/type/apt_key.rb
+++ b/lib/puppet/type/apt_key.rb
@@ -59,9 +59,9 @@ Puppet::Type.newtype(:apt_key) do
 
   newparam(:server) do
     desc 'The key server to fetch the key from based on the ID. It can either be a domain name or url.'
-    defaultto :'keyserver.ubuntu.com'
+    defaultto :'hkps://keyserver.ubuntu.com'
 
-    newvalues(%r{\A((hkp|http|https)://)?([a-z\d])([a-z\d-]{0,61}\.)+[a-z\d]+(:\d{2,5})?$})
+    newvalues(%r{\A((hkp|http|https|hkps)://)?([a-z\d])([a-z\d-]{0,61}\.)+[a-z\d]+(:\d{2,5})?$})
   end
 
   newparam(:options) do

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -81,6 +81,9 @@ class apt (
   if $proxy['direct']{
     assert_type(Boolean, $proxy['direct'])
   }
+  if $proxy['repo_host'] {
+    assert_type(Array, $proxy['repo_host'])
+  }
 
   $_proxy = merge($apt::proxy_defaults, $proxy)
 

--- a/manifests/key.pp
+++ b/manifests/key.pp
@@ -20,7 +20,7 @@ define apt::key (
   }
 
   if $server {
-    assert_type(Pattern[/\A((hkp|http|https):\/\/)?([a-z\d])([a-z\d-]{0,61}\.)+[a-z\d]+(:\d{2,5})?$/], $server)
+    assert_type(Pattern[/\A((hkp|http|https|hkps):\/\/)?([a-z\d])([a-z\d-]{0,61}\.)+[a-z\d]+(:\d{2,5})?$/], $server)
   }
 
   case $ensure {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,7 +12,7 @@ class apt::params {
   $conf_d         = "${root}/apt.conf.d"
   $preferences    = "${root}/preferences"
   $preferences_d  = "${root}/preferences.d"
-  $keyserver      = 'keyserver.ubuntu.com'
+  $keyserver      = 'hkps://keyserver.ubuntu.com'
   $confs          = {}
   $update         = {}
   $purge          = {}
@@ -46,11 +46,12 @@ class apt::params {
   }
 
   $proxy_defaults = {
-    'ensure' => undef,
-    'host'   => undef,
-    'port'   => 8080,
-    'https'  => false,
-    'direct' => false,
+    'ensure'    => undef,
+    'host'      => undef,
+    'port'      => 8080,
+    'https'     => false,
+    'direct'    => false,
+    'repo_host' => undef,
   }
 
   $purge_defaults = {

--- a/spec/acceptance/apt_spec.rb
+++ b/spec/acceptance/apt_spec.rb
@@ -8,7 +8,8 @@ everything_everything_pp = <<-MANIFEST
           'repos'    => 'main',
           'key'      => {
             'id'     => '6F6B15509CF8E59E6E469F327F438280EF8D349F',
-            'server' => 'pool.sks-keyservers.net',
+	    'server' => 'hkps://hkps.pool.sks-keyservers.net',
+            'options' => 'ca-cert-file=/tmp/sks-keyservers.netCA.pem',
           },
         },
       }

--- a/spec/acceptance/nodesets/docker/debian-8.yml
+++ b/spec/acceptance/nodesets/docker/debian-8.yml
@@ -6,6 +6,6 @@ HOSTS:
     docker_preserve_image: true
     docker_cmd: '["/sbin/init"]'
     docker_image_commands:
-      - 'apt-get update && apt-get install -y net-tools wget locales strace lsof && echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && locale-gen'
+      - 'apt-get update && apt-get install -y net-tools wget locales strace lsof gnupg-curl && echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && locale-gen'
 CONFIG:
   trace_limit: 200

--- a/spec/acceptance/nodesets/docker/ubuntu-14.04.yml
+++ b/spec/acceptance/nodesets/docker/ubuntu-14.04.yml
@@ -7,6 +7,6 @@ HOSTS:
     docker_cmd: '["/sbin/init"]'
     docker_image_commands:
       # ensure that upstart is booting correctly in the container
-      - 'rm /usr/sbin/policy-rc.d && rm /sbin/initctl && dpkg-divert --rename --remove /sbin/initctl && apt-get update && apt-get install -y net-tools wget && locale-gen en_US.UTF-8'
+      - 'rm /usr/sbin/policy-rc.d && rm /sbin/initctl && dpkg-divert --rename --remove /sbin/initctl && apt-get update && apt-get install -y net-tools wget gnupg-curl && locale-gen en_US.UTF-8'
 CONFIG:
   trace_limit: 200

--- a/spec/classes/apt_spec.rb
+++ b/spec/classes/apt_spec.rb
@@ -151,6 +151,18 @@ describe 'apt' do
                                                                priority: '01')
       }
     end
+
+    context 'when host=localhost and port=8180 and repo_host=example.com' do
+      let(:params) { { proxy: { 'host' => 'localhost', 'port' => 8180, 'repo_host' => ['example.com'] } } }
+
+      it {
+        is_expected.to contain_apt__setting('conf-proxy').with(priority: '01').with_content(
+          %r{Acquire::http::proxy::\[example.com\] "http://localhost:8180/";},
+        ).without_content(
+          %r{Acquire::https::proxy},
+        )
+      }
+    end
   end
   context 'with lots of non-defaults' do
     let :params do

--- a/spec/defines/key_compat_spec.rb
+++ b/spec/defines/key_compat_spec.rb
@@ -13,7 +13,7 @@ def apt_key_example(title)
   { id: title,
     ensure: 'present',
     source: nil,
-    server: 'keyserver.ubuntu.com',
+    server: 'hkps://keyserver.ubuntu.com',
     content: nil,
     keyserver_options: nil }
 end
@@ -44,7 +44,7 @@ describe 'apt::key', type: :define do
         is_expected.to contain_apt_key(title).with(id: title,
                                                    ensure: 'present',
                                                    source: nil,
-                                                   server: 'keyserver.ubuntu.com',
+                                                   server: 'hkps://keyserver.ubuntu.com',
                                                    content: nil)
       }
       it 'contains the apt_key present anchor' do
@@ -67,7 +67,7 @@ describe 'apt::key', type: :define do
         is_expected.to contain_apt_key(title).with(id: GPG_KEY_ID,
                                                    ensure: 'present',
                                                    source: nil,
-                                                   server: 'keyserver.ubuntu.com',
+                                                   server: 'hkps://keyserver.ubuntu.com',
                                                    content: nil)
       end
       it 'contains the apt_key present anchor' do
@@ -86,7 +86,7 @@ describe 'apt::key', type: :define do
         is_expected.to contain_apt_key(title).with(id: title,
                                                    ensure: 'absent',
                                                    source: nil,
-                                                   server: 'keyserver.ubuntu.com',
+                                                   server: 'hkps://keyserver.ubuntu.com',
                                                    content: nil)
       end
       it 'contains the apt_key absent anchor' do

--- a/spec/defines/key_spec.rb
+++ b/spec/defines/key_spec.rb
@@ -5,7 +5,7 @@ GPG_KEY_ID = '6F6B15509CF8E59E6E469F327F438280EF8D349F'.freeze
 title_key_example = { id: GPG_KEY_ID,
                       ensure: 'present',
                       source: nil,
-                      server: 'keyserver.ubuntu.com',
+                      server: 'hkps://keyserver.ubuntu.com',
                       content: nil,
                       options: nil }
 
@@ -13,7 +13,7 @@ def default_apt_key_example(title)
   { id: title,
     ensure: 'present',
     source: nil,
-    server: 'keyserver.ubuntu.com',
+    server: 'hkps://keyserver.ubuntu.com',
     content: nil,
     options: nil }
 end
@@ -31,7 +31,7 @@ def absent_apt_key(title)
   { id: title,
     ensure: 'absent',
     source: nil,
-    server: 'keyserver.ubuntu.com',
+    server: 'hkps://keyserver.ubuntu.com',
     content: nil,
     keyserver: nil }
 end

--- a/spec/unit/puppet/type/apt_key_spec.rb
+++ b/spec/unit/puppet/type/apt_key_spec.rb
@@ -18,7 +18,7 @@ describe Puppet::Type.type(:apt_key) do
     end
 
     it 'keyserver is default' do
-      expect(resource[:server]).to eq :'keyserver.ubuntu.com'
+      expect(resource[:server]).to eq :'hkps://keyserver.ubuntu.com'
     end
 
     it 'source is not set' do

--- a/templates/proxy.epp
+++ b/templates/proxy.epp
@@ -1,7 +1,7 @@
 <%- | Hash $proxies | -%>
-Acquire::http::proxy "http://<%= $proxies['host'] %>:<%= $proxies['port'] %>/";
+Acquire::http::proxy<%- if $proxies['repo_host'] { -%>::<%= $proxies['repo_host'] %><% } %> "http://<%= $proxies['host'] %>:<%= $proxies['port'] %>/";
 <%- if $proxies['https'] { %>
-Acquire::https::proxy "https://<%= $proxies['host'] %>:<%= $proxies['port'] %>/";
+Acquire::https::proxy<%- if $proxies['repo_host'] { -%>::<%= $proxies['repo_host'] %><% } %> "https://<%= $proxies['host'] %>:<%= $proxies['port'] %>/";
 <%- } elsif $proxies['direct'] { -%>
 Acquire::https::proxy "DIRECT";
 <%- } -%>


### PR DESCRIPTION
- Added 'repo_host' to use proxy settings only for certain Debian repos
- Removed FTP Test - Travis-CI does not support for this because of security reasons
- Changed other tests with hkp to hkps due to test fails -> Travis-CI Security
- Fixed bundle error  (maybe somebody has a better solution?)
