### PR TITLE
Check existence of gpg key in apt:ppa

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,6 +9,7 @@ class apt::params {
   $provider       = '/usr/bin/apt-get'
   $sources_list   = "${root}/sources.list"
   $sources_list_d = "${root}/sources.list.d"
+  $trusted_gpg_d  = "${root}/trusted.gpg.d"
   $conf_d         = "${root}/apt.conf.d"
   $preferences    = "${root}/preferences"
   $preferences_d  = "${root}/preferences.d"

--- a/manifests/ppa.pp
+++ b/manifests/ppa.pp
@@ -25,6 +25,10 @@ define apt::ppa(
   $filename_no_specialchars = regsubst($filename_no_slashes, '[\.\+]', '_', 'G')
   $sources_list_d_filename  = "${filename_no_specialchars}.list"
 
+  $name_no_slashes = regsubst($name, '/', '-', 'G')
+  $name_no_specialchars = regsubst($name_no_slashes, '[\.\+]', '_', 'G')
+  $trusted_gpg_d_filename = regsubst($name_no_specialchars, '^ppa:(.+)', "\\1.gpg")
+
   if $ensure == 'present' {
     if $package_manage {
       ensure_packages($package_name)
@@ -47,7 +51,7 @@ define apt::ppa(
     exec { "add-apt-repository-${name}":
       environment => $_proxy_env,
       command     => "/usr/bin/add-apt-repository ${options} ${name}",
-      unless      => "/usr/bin/test -f ${::apt::sources_list_d}/${sources_list_d_filename}",
+      unless      => "/usr/bin/test -f ${::apt::sources_list_d}/${sources_list_d_filename} && /usr/bin/test -f ${::apt::trusted_gpg_d}/${trusted_gpg_d_filename}",
       user        => 'root',
       logoutput   => 'on_failure',
       notify      => Class['apt::update'],

--- a/spec/defines/ppa_spec.rb
+++ b/spec/defines/ppa_spec.rb
@@ -23,7 +23,7 @@ describe 'apt::ppa' do
     it {
       is_expected.to contain_exec('add-apt-repository-ppa:needs/such.substitution/wow+type').that_notifies('Class[Apt::Update]').with(environment: [],
                                                                                                                                       command: '/usr/bin/add-apt-repository -y ppa:needs/such.substitution/wow+type', # rubocop:disable Metrics/LineLength
-                                                                                                                                      unless: '/usr/bin/test -f /etc/apt/sources.list.d/needs-such_substitution-wow_type-trusty.list', # rubocop:disable Metrics/LineLength
+                                                                                                                                      unless: '/usr/bin/test -f /etc/apt/sources.list.d/needs-such_substitution-wow_type-trusty.list && /usr/bin/test -f /etc/apt/trusted.gpg.d/needs-such_substitution-wow_type.gpg', # rubocop:disable Metrics/LineLength
                                                                                                                                       user: 'root',
                                                                                                                                       logoutput: 'on_failure')
     }
@@ -47,7 +47,7 @@ describe 'apt::ppa' do
     it {
       is_expected.to contain_exec('add-apt-repository-ppa:user/foo').that_notifies('Class[Apt::Update]').with(environment: [],
                                                                                                               command: '/usr/bin/add-apt-repository -y ppa:user/foo',
-                                                                                                              unless: '/usr/bin/test -f /etc/apt/sources.list.d/user-ubuntu-foo-wily.list',
+                                                                                                              unless: '/usr/bin/test -f /etc/apt/sources.list.d/user-ubuntu-foo-wily.list && /usr/bin/test -f /etc/apt/trusted.gpg.d/user-foo.gpg', # rubocop:disable Metrics/LineLength
                                                                                                               user: 'root',
                                                                                                               logoutput: 'on_failure')
     }
@@ -81,7 +81,7 @@ describe 'apt::ppa' do
     it {
       is_expected.to contain_exec('add-apt-repository-ppa:needs/such.substitution/wow').that_notifies('Class[Apt::Update]').with('environment' => [],
                                                                                                                                  'command'     => '/usr/bin/add-apt-repository -y ppa:needs/such.substitution/wow', # rubocop:disable Metrics/LineLength
-                                                                                                                                 'unless'      => '/usr/bin/test -f /etc/apt/sources.list.d/needs-such_substitution-wow-trusty.list', # rubocop:disable Metrics/LineLength
+                                                                                                                                 'unless'      => '/usr/bin/test -f /etc/apt/sources.list.d/needs-such_substitution-wow-trusty.list && /usr/bin/test -f /etc/apt/trusted.gpg.d/needs-such_substitution-wow.gpg', # rubocop:disable Metrics/LineLength
                                                                                                                                  'user'        => 'root',
                                                                                                                                  'logoutput'   => 'on_failure')
     }
@@ -118,7 +118,7 @@ describe 'apt::ppa' do
     it {
       is_expected.to contain_exec('add-apt-repository-ppa:needs/such.substitution/wow').that_notifies('Class[Apt::Update]').with('environment' => [],
                                                                                                                                  'command'     => '/usr/bin/add-apt-repository -y ppa:needs/such.substitution/wow', # rubocop:disable Metrics/LineLength
-                                                                                                                                 'unless'      => '/usr/bin/test -f /etc/apt/sources.list.d/needs-such_substitution-wow-trusty.list', # rubocop:disable Metrics/LineLength
+                                                                                                                                 'unless'      => '/usr/bin/test -f /etc/apt/sources.list.d/needs-such_substitution-wow-trusty.list && /usr/bin/test -f /etc/apt/trusted.gpg.d/needs-such_substitution-wow.gpg', # rubocop:disable Metrics/LineLength
                                                                                                                                  'user'        => 'root',
                                                                                                                                  'logoutput'   => 'on_failure')
     }
@@ -159,7 +159,7 @@ describe 'apt::ppa' do
     it {
       is_expected.to contain_exec('add-apt-repository-ppa:user/foo').that_notifies('Class[Apt::Update]').with(environment: [],
                                                                                                               command: '/usr/bin/add-apt-repository  ppa:user/foo',
-                                                                                                              unless: '/usr/bin/test -f /etc/apt/sources.list.d/user-foo-trusty.list',
+                                                                                                              unless: '/usr/bin/test -f /etc/apt/sources.list.d/user-foo-trusty.list && /usr/bin/test -f /etc/apt/trusted.gpg.d/user-foo.gpg',
                                                                                                               user: 'root',
                                                                                                               logoutput: 'on_failure')
     }
@@ -194,7 +194,7 @@ describe 'apt::ppa' do
     it {
       is_expected.to contain_exec('add-apt-repository-ppa:user/foo').that_notifies('Class[Apt::Update]').with(environment: ['http_proxy=http://localhost:8080'],
                                                                                                               command: '/usr/bin/add-apt-repository  ppa:user/foo',
-                                                                                                              unless: '/usr/bin/test -f /etc/apt/sources.list.d/user-foo-trusty.list',
+                                                                                                              unless: '/usr/bin/test -f /etc/apt/sources.list.d/user-foo-trusty.list && /usr/bin/test -f /etc/apt/trusted.gpg.d/user-foo.gpg',
                                                                                                               user: 'root',
                                                                                                               logoutput: 'on_failure')
     }
@@ -229,7 +229,7 @@ describe 'apt::ppa' do
     it {
       is_expected.to contain_exec('add-apt-repository-ppa:user/foo').that_notifies('Class[Apt::Update]').with(environment: ['http_proxy=http://localhost:8180'],
                                                                                                               command: '/usr/bin/add-apt-repository  ppa:user/foo',
-                                                                                                              unless: '/usr/bin/test -f /etc/apt/sources.list.d/user-foo-trusty.list',
+                                                                                                              unless: '/usr/bin/test -f /etc/apt/sources.list.d/user-foo-trusty.list && /usr/bin/test -f /etc/apt/trusted.gpg.d/user-foo.gpg',
                                                                                                               user: 'root',
                                                                                                               logoutput: 'on_failure')
     }
@@ -264,7 +264,7 @@ describe 'apt::ppa' do
     it {
       is_expected.to contain_exec('add-apt-repository-ppa:user/foo').that_notifies('Class[Apt::Update]').with(environment: ['http_proxy=http://localhost:8180', 'https_proxy=https://localhost:8180'],
                                                                                                               command: '/usr/bin/add-apt-repository  ppa:user/foo',
-                                                                                                              unless: '/usr/bin/test -f /etc/apt/sources.list.d/user-foo-trusty.list',
+                                                                                                              unless: '/usr/bin/test -f /etc/apt/sources.list.d/user-foo-trusty.list && /usr/bin/test -f /etc/apt/trusted.gpg.d/user-foo.gpg',
                                                                                                               user: 'root',
                                                                                                               logoutput: 'on_failure')
     }


### PR DESCRIPTION
`apt-add-repository` adds a repository into `/etc/apt/sources.list.d/` and also adds a public key into `/etc/apt/trusted.gpg.d/`. Since it's possible that the repository is added but the key fails to be fetched, we should check the existence of the gpg key in `unless` attribute.