### PR TITLE
Install gnupg instead of dirmngr

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -302,5 +302,5 @@ class apt (
   }
 
   # required for adding GPG keys on Debian 9 (and derivatives)
-  ensure_packages(['dirmngr'])
+  ensure_packages(['gnupg'])
 }

--- a/manifests/key.pp
+++ b/manifests/key.pp
@@ -66,13 +66,13 @@ define apt::key (
         case $facts['os']['name'] {
           'Debian': {
             if versioncmp($facts['os']['release']['major'], '9') >= 0 {
-              ensure_packages(['dirmngr'])
+              ensure_packages(['gnupg'])
               Apt::Key<| title == $title |>
             }
           }
           'Ubuntu': {
             if versioncmp($facts['os']['release']['full'], '17.04') >= 0 {
-              ensure_packages(['dirmngr'])
+              ensure_packages(['gnupg'])
               Apt::Key<| title == $title |>
             }
           }


### PR DESCRIPTION
gnupg pulls in dirmngt and gpg, which are needed by apt_key