### PR TITLE
Revert "(MODULES-6408) - Fix dirmngr install failing"

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -208,13 +208,6 @@ class apt (
     content  => "${confheadertmp}${updatestamptmp}",
   }
 
-  # Required for adding GPG keys on Debian 9 (and derivatives)
-  $apt_files = [ 'sources.list', 'sources.list.d', 'preferences', 'preferences.d', '/etc/apt/auth.conf' ]
-  package { 'dirmngr':
-    ensure => present,
-    before => [File[$apt_files]]
-  }
-
   file { 'sources.list':
     ensure  => file,
     path    => $::apt::sources_list,
@@ -296,4 +289,7 @@ class apt (
   if $pins {
     create_resources('apt::pin', $pins)
   }
+
+  # required for adding GPG keys on Debian 9 (and derivatives)
+  ensure_packages(['dirmngr'])
 }


### PR DESCRIPTION
Reverts puppetlabs/puppetlabs-apt#801. Reverting as this is causing failures in [Puppet DB](https://github.com/puppetlabs/puppetlabs-puppetdb/pull/288).