### PR TITLE
implement apt.conf.d purging

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,11 @@ APT is a package manager available on Debian, Ubuntu, and several other operatin
 
 * Your system's `preferences` file and `preferences.d` directory
 * Your system's `sources.list` file and `sources.list.d` directory
+* Your system's `apt.conf.d` directory
 * System repositories
 * Authentication keys
 
-**Note:** This module offers `purge` parameters which, if set to `true`, **destroy** any configuration on the node's `sources.list(.d)` and `preferences(.d)` that you haven't declared through Puppet. The default for these parameters is `false`.
+**Note:** This module offers `purge` parameters which, if set to `true`, **destroy** any configuration on the node's `sources.list(.d)`, `preferences(.d)` and `apt.conf.d` that you haven't declared through Puppet. The default for these parameters is `false`.
 
 <a id="beginning-with-apt"></a>
 ### Beginning with apt

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -144,6 +144,7 @@ class apt (
   String $conf_d                = $apt::params::conf_d,
   String $preferences           = $apt::params::preferences,
   String $preferences_d         = $apt::params::preferences_d,
+  String $apt_conf_d            = $apt::params::apt_conf_d,
   Hash $config_files            = $apt::params::config_files,
   Hash $source_key_defaults     = $apt::params::source_key_defaults,
 ) inherits apt::params {
@@ -179,6 +180,9 @@ class apt (
   }
   if $purge['preferences.d'] {
     assert_type(Boolean, $purge['preferences.d'])
+  }
+  if $purge['apt.conf.d'] {
+    assert_type(Boolean, $purge['apt.conf.d'])
   }
 
   $_purge = merge($::apt::purge_defaults, $purge)
@@ -255,6 +259,17 @@ class apt (
     mode    => '0644',
     purge   => $_purge['preferences.d'],
     recurse => $_purge['preferences.d'],
+    notify  => Class['apt::update'],
+  }
+
+  file { 'apt.conf.d':
+    ensure  => directory,
+    path    => $::apt::apt_conf_d,
+    owner   => root,
+    group   => root,
+    mode    => '0644',
+    purge   => $_purge['apt.conf.d'],
+    recurse => $_purge['apt.conf.d'],
     notify  => Class['apt::update'],
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,6 +16,7 @@ class apt::params {
   $conf_d         = "${root}/apt.conf.d"
   $preferences    = "${root}/preferences"
   $preferences_d  = "${root}/preferences.d"
+  $apt_conf_d     = "${root}/apt.conf.d"
   $keyserver      = 'keyserver.ubuntu.com'
   $confs          = {}
   $update         = {}
@@ -64,6 +65,7 @@ class apt::params {
     'sources.list.d' => false,
     'preferences'    => false,
     'preferences.d'  => false,
+    'apt.conf.d'     => false,
   }
 
   $source_key_defaults = {

--- a/spec/acceptance/apt_spec.rb
+++ b/spec/acceptance/apt_spec.rb
@@ -23,6 +23,7 @@ everything_everything_pp = <<-MANIFEST
           'sources.list.d' => true,
           'preferences'    => true,
           'preferences.d'  => true,
+          'apt.conf.d'     => true,
         },
         sources => $sources,
       }

--- a/spec/classes/apt_spec.rb
+++ b/spec/classes/apt_spec.rb
@@ -32,6 +32,15 @@ preferences_d = { ensure: 'directory',
                   recurse: false,
                   notify: 'Class[Apt::Update]' }
 
+apt_conf_d = {    ensure: 'directory',
+                  path: '/etc/apt/apt.conf.d',
+                  owner: 'root',
+                  group: 'root',
+                  mode: '0644',
+                  purge: false,
+                  recurse: false,
+                  notify: 'Class[Apt::Update]' }
+
 describe 'apt' do
   let(:facts) do
     {
@@ -57,6 +66,10 @@ describe 'apt' do
 
     it {
       is_expected.to contain_file('preferences.d').that_notifies('Class[Apt::Update]').only_with(preferences_d)
+    }
+
+    it {
+      is_expected.to contain_file('apt.conf.d').that_notifies('Class[Apt::Update]').only_with(apt_conf_d)
     }
 
     it { is_expected.to contain_file('/etc/apt/auth.conf').with_ensure('absent') }
@@ -158,7 +171,8 @@ describe 'apt' do
       {
         update: { 'frequency' => 'always', 'timeout' => 1, 'tries' => 3 },
         purge: { 'sources.list' => false, 'sources.list.d' => false,
-                 'preferences' => false, 'preferences.d' => false },
+                 'preferences' => false, 'preferences.d' => false,
+                 'apt.conf.d' => false },
       }
     end
 
@@ -178,6 +192,11 @@ describe 'apt' do
     it {
       is_expected.to contain_file('preferences.d').with(purge: false,
                                                         recurse: false)
+    }
+
+    it {
+      is_expected.to contain_file('apt.conf.d').with(purge: false,
+                                                     recurse: false)
     }
 
     it {
@@ -504,6 +523,14 @@ machine apt.example.com login aptlogin password supersecret
 
     context "with purge['preferences.d']=>'banana'" do
       let(:params) { { purge: { 'preferences.d' => 'banana' } } }
+
+      it do
+        is_expected.to raise_error(Puppet::Error)
+      end
+    end
+
+    context "with purge['apt.conf.d']=>'banana'" do
+      let(:params) { { purge: { 'apt.conf.d' => 'banana' } } }
 
       it do
         is_expected.to raise_error(Puppet::Error)


### PR DESCRIPTION
this module already has parameters that let users purge sources.list.d
and preferences.d. It also has resources to create source files in
sources.list.d and "pins" in preferences.d and also has a resource to
create a configuration file in apt.conf.d. however, for some reason it
can't purge apt.conf.d

purging this directory can help users ensure that systems run exactly
with what puppet knows the system should be configured with.

This pull request would close MODULES-9481