### PR TITLE
MODULES-10543: only consider lsbdistcodename for apt-transport-https

### DIFF
--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -88,7 +88,7 @@ define apt::source(
     }
     # Newer oses, do not need the package for HTTPS transport.
     $_transport_https_releases = [ 'wheezy', 'jessie', 'stretch', 'trusty', 'xenial' ]
-    if ($_release in $_transport_https_releases or $facts['lsbdistcodename'] in $_transport_https_releases) and $location =~ /(?i:^https:\/\/)/ {
+    if ($facts['lsbdistcodename'] in $_transport_https_releases) and $location =~ /(?i:^https:\/\/)/ {
       ensure_packages('apt-transport-https')
     }
   }


### PR DESCRIPTION
It does not matter if we have *one* older source from (say) jessie or
stretch, we could still be running buster or later. The latter is more
reliably indicated by the fact than by the provided "release"
parameter, which is really just an arbitrary string that does not
necessarily match a Debian suite, especially for third-party
repositories.

I have had a problem with this setting when deploying a "stretch"
repository on a "buster" system because I needed to keep MongoDB
running (which is gone from buster). The "stretch" line triggered this
line, which conflicted with a `ensure_packages` I had elsewhere in our
code base, to *remove* the `apt-transport-https` package from buster
and later.

An alternative implementation might prefer to remove the package
unconditionnally if we run a newer release, but I figured I would keep
the changes to a minimum.