### PR TITLE
Add apt::key_options for default apt::key options

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,6 +9,9 @@
 #   Specifies a keyserver to provide the GPG key. Valid options: a string containing a domain name or a full URL (http://, https://, or
 #   hkp://).
 #
+# @param key_options
+#   Specifies the default options for apt::key resources.
+#
 # @param ppa_options
 #   Supplies options to be passed to the `add-apt-repository` command.
 #
@@ -122,6 +125,7 @@ class apt (
   Hash $include_defaults        = $apt::params::include_defaults,
   String $provider              = $apt::params::provider,
   String $keyserver             = $apt::params::keyserver,
+  Optional[String] $key_options = $apt::params::key_options,
   Optional[String] $ppa_options = $apt::params::ppa_options,
   Optional[String] $ppa_package = $apt::params::ppa_package,
   Optional[Hash] $backports     = $apt::params::backports,

--- a/manifests/key.pp
+++ b/manifests/key.pp
@@ -42,7 +42,7 @@ define apt::key (
   Optional[Pattern[/\Ahttps?:\/\//, /\Aftp:\/\//, /\A\/\w+/]] $source                                = undef,
   Pattern[/\A((hkp|hkps|http|https):\/\/)?([a-z\d])([a-z\d-]{0,61}\.)+[a-z\d]+(:\d{2,5})?$/] $server = $::apt::keyserver,
   Boolean $weak_ssl                                                                                  = false,
-  Optional[String] $options                                                                          = undef,
+  Optional[String] $options                                                                          = $::apt::key_options,
   ) {
 
   case $ensure {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,6 +17,7 @@ class apt::params {
   $preferences    = "${root}/preferences"
   $preferences_d  = "${root}/preferences.d"
   $keyserver      = 'keyserver.ubuntu.com'
+  $key_options    = undef
   $confs          = {}
   $update         = {}
   $purge          = {}

--- a/spec/defines/key_spec.rb
+++ b/spec/defines/key_spec.rb
@@ -392,5 +392,17 @@ describe 'apt::key' do
         is_expected.to contain_apt_key(title).with_server('keyserver.example.com')
       end
     end
+
+    context 'when setting key_options on the apt class' do
+      let :pre_condition do
+        'class { "apt":
+          key_options => "http-proxy=http://proxy.example.com:8080",
+        }'
+      end
+
+      it 'uses default keyserver' do
+        is_expected.to contain_apt_key(title).with_options('http-proxy=http://proxy.example.com:8080')
+      end
+    end
   end
 end

--- a/spec/defines/key_spec.rb
+++ b/spec/defines/key_spec.rb
@@ -379,4 +379,18 @@ describe 'apt::key' do
       end
     end
   end
+
+  describe 'defaults' do
+    context 'when setting keyserver on the apt class' do
+      let :pre_condition do
+        'class { "apt":
+          keyserver => "keyserver.example.com",
+        }'
+      end
+
+      it 'uses default keyserver' do
+        is_expected.to contain_apt_key(title).with_server('keyserver.example.com')
+      end
+    end
+  end
 end


### PR DESCRIPTION
This allows to set global default for `apt::key` options (such as http proxies), just as it is done with `keyserver`.