### PR TITLE
(MODULES-8081): add support for hkps:// protocol in apt::key

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -65,8 +65,8 @@ Default value: $apt::params::provider
 
 Data type: `String`
 
-Specifies a keyserver to provide the GPG key. Valid options: a string containing a domain name or a full URL (http://, https://, or
-hkp://).
+Specifies a keyserver to provide the GPG key. Valid options: a string containing a domain name or a full URL (http://, https://,
+hkp:// or hkps://).
 
 Default value: $apt::params::keyserver
 
@@ -481,10 +481,10 @@ Default value: `undef`
 
 ##### `server`
 
-Data type: `Pattern[/\A((hkp|http|https):\/\/)?([a-z\d])([a-z\d-]{0,61}\.)+[a-z\d]+(:\d{2,5})?$/]`
+Data type: `Pattern[/\A((hkp|hkps|http|https):\/\/)?([a-z\d])([a-z\d-]{0,61}\.)+[a-z\d]+(:\d{2,5})?$/]`
 
-Specifies a keyserver to provide the GPG key. Valid options: a string containing a domain name or a full URL (http://, https://, or
-hkp://).
+Specifies a keyserver to provide the GPG key. Valid options: a string containing a domain name or a full URL (http://, https://,
+hkp:// or hkps://).
 
 Default value: $::apt::keyserver
 

--- a/lib/puppet/type/apt_key.rb
+++ b/lib/puppet/type/apt_key.rb
@@ -68,7 +68,7 @@ Puppet::Type.newtype(:apt_key) do
     desc 'The key server to fetch the key from based on the ID. It can either be a domain name or url.'
     defaultto :'keyserver.ubuntu.com'
 
-    newvalues(%r{\A((hkp|http|https)://)?([a-z\d])([a-z\d-]{0,61}\.)+[a-z\d]+(:\d{2,5})?$})
+    newvalues(%r{\A((hkp|hkps|http|https)://)?([a-z\d])([a-z\d-]{0,61}\.)+[a-z\d]+(:\d{2,5})?$})
   end
 
   newparam(:options) do

--- a/manifests/key.pp
+++ b/manifests/key.pp
@@ -33,12 +33,12 @@
 #   Passes additional options to `apt-key adv --keyserver-options`.
 #
 define apt::key (
-  Pattern[/\A(0x)?[0-9a-fA-F]{8}\Z/, /\A(0x)?[0-9a-fA-F]{16}\Z/, /\A(0x)?[0-9a-fA-F]{40}\Z/] $id = $title,
-  Enum['present', 'absent', 'refreshed'] $ensure                                                 = present,
-  Optional[String] $content                                                                      = undef,
-  Optional[Pattern[/\Ahttps?:\/\//, /\Aftp:\/\//, /\A\/\w+/]] $source                            = undef,
-  Pattern[/\A((hkp|http|https):\/\/)?([a-z\d])([a-z\d-]{0,61}\.)+[a-z\d]+(:\d{2,5})?$/] $server  = $::apt::keyserver,
-  Optional[String] $options                                                                      = undef,
+  Pattern[/\A(0x)?[0-9a-fA-F]{8}\Z/, /\A(0x)?[0-9a-fA-F]{16}\Z/, /\A(0x)?[0-9a-fA-F]{40}\Z/] $id     = $title,
+  Enum['present', 'absent', 'refreshed'] $ensure                                                     = present,
+  Optional[String] $content                                                                          = undef,
+  Optional[Pattern[/\Ahttps?:\/\//, /\Aftp:\/\//, /\A\/\w+/]] $source                                = undef,
+  Pattern[/\A((hkp|hkps|http|https):\/\/)?([a-z\d])([a-z\d-]{0,61}\.)+[a-z\d]+(:\d{2,5})?$/] $server = $::apt::keyserver,
+  Optional[String] $options                                                                          = undef,
   ) {
 
   case $ensure {

--- a/spec/acceptance/apt_key_provider_spec.rb
+++ b/spec/acceptance/apt_key_provider_spec.rb
@@ -794,6 +794,17 @@ describe 'apt_key' do
       end
     end
 
+    context 'with hkps://keyserver.ubuntu.com' do
+      it 'works' do
+        retry_on_error_matching do
+          apply_manifest(hkp_ubuntu_pp, catch_failures: true)
+        end
+
+        apply_manifest(hkp_ubuntu_pp, catch_changes: true)
+        shell(PUPPETLABS_KEY_CHECK_COMMAND)
+      end
+    end
+
     context 'with nonexistant.key.server' do
       it 'fails' do
         apply_manifest(nonexistant_key_server_pp, expect_failures: true) do |r|

--- a/spec/acceptance/apt_key_provider_spec.rb
+++ b/spec/acceptance/apt_key_provider_spec.rb
@@ -478,6 +478,14 @@ hkp_pool_pp = <<-MANIFEST
         }
   MANIFEST
 
+hkps_ubuntu_pp = <<-MANIFEST
+        apt_key { 'puppetlabs':
+          id     => '#{PUPPETLABS_GPG_KEY_LONG_ID}',
+          ensure => 'present',
+	  server => 'hkps://keyserver.ubuntu.com',
+        }
+  MANIFEST
+
 nonexistant_key_server_pp = <<-MANIFEST
         apt_key { 'puppetlabs':
           id     => '#{PUPPETLABS_GPG_KEY_LONG_ID}',


### PR DESCRIPTION
Add hkps:// to the list of protocols supported by apt::key
(hkp://, http:// and https://).