### PR TITLE
(maint) Prefer LF over CRLF line endings for .epp files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,4 @@
 *.erb eol=lf
 *.pp eol=lf
 *.sh eol=lf
+*.epp eol=lf


### PR DESCRIPTION
This will keep the line endings consistent between platforms, allowing the unit tests to pass when run on a Windows workstation.