### PR TITLE
Apt-key fixes to properly work on Debian 9

### DIFF
--- a/lib/puppet/provider/apt_key/apt_key.rb
+++ b/lib/puppet/provider/apt_key/apt_key.rb
@@ -19,7 +19,7 @@ Puppet::Type.type(:apt_key).provide(:apt_key) do
   commands   gpg: '/usr/bin/gpg'
 
   def self.instances
-    cli_args = ['adv', '--list-keys', '--with-colons', '--fingerprint', '--fixed-list-mode']
+    cli_args = ['adv', '--no-tty', '--list-keys', '--with-colons', '--fingerprint', '--fixed-list-mode']
 
     key_output = apt_key(cli_args).encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '')
 
@@ -160,7 +160,7 @@ Puppet::Type.type(:apt_key).provide(:apt_key) do
     # confirm that the fingerprint from the file, matches the long key that is in the manifest
     if name.size == 40
       if File.executable? command(:gpg)
-        extracted_key = execute(["#{command(:gpg)} --with-fingerprint --with-colons #{file.path} | awk -F: '/^fpr:/ { print $10 }'"], failonfail: false)
+        extracted_key = execute(["#{command(:gpg)} --no-tty --with-fingerprint --with-colons #{file.path} | awk -F: '/^fpr:/ { print $10 }'"], failonfail: false)
         extracted_key = extracted_key.chomp
 
         found_match = false
@@ -193,7 +193,7 @@ Puppet::Type.type(:apt_key).provide(:apt_key) do
 
     # Breaking up the command like this is needed because it blows up
     # if --recv-keys isn't the last argument.
-    command.push('adv', '--keyserver', resource[:server])
+    command.push('adv', '--no-tty', '--keyserver', resource[:server])
     unless resource[:options].nil?
       command.push('--keyserver-options', resource[:options])
     end
@@ -211,7 +211,7 @@ Puppet::Type.type(:apt_key).provide(:apt_key) do
     if resource[:source].nil? && resource[:content].nil?
       # Breaking up the command like this is needed because it blows up
       # if --recv-keys isn't the last argument.
-      command.push('adv', '--keyserver', resource[:server])
+      command.push('adv', '--no-tty', '--keyserver', resource[:server])
       unless resource[:options].nil?
         command.push('--keyserver-options', resource[:options])
       end

--- a/lib/puppet/type/apt_key.rb
+++ b/lib/puppet/type/apt_key.rb
@@ -64,6 +64,10 @@ Puppet::Type.newtype(:apt_key) do
     end
   end
 
+  autorequire(:package) do
+    'dirmngr'
+  end
+
   newparam(:server) do
     desc 'The key server to fetch the key from based on the ID. It can either be a domain name or url.'
     defaultto :'keyserver.ubuntu.com'

--- a/manifests/key.pp
+++ b/manifests/key.pp
@@ -57,22 +57,6 @@ define apt::key (
           server  => $server,
           options => $options,
         } -> anchor { "apt_key ${id} present": }
-
-        case $facts['os']['name'] {
-          'Debian': {
-            if versioncmp($facts['os']['release']['major'], '9') >= 0 {
-              ensure_packages(['dirmngr'])
-              Apt::Key<| title == $title |>
-            }
-          }
-          'Ubuntu': {
-            if versioncmp($facts['os']['release']['full'], '17.04') >= 0 {
-              ensure_packages(['dirmngr'])
-              Apt::Key<| title == $title |>
-            }
-          }
-          default: { }
-        }
       }
     }
 

--- a/spec/acceptance/apt_key_provider_spec.rb
+++ b/spec/acceptance/apt_key_provider_spec.rb
@@ -665,12 +665,6 @@ refresh_del_key_pp = <<-MANIFEST
         }
 MANIFEST
 
-refresh_check_for_dirmngr_pp = <<-MANIFEST
-        package { 'dirmngr':
-          ensure  => 'present',
-        }
-MANIFEST
-
 describe 'apt_key' do
   before(:each) do
     # Delete twice to make sure everything is cleaned
@@ -977,10 +971,6 @@ describe 'apt_key' do
       let(:puppetlabs_exp_check_command) { PUPPETLABS_EXP_CHECK_COMMAND }
     end
     before(:each) do
-      if fact('lsbdistcodename') == 'stretch' || fact('lsbdistcodename') == 'bionic'
-        # Ensure dirmngr package is installed
-        apply_manifest(refresh_check_for_dirmngr_pp, acceptable_exit_codes: [0, 2])
-      end
       # Delete the Puppet Labs Release Key and install an expired version of the key
       apply_manifest(refresh_del_key_pp)
       apply_manifest(refresh_pp, catch_failures: true)

--- a/spec/acceptance/apt_key_provider_spec.rb
+++ b/spec/acceptance/apt_key_provider_spec.rb
@@ -13,7 +13,7 @@ CENTOS_GPG_KEY_FILE                 = 'RPM-GPG-KEY-CentOS-6'.freeze
 PUPPETLABS_EXP_KEY_LONG_ID          = '47B320EB4C7C375AA9DAE1A01054B7A24BD6EC30'.freeze
 PUPPETLABS_EXP_KEY_DATES            = 'pub:e:4096:1:1054B7A24BD6EC30:2010-07-10:2017-01-05::-:Puppet Labs Release Key'.freeze
 SHOULD_NEVER_EXIST_ID               = 'EF8D349F'.freeze
-KEY_CHECK_COMMAND                   = 'apt-key adv --list-keys --with-colons --fingerprint | grep '.freeze
+KEY_CHECK_COMMAND                   = 'apt-key adv --no-tty --list-keys --with-colons --fingerprint | grep '.freeze
 PUPPETLABS_KEY_CHECK_COMMAND        = "#{KEY_CHECK_COMMAND} #{PUPPETLABS_GPG_KEY_FINGERPRINT}".freeze
 CENTOS_KEY_CHECK_COMMAND            = "#{KEY_CHECK_COMMAND} #{CENTOS_GPG_KEY_FINGERPRINT}".freeze
 PUPPETLABS_EXP_CHECK_COMMAND        = "#{KEY_CHECK_COMMAND} '#{PUPPETLABS_EXP_KEY_DATES}'".freeze
@@ -31,7 +31,7 @@ end
 
 def install_key(key)
   retry_on_error_matching do
-    shell("apt-key adv --keyserver pgp.mit.edu --recv-keys #{key}")
+    shell("apt-key adv --no-tty --keyserver pgp.mit.edu --recv-keys #{key}")
   end
 end
 
@@ -980,8 +980,6 @@ describe 'apt_key' do
       if fact('lsbdistcodename') == 'stretch' || fact('lsbdistcodename') == 'bionic'
         # Ensure dirmngr package is installed
         apply_manifest(refresh_check_for_dirmngr_pp, acceptable_exit_codes: [0, 2])
-        # Export environment variable to disable apt-key warning when using grep
-        shell('export APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1')
       end
       # Delete the Puppet Labs Release Key and install an expired version of the key
       apply_manifest(refresh_del_key_pp)


### PR DESCRIPTION
On modern Debian(-based) distros this is needed for gpg to function when no TTY is available. Since Puppet often runs from cron or a daemon, this is often the case.

By using autorequire we can clean up the dirmngr handling around apt::key.

Verified by running:
```
PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_setfile='debian9-64{hypervisor=docker}' BEAKER_TESTMODE=apply bundle exec rspec spec/acceptance/apt_key_provider_spec.rb
```