### PR TITLE
Allow URI escaping in any user/pass in the URL

### DIFF
--- a/lib/puppet/provider/apt_key/apt_key.rb
+++ b/lib/puppet/provider/apt_key/apt_key.rb
@@ -134,6 +134,12 @@ Puppet::Type.type(:apt_key).provide(:apt_key) do
         else
           user_pass = parsed_value.userinfo.split(':')
           parsed_value.userinfo = ''
+          unless user_pass.nil?
+            # URI unescape the username and password in case they had any special
+            # characters that required escaping
+            user_pass[0] = URI.unescape(user_pass[0])
+            user_pass[1] = URI.unescape(user_pass[1])
+          end
           key = open(parsed_value, http_basic_authentication: user_pass).read
         end
       rescue OpenURI::HTTPError, Net::FTPPermError => e

--- a/spec/acceptance/apt_key_provider_spec.rb
+++ b/spec/acceptance/apt_key_provider_spec.rb
@@ -485,6 +485,14 @@ http_works_userinfo_pp = <<-MANIFEST
         }
   MANIFEST
 
+http_works_special_character_userinfo_pp = <<-MANIFEST
+        apt_key { 'puppetlabs':
+          id     => '#{PUPPETLABS_GPG_KEY_LONG_ID}',
+          ensure => 'present',
+          source => 'http://dummyus$r:dummypassword@#{PUPPETLABS_APT_URL}/#{PUPPETLABS_GPG_KEY_FILE}',
+        }
+  MANIFEST
+
 four_oh_four_pp = <<-MANIFEST
         apt_key { 'puppetlabs':
           id     => '#{PUPPETLABS_GPG_KEY_LONG_ID}',
@@ -547,6 +555,14 @@ https_userinfo_pp = <<-MANIFEST
           id     => '#{PUPPETLABS_GPG_KEY_LONG_ID}',
           ensure => 'present',
           source => 'https://dummyuser:dummypassword@#{PUPPETLABS_APT_URL}/#{PUPPETLABS_GPG_KEY_FILE}',
+        }
+  MANIFEST
+
+https_special_character_userinfo_pp = <<-MANIFEST
+        apt_key { 'puppetlabs':
+          id     => '#{PUPPETLABS_GPG_KEY_LONG_ID}',
+          ensure => 'present',
+          source => 'https://dummyuser@google.co.uk:dummypassword@#{PUPPETLABS_APT_URL}/#{PUPPETLABS_GPG_KEY_FILE}',
         }
   MANIFEST
 
@@ -756,6 +772,11 @@ describe 'apt_key' do
         run_shell(PUPPETLABS_KEY_CHECK_COMMAND)
       end
 
+      it 'works with special character userinfo' do
+        apply_manifest_twice(http_works_special_character_userinfo_pp)
+        run_shell(PUPPETLABS_KEY_CHECK_COMMAND)
+      end
+
       it 'fails with a 404' do
         apply_manifest(four_oh_four_pp, expect_failures: true) do |r|
           expect(r.stderr).to match(%r{404 Not Found})
@@ -806,6 +827,11 @@ describe 'apt_key' do
 
       it 'works with userinfo' do
         apply_manifest_twice(https_userinfo_pp)
+        run_shell(PUPPETLABS_KEY_CHECK_COMMAND)
+      end
+
+      it 'works with special character userinfo' do
+        apply_manifest_twice(https_special_character_userinfo_pp)
         run_shell(PUPPETLABS_KEY_CHECK_COMMAND)
       end
 


### PR DESCRIPTION
One of my providers distributes packages from behind a password protected repository. And email addresses have become very common usernames, and the '@' in a username won't work since the URL decoder will detect that as the end of the user:pass part. This trivial patch allows both the username and the password to be URI encoded.

I'm pretty sure that doing the URI un-escaping after splitting 'parsed_value' is the right thing, in case either includes a colon ':' character.