### PR TITLE
Include apt in apt::backports

### DIFF
--- a/manifests/backports.pp
+++ b/manifests/backports.pp
@@ -52,6 +52,9 @@ class apt::backports (
   Optional[Variant[String, Hash]] $key          = undef,
   Optional[Variant[Integer, String, Hash]] $pin = 200,
 ){
+
+  include apt
+
   if $location {
     $_location = $location
   }


### PR DESCRIPTION
we had issues with the order apt and apt::backports were evaluated.
Even if we have both in catalog. 
like:

> Evaluation Error: Operator '[]' is not applicable to an Undef Value. (file: /etc/puppetlabs/code/environments/production/modules/apt/manifests/backports.pp, line: 73, column: 18) on node 