### PR TITLE
/etc/apt/auth.conf owner changed endlessly

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -87,6 +87,9 @@
 #   https://manpages.debian.org/testing/apt/apt_auth.conf.5.en.html for details. If specified each hash must contain the keys machine, login and 
 #   password and no others.
 #
+# @param auth_conf_owner
+#   The owner of the file /etc/apt/auth.conf. Default: '_apt' or 'root' on old releases.
+#
 # @param root
 #   Specifies root directory of Apt executable.
 #
@@ -129,6 +132,7 @@ class apt (
   Hash $settings                = $apt::params::settings,
   Array[Apt::Auth_conf_entry]
     $auth_conf_entries          = $apt::params::auth_conf_entries,
+  String $auth_conf_owner       = $apt::params::auth_conf_owner,
   String $root                  = $apt::params::root,
   String $sources_list          = $apt::params::sources_list,
   String $sources_list_d        = $apt::params::sources_list_d,
@@ -278,7 +282,7 @@ class apt (
 
   file { '/etc/apt/auth.conf':
     ensure  => $auth_conf_ensure,
-    owner   => 'root',
+    owner   => $auth_conf_owner,
     group   => 'root',
     mode    => '0600',
     content => "${confheadertmp}${auth_conf_tmp}",

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -86,6 +86,11 @@ class apt::params {
           }
       $ppa_options = undef
       $ppa_package = undef
+      if versioncmp($facts['os']['release']['major'], '9') >= 0 {
+        $auth_conf_owner = '_apt'
+      } else {
+        $auth_conf_owner = 'root'
+      }
     }
     'Ubuntu': {
       $backports = {
@@ -95,6 +100,11 @@ class apt::params {
       }
       $ppa_options        = '-y'
       $ppa_package        = 'software-properties-common'
+      if versioncmp($facts['os']['release']['full'], '16.04') >= 0 {
+        $auth_conf_owner = '_apt'
+      } else {
+        $auth_conf_owner = 'root'
+      }
     }
     undef: {
       fail(translate('Unable to determine value for fact os[\"name\"]'))
@@ -103,6 +113,7 @@ class apt::params {
       $ppa_options = undef
       $ppa_package = undef
       $backports   = undef
+      $auth_conf_owner = 'root'
     }
   }
 }


### PR DESCRIPTION
Starting from Debian 9 and Ubuntu 16.04 the user _apt owns the file /etc/apt/auth.conf.
puppetlabs-apt changes the owner to root and triggers apt update, which will reset the owner to _apt. The next Puppet run changes the owner again and so on.

The attached patch adds the parameter $auth_conf_owner. The parameter defaults to '_apt' or 'root' depending on the Debian or Ubuntu release.