### PR TITLE
(MODULES-8321) - Add manage_auth_conf parameter

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -26,6 +26,7 @@ class apt::params {
   $ppas           = {}
   $pins           = {}
   $settings       = {}
+  $manage_auth_conf = true
   $auth_conf_entries = []
 
   $config_files = {

--- a/spec/classes/apt_spec.rb
+++ b/spec/classes/apt_spec.rb
@@ -202,19 +202,35 @@ describe 'apt' do
       }
     end
 
-    auth_conf_content = "// This file is managed by Puppet. DO NOT EDIT.
+    context 'with manage_auth_conf => true' do
+      let(:params) do
+        super().merge(manage_auth_conf: true)
+      end
+
+      auth_conf_content = "// This file is managed by Puppet. DO NOT EDIT.
 machine deb.example.net login foologin password secret
 machine apt.example.com login aptlogin password supersecret
 "
 
-    it {
-      is_expected.to contain_file('/etc/apt/auth.conf').with(ensure: 'present',
-                                                             owner: 'root',
-                                                             group: 'root',
-                                                             mode: '0600',
-                                                             notify: 'Class[Apt::Update]',
-                                                             content: auth_conf_content)
-    }
+      it {
+        is_expected.to contain_file('/etc/apt/auth.conf').with(ensure: 'present',
+                                                               owner: 'root',
+                                                               group: 'root',
+                                                               mode: '0600',
+                                                               notify: 'Class[Apt::Update]',
+                                                               content: auth_conf_content)
+      }
+    end
+
+    context 'with manage_auth_conf => false' do
+      let(:params) do
+        super().merge(manage_auth_conf: false)
+      end
+
+      it {
+        is_expected.not_to contain_file('/etc/apt/auth.conf')
+      }
+    end
   end
 
   context 'with improperly specified entries for /etc/apt/auth.conf' do


### PR DESCRIPTION
This new parameter allows the user to choose whether Puppet should manage the `/etc/apt/auth.conf` file.