### PR TITLE
(MODULES-8326) - apt-transport-https not ensured properly

### DIFF
--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -88,7 +88,7 @@ define apt::source(
     }
     # Newer oses, do not need the package for HTTPS transport.
     $_transport_https_releases = [ 'wheezy', 'jessie', 'stretch', 'trusty', 'xenial' ]
-    if $_release in $_transport_https_releases and $location =~ /(?i:^https:\/\/)/ {
+    if ($_release in $_transport_https_releases or $facts['lsbdistcodename'] in $_transport_https_releases) and $location =~ /(?i:^https:\/\/)/ {
       ensure_packages('apt-transport-https')
     }
   }

--- a/spec/defines/source_spec.rb
+++ b/spec/defines/source_spec.rb
@@ -196,6 +196,29 @@ describe 'apt::source' do
     }
   end
 
+  context 'with a https location and custom release, install apt-transport-https' do
+    let :facts do
+      {
+        os: { family: 'Debian', name: 'Debian', release: { major: '8', full: '8.0' } },
+        lsbdistid: 'Debian',
+        lsbdistcodename: 'jessie',
+        osfamily: 'Debian',
+        puppetversion: Puppet.version,
+      }
+    end
+    let :params do
+      {
+        location: 'HTTPS://foo.bar',
+        allow_unsigned: false,
+        release: 'customrelease',
+      }
+    end
+
+    it {
+      is_expected.to contain_package('apt-transport-https')
+    }
+  end
+
   context 'with a https location, do not install apt-transport-https on oses not in list eg buster' do
     let :facts do
       {


### PR DESCRIPTION
This change is to ensure that apt-transport-https is installed. The current implementation compares  the $release parameter with distro names however in some cases a user may need to supply a custom distro name.