### PR TITLE
MODULES-10063, extend apt::key to support deeplinks

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -520,7 +520,7 @@ Default value: `undef`
 
 ##### `server`
 
-Data type: `Pattern[/\A((hkp|hkps|http|https):\/\/)?([a-z\d])([a-z\d-]{0,61}\.)+[a-z\d]+(:\d{2,5})?$/]`
+Data type: `Pattern[/\A((hkp|hkps|http|https):\/\/)?([a-z\d])([a-z\d-]{0,61}\.)+[a-z\d]+(:\d{2,5})?(\/[a-zA-Z\d\-_]+)*\/?$/]`
 
 Specifies a keyserver to provide the GPG key. Valid options: a string containing a domain name or a full URL (http://, https://,
 hkp:// or hkps://). The hkps:// protocol is currently only supported on Ubuntu 18.04.

--- a/lib/puppet/type/apt_key.rb
+++ b/lib/puppet/type/apt_key.rb
@@ -68,7 +68,7 @@ Puppet::Type.newtype(:apt_key) do
     desc 'The key server to fetch the key from based on the ID. It can either be a domain name or url.'
     defaultto :'keyserver.ubuntu.com'
 
-    newvalues(%r{\A((hkp|hkps|http|https)://)?([a-z\d])([a-z\d-]{0,61}\.)+[a-z\d]+(:\d{2,5})?$})
+    newvalues(%r{\A((hkp|hkps|http|https):\/\/)?([a-z\d])([a-z\d-]{0,61}\.)+[a-z\d]+(:\d{2,5})?(\/[a-zA-Z\d\-_]+)*\/?$})
   end
 
   newparam(:options) do

--- a/manifests/key.pp
+++ b/manifests/key.pp
@@ -36,13 +36,13 @@
 #   Passes additional options to `apt-key adv --keyserver-options`.
 #
 define apt::key (
-  Pattern[/\A(0x)?[0-9a-fA-F]{8}\Z/, /\A(0x)?[0-9a-fA-F]{16}\Z/, /\A(0x)?[0-9a-fA-F]{40}\Z/] $id     = $title,
-  Enum['present', 'absent', 'refreshed'] $ensure                                                     = present,
-  Optional[String] $content                                                                          = undef,
-  Optional[Pattern[/\Ahttps?:\/\//, /\Aftp:\/\//, /\A\/\w+/]] $source                                = undef,
-  Pattern[/\A((hkp|hkps|http|https):\/\/)?([a-z\d])([a-z\d-]{0,61}\.)+[a-z\d]+(:\d{2,5})?$/] $server = $::apt::keyserver,
-  Boolean $weak_ssl                                                                                  = false,
-  Optional[String] $options                                                                          = $::apt::key_options,
+  Pattern[/\A(0x)?[0-9a-fA-F]{8}\Z/, /\A(0x)?[0-9a-fA-F]{16}\Z/, /\A(0x)?[0-9a-fA-F]{40}\Z/] $id                        = $title,
+  Enum['present', 'absent', 'refreshed'] $ensure                                                                        = present,
+  Optional[String] $content                                                                                             = undef,
+  Optional[Pattern[/\Ahttps?:\/\//, /\Aftp:\/\//, /\A\/\w+/]] $source                                                   = undef,
+  Pattern[/\A((hkp|hkps|http|https):\/\/)?([a-z\d])([a-z\d-]{0,61}\.)+[a-z\d]+(:\d{2,5})?(\/[a-zA-Z\d\-_]+)*\/?$/] $server = $::apt::keyserver,
+  Boolean $weak_ssl                                                                                                     = false,
+  Optional[String] $options                                                                                             = $::apt::key_options,
   ) {
 
   case $ensure {


### PR DESCRIPTION
urrent implementation only supports baseurls. nothing like 'https://www.apache.org/dist/cassandra/keys'