### PR TITLE
key: Don't include dirmngr unless necessary

### DIFF
--- a/manifests/key.pp
+++ b/manifests/key.pp
@@ -1,6 +1,6 @@
-# @summary Manages the GPG keys that Apt uses to authenticate packages. 
+# @summary Manages the GPG keys that Apt uses to authenticate packages.
 #
-# @note 
+# @note
 #   The apt::key defined type makes use of the apt_key type, but includes extra functionality to help prevent duplicate keys.
 #
 # @example Declare Apt key for apt.puppetlabs.com source
@@ -11,7 +11,7 @@
 #   }
 #
 # @param id
-#   Specifies a GPG key to authenticate Apt package signatures. Valid options: a string containing a key ID (8 or 16 hexadecimal 
+#   Specifies a GPG key to authenticate Apt package signatures. Valid options: a string containing a key ID (8 or 16 hexadecimal
 #   characters, optionally prefixed with "0x") or a full key fingerprint (40 hexadecimal characters).
 #
 # @param ensure
@@ -22,7 +22,7 @@
 #   Supplies the entire GPG key. Useful in case the key can't be fetched from a remote location and using a file resource is inconvenient.
 #
 # @param source
-#   Specifies the location of an existing GPG key file to copy. Valid options: a string containing a URL (ftp://, http://, or https://) or 
+#   Specifies the location of an existing GPG key file to copy. Valid options: a string containing a URL (ftp://, http://, or https://) or
 #   an absolute path.
 #
 # @param server
@@ -65,13 +65,13 @@ define apt::key (
 
         case $facts['os']['name'] {
           'Debian': {
-            if versioncmp($facts['os']['release']['major'], '9') >= 0 {
+            if !($source or $content) and (versioncmp($facts['os']['release']['major'], '9')) >= 0 {
               ensure_packages(['dirmngr'])
               Apt::Key<| title == $title |>
             }
           }
           'Ubuntu': {
-            if versioncmp($facts['os']['release']['full'], '17.04') >= 0 {
+            if !($source or $content) and (versioncmp($facts['os']['release']['full'], '17.04')) >= 0 {
               ensure_packages(['dirmngr'])
               Apt::Key<| title == $title |>
             }

--- a/spec/defines/key_spec.rb
+++ b/spec/defines/key_spec.rb
@@ -131,7 +131,6 @@ describe 'apt::key' do
         is_expected.to contain_anchor("apt_key #{title} present")
       end
     end
-
     context 'when domain with dash' do
       let(:params) do
         {
@@ -167,6 +166,62 @@ describe 'apt::key' do
       it 'contains the apt_key' do
         is_expected.to contain_apt_key(title).with(id: title,
                                                    server: 'hkp://pgp.mit.edu:80')
+      end
+    end
+  end
+
+  describe 'dirmngr dependency' do
+    let :pre_condition do
+      'class { "apt": }'
+    end
+
+    let(:facts) do
+      {
+        os: { family: 'Debian', name: 'Debian', release: { major: '9', full: '9.8' } },
+        lsbdistid: 'Debian',
+        osfamily: 'Debian',
+        lsbdistcodename: 'stretch',
+      }
+    end
+
+    let :title do
+      GPG_KEY_ID
+    end
+
+    context 'no content or source' do
+      let :params do
+        {
+          content: nil,
+          source: nil,
+        }
+      end
+
+      it 'depends on dirmngr' do
+        is_expected.to contain_package('dirmngr')
+      end
+    end
+
+    context 'with content' do
+      let :params do
+        {
+          content: 'test',
+        }
+      end
+
+      it 'does not depend on dirmngr' do
+        is_expected.not_to contain_package('dirmngr')
+      end
+    end
+
+    context 'with source' do
+      let :params do
+        {
+          source: 'http://test',
+        }
+      end
+
+      it 'does not depend on dirmngr' do
+        is_expected.not_to contain_package('dirmngr')
       end
     end
   end


### PR DESCRIPTION
We should not depend on dirmngr unless the apt::key resource does not
specify a content or a source parameter. When either content or source
is set we either have a local file or will fetch one over http.

This also fixes a subtle bug related to Raspbian where dirmngr isn't
available which renders apt::key unusable even when the apt::key
or apt::source entry specifies a content/source parameter for the
key.