### PR TITLE
(MODULES-7668) Remove support for Puppet 4.7

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -33,7 +33,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.7.0 < 6.0.0"
+      "version_requirement": ">= 4.8.0 < 6.0.0"
     }
   ],
   "template-url": "https://github.com/puppetlabs/pdk-templates",


### PR DESCRIPTION
Prior to this PR, the metadata.json listed support for Puppet 4.7, which is not compatible with the current module. This PR updates the metadata.json to list 4.8 as the lowest compatible version within the 5.x branch. 