### PR TITLE
(MODULES-8272) - Revert "Autorequire dirmngr in apt_key types"

### DIFF
--- a/lib/puppet/type/apt_key.rb
+++ b/lib/puppet/type/apt_key.rb
@@ -64,10 +64,6 @@ Puppet::Type.newtype(:apt_key) do
     end
   end
 
-  autorequire(:package) do
-    'dirmngr'
-  end
-
   newparam(:server) do
     desc 'The key server to fetch the key from based on the ID. It can either be a domain name or url.'
     defaultto :'keyserver.ubuntu.com'

--- a/manifests/key.pp
+++ b/manifests/key.pp
@@ -57,6 +57,22 @@ define apt::key (
           server  => $server,
           options => $options,
         } -> anchor { "apt_key ${id} present": }
+
+        case $facts['os']['name'] {
+          'Debian': {
+            if versioncmp($facts['os']['release']['major'], '9') >= 0 {
+              ensure_packages(['dirmngr'])
+              Apt::Key<| title == $title |>
+            }
+          }
+          'Ubuntu': {
+            if versioncmp($facts['os']['release']['full'], '17.04') >= 0 {
+              ensure_packages(['dirmngr'])
+              Apt::Key<| title == $title |>
+            }
+          }
+          default: { }
+        }
       }
     }
 

--- a/spec/acceptance/apt_key_provider_spec.rb
+++ b/spec/acceptance/apt_key_provider_spec.rb
@@ -665,6 +665,12 @@ refresh_del_key_pp = <<-MANIFEST
         }
 MANIFEST
 
+refresh_check_for_dirmngr_pp = <<-MANIFEST
+        package { 'dirmngr':
+          ensure  => 'present',
+        }
+MANIFEST
+
 describe 'apt_key' do
   before(:each) do
     # Delete twice to make sure everything is cleaned
@@ -971,6 +977,10 @@ describe 'apt_key' do
       let(:puppetlabs_exp_check_command) { PUPPETLABS_EXP_CHECK_COMMAND }
     end
     before(:each) do
+      if fact('lsbdistcodename') == 'stretch' || fact('lsbdistcodename') == 'bionic'
+        # Ensure dirmngr package is installed
+        apply_manifest(refresh_check_for_dirmngr_pp, acceptable_exit_codes: [0, 2])
+      end
       # Delete the Puppet Labs Release Key and install an expired version of the key
       apply_manifest(refresh_del_key_pp)
       apply_manifest(refresh_pp, catch_failures: true)


### PR DESCRIPTION
A bug has been introduced through this commit which creates a dependency cycle in Debian 9 when applying a simple manifest. This reverts commit 53ea6e7a789ebec00d463ba78abf09bfe031efd9. 