### PR TITLE
apt::pin: default to undef to omit unused qualifiers

### DIFF
--- a/manifests/pin.pp
+++ b/manifests/pin.pp
@@ -7,14 +7,14 @@ define apt::pin(
   Variant[Integer] $order                             = 50,
   Variant[String, Array] $packages                    = '*',
   Variant[Numeric, String] $priority                  = 0,
-  Optional[String] $release                           = '', # a=
+  Optional[String] $release                           = undef, # a=
   Optional[String] $origin                            = '',
   Optional[String] $version                           = '',
-  Optional[String] $codename                          = '', # n=
-  Optional[String] $release_version                   = '', # v=
-  Optional[String] $component                         = '', # c=
-  Optional[String] $originator                        = '', # o=
-  Optional[String] $label                             = '',  # l=
+  Optional[String] $codename                          = undef, # n=
+  Optional[String] $release_version                   = undef, # v=
+  Optional[String] $component                         = undef, # c=
+  Optional[String] $originator                        = undef, # o=
+  Optional[String] $label                             = undef, # l=
 ) {
 
   if $explanation {


### PR DESCRIPTION
Unused qualifiers should not turn up in the generated pinning.

The generated selectors in https://github.com/puppetlabs/puppetlabs-apt/blob/master/templates/pin.pref.epp#L5 only skip qualifiers that are `undef`, but not empty strings.

Another solution would be to treat empty strings the same as `undef` by explicitly skipping empty strings in https://github.com/puppetlabs/puppetlabs-apt/blob/master/templates/pin.pref.epp#L5, but the `Optional[String]` type suggests that `undef` and empty string are supposed to have different semantics...