### PR TITLE
Add support for dist-upgrade & autoremove action

### DIFF
--- a/spec/acceptance/init_task_spec.rb
+++ b/spec/acceptance/init_task_spec.rb
@@ -1,11 +1,29 @@
 # run a test task
 require 'spec_helper_acceptance'
 
-describe 'apt tasks' do
-  describe 'update and upgrade', if: pe_install? && puppet_version =~ %r{(5\.\d\.\d)} && fact_on(master, 'osfamily') == 'Debian' do
-    it 'execute arbitary sql' do
+describe 'apt tasks', if: pe_install? && puppet_version =~ %r{(5\.\d\.\d)} && fact_on(master, 'osfamily') == 'Debian' do
+  describe 'update' do
+    it 'updates package lists' do
       result = run_task(task_name: 'apt', params: 'action=update')
       expect_multiple_regexes(result: result, regexes: [%r{Reading package lists}, %r{Job completed. 1/1 nodes succeeded}])
+    end
+  end
+  describe 'upgrade' do
+    it 'upgrades packages' do
+      result = run_task(task_name: 'apt', params: 'action=upgrade')
+      expect_multiple_regexes(result: result, regexes: [%r{\d+ upgraded, \d+ newly installed, \d+ to remove and \d+ not upgraded}, %r{Job completed. 1/1 nodes succeeded}])
+    end
+  end
+  describe 'dist-upgrade' do
+    it 'dist-upgrades packages' do
+      result = run_task(task_name: 'apt', params: 'action=dist-upgrade')
+      expect_multiple_regexes(result: result, regexes: [%r{\d+ upgraded, \d+ newly installed, \d+ to remove and \d+ not upgraded}, %r{Job completed. 1/1 nodes succeeded}])
+    end
+  end
+  describe 'autoremove' do
+    it 'autoremoves obsolete packages' do
+      result = run_task(task_name: 'apt', params: 'action=autoremove')
+      expect_multiple_regexes(result: result, regexes: [%r{\d+ upgraded, \d+ newly installed, \d+ to remove and \d+ not upgraded}, %r{Job completed. 1/1 nodes succeeded}])
     end
   end
 end

--- a/tasks/init.json
+++ b/tasks/init.json
@@ -4,7 +4,7 @@
   "parameters": {
     "action": {
       "description": "Action to perform ",
-      "type": "Enum[update, upgrade]"
+      "type": "Enum[update, upgrade, dist-upgrade, autoremove]"
     }
   }
 }

--- a/tasks/init.rb
+++ b/tasks/init.rb
@@ -5,7 +5,7 @@ require 'puppet'
 
 def apt_get(action)
   cmd = ['apt-get', action]
-  cmd << '-y' if action == 'upgrade'
+  cmd << '-y' if ['upgrade', 'dist-upgrade', 'autoremove'].include?(action)
   stdout, stderr, status = Open3.capture3(*cmd)
   raise Puppet::Error, stderr if status != 0 # rubocop:disable GetText/DecorateFunctionMessage
   { status: stdout.strip }


### PR DESCRIPTION
It would be useful if the `apt` task could also be used for performing `dist-upgrade` and `autoremove` actions in batch. This PR adds support for these.