### PR TITLE
MODULES-10063, extend apt::key to support deeplinks, this time with f…

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -520,7 +520,7 @@ Default value: `undef`
 
 ##### `server`
 
-Data type: `Pattern[/\A((hkp|hkps|http|https):\/\/)?([a-z\d])([a-z\d-]{0,61}\.)+[a-z\d]+(:\d{2,5})?(\/[a-zA-Z\d\-_]+)*\/?$/]`
+Data type: `Pattern[/\A((hkp|hkps|http|https):\/\/)?([a-z\d])([a-z\d-]{0,61}\.)+[a-z\d]+(:\d{2,5})?(\/[a-zA-Z\d\-_.]+)*\/?$/]`
 
 Specifies a keyserver to provide the GPG key. Valid options: a string containing a domain name or a full URL (http://, https://,
 hkp:// or hkps://). The hkps:// protocol is currently only supported on Ubuntu 18.04.

--- a/lib/puppet/type/apt_key.rb
+++ b/lib/puppet/type/apt_key.rb
@@ -68,7 +68,7 @@ Puppet::Type.newtype(:apt_key) do
     desc 'The key server to fetch the key from based on the ID. It can either be a domain name or url.'
     defaultto :'keyserver.ubuntu.com'
 
-    newvalues(%r{\A((hkp|hkps|http|https):\/\/)?([a-z\d])([a-z\d-]{0,61}\.)+[a-z\d]+(:\d{2,5})?(\/[a-zA-Z\d\-_]+)*\/?$})
+    newvalues(%r{\A((hkp|hkps|http|https):\/\/)?([a-z\d])([a-z\d-]{0,61}\.)+[a-z\d]+(:\d{2,5})?(\/[a-zA-Z\d\-_.]+)*\/?$})
   end
 
   newparam(:options) do

--- a/manifests/key.pp
+++ b/manifests/key.pp
@@ -40,7 +40,7 @@ define apt::key (
   Enum['present', 'absent', 'refreshed'] $ensure                                                                        = present,
   Optional[String] $content                                                                                             = undef,
   Optional[Pattern[/\Ahttps?:\/\//, /\Aftp:\/\//, /\A\/\w+/]] $source                                                   = undef,
-  Pattern[/\A((hkp|hkps|http|https):\/\/)?([a-z\d])([a-z\d-]{0,61}\.)+[a-z\d]+(:\d{2,5})?(\/[a-zA-Z\d\-_]+)*\/?$/] $server = $::apt::keyserver,
+  Pattern[/\A((hkp|hkps|http|https):\/\/)?([a-z\d])([a-z\d-]{0,61}\.)+[a-z\d]+(:\d{2,5})?(\/[a-zA-Z\d\-_.]+)*\/?$/] $server = $::apt::keyserver,
   Boolean $weak_ssl                                                                                                     = false,
   Optional[String] $options                                                                                             = $::apt::key_options,
   ) {


### PR DESCRIPTION
…ilename (https://some.source/somefile.key)