### PR TITLE
Update key.pp

### DIFF
--- a/manifests/key.pp
+++ b/manifests/key.pp
@@ -54,7 +54,6 @@ define apt::key (
       if !defined(Anchor["apt_key ${id} present"]) {
         apt_key { $title:
           ensure   => present,
-          refresh  => $ensure == 'refreshed',
           id       => $id,
           source   => $source,
           content  => $content,


### PR DESCRIPTION
Line 57 references a value that apparently doesn't exist (see error message below).
When I remove the line my Puppet works.

Error message:
`Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: no parameter named 'refresh' (file: /etc/puppetlabs/code/modules/apt/manifests/ke
y.pp, line: 51) on Apt_key[Add key: F51A91A5EE001AA5D77D53C4C6E319C334410682 from Apt::Source icinga-stable-release] (file: /etc/puppetlabs/code/modules/apt/manifests/key
.pp, line: 51) on node icinga.pocld.net`

I'm using V6.3 (_puppet/unattended_upgrades_ doesn't support v7).

I wondering if I'm missing something though, surely someone must have noticed this before if it is an actual issue.