### PR TITLE
MODULES-10548: make files readonly

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -230,7 +230,7 @@ class apt (
     path   => $::apt::sources_list,
     owner  => root,
     group  => root,
-    mode   => '0644',
+    mode   => '0444',
     notify => Class['apt::update'],
   }
 
@@ -239,7 +239,7 @@ class apt (
     path    => $::apt::sources_list_d,
     owner   => root,
     group   => root,
-    mode    => '0644',
+    mode    => '0555',
     purge   => $_purge['sources.list.d'],
     recurse => $_purge['sources.list.d'],
     notify  => Class['apt::update'],
@@ -250,7 +250,7 @@ class apt (
     path   => $::apt::preferences,
     owner  => root,
     group  => root,
-    mode   => '0644',
+    mode   => '0444',
     notify => Class['apt::update'],
   }
 
@@ -259,7 +259,7 @@ class apt (
     path    => $::apt::preferences_d,
     owner   => root,
     group   => root,
-    mode    => '0644',
+    mode    => '0555',
     purge   => $_purge['preferences.d'],
     recurse => $_purge['preferences.d'],
     notify  => Class['apt::update'],
@@ -308,7 +308,7 @@ class apt (
       ensure  => $auth_conf_ensure,
       owner   => $auth_conf_owner,
       group   => 'root',
-      mode    => '0600',
+      mode    => '0400',
       content => "${confheadertmp}${auth_conf_tmp}",
       notify  => Class['apt::update'],
     }

--- a/manifests/setting.pp
+++ b/manifests/setting.pp
@@ -69,7 +69,7 @@ define apt::setting (
     ensure  => $ensure,
     owner   => 'root',
     group   => 'root',
-    mode    => '0644',
+    mode    => '0444',
     content => $content,
     source  => $source,
     notify  => $_notify,

--- a/spec/classes/apt_spec.rb
+++ b/spec/classes/apt_spec.rb
@@ -4,14 +4,14 @@ sources_list = {  ensure: 'file',
                   path: '/etc/apt/sources.list',
                   owner: 'root',
                   group: 'root',
-                  mode: '0644',
+                  mode: '0444',
                   notify: 'Class[Apt::Update]' }
 
 sources_list_d = { ensure: 'directory',
                    path: '/etc/apt/sources.list.d',
                    owner: 'root',
                    group: 'root',
-                   mode: '0644',
+                   mode: '0555',
                    purge: false,
                    recurse: false,
                    notify: 'Class[Apt::Update]' }
@@ -20,14 +20,14 @@ preferences = { ensure: 'file',
                 path: '/etc/apt/preferences',
                 owner: 'root',
                 group: 'root',
-                mode: '0644',
+                mode: '0444',
                 notify: 'Class[Apt::Update]' }
 
 preferences_d = { ensure: 'directory',
                   path: '/etc/apt/preferences.d',
                   owner: 'root',
                   group: 'root',
-                  mode: '0644',
+                  mode: '0555',
                   purge: false,
                   recurse: false,
                   notify: 'Class[Apt::Update]' }
@@ -76,7 +76,7 @@ describe 'apt' do
 
     it 'lays down /etc/apt/apt.conf.d/15update-stamp' do
       is_expected.to contain_file('/etc/apt/apt.conf.d/15update-stamp').with(group: 'root',
-                                                                             mode: '0644',
+                                                                             mode: '0444',
                                                                              owner: 'root').with_content(
                                                                                %r{APT::Update::Post-Invoke-Success {"touch /var/lib/apt/periodic/update-success-stamp 2>/dev/null || true";};},
                                                                              )
@@ -301,7 +301,7 @@ machine apt.example.com login aptlogin password supersecret
             is_expected.to contain_file('/etc/apt/auth.conf').with(ensure: 'present',
                                                                    owner: auth_conf_owner,
                                                                    group: 'root',
-                                                                   mode: '0600',
+                                                                   mode: '0400',
                                                                    notify: 'Class[Apt::Update]',
                                                                    content: auth_conf_content)
           }

--- a/spec/defines/conf_spec.rb
+++ b/spec/defines/conf_spec.rb
@@ -35,7 +35,7 @@ describe 'apt::conf', type: :define do
                                                  'content'   => %r{Apt::Install-Recommends 0;\nApt::AutoRemove::InstallRecommends 1;},
                                                  'owner'     => 'root',
                                                  'group'     => 'root',
-                                                 'mode'      => '0644')
+                                                 'mode'      => '0444')
     }
 
     context 'with notify_update = true (default)' do
@@ -83,7 +83,7 @@ describe 'apt::conf', type: :define do
       is_expected.to contain_file(filename).with('ensure' => 'absent',
                                                  'owner'     => 'root',
                                                  'group'     => 'root',
-                                                 'mode'      => '0644')
+                                                 'mode'      => '0444')
     }
   end
 end

--- a/spec/defines/setting_spec.rb
+++ b/spec/defines/setting_spec.rb
@@ -50,7 +50,7 @@ describe 'apt::setting' do
         is_expected.to contain_file('/etc/apt/apt.conf.d/50teddybear').that_notifies('Class[Apt::Update]').with(ensure: 'file',
                                                                                                                 owner: 'root',
                                                                                                                 group: 'root',
-                                                                                                                mode: '0644',
+                                                                                                                mode: '0444',
                                                                                                                 source: params[:source].to_s)
       }
     end
@@ -62,7 +62,7 @@ describe 'apt::setting' do
         is_expected.to contain_file('/etc/apt/apt.conf.d/50teddybear').that_notifies('Class[Apt::Update]').with(ensure: 'file',
                                                                                                                 owner: 'root',
                                                                                                                 group: 'root',
-                                                                                                                mode: '0644',
+                                                                                                                mode: '0444',
                                                                                                                 content: params[:content].to_s)
       }
     end


### PR DESCRIPTION
Files created by the apt module are mode writable by the
owner. Because those files are managed by Puppet, they should really
not be writable by anyone, even root. While root can bypass those
warnings, having files readonly does provide an immediate and reliable
indication that a file should not be edited on site, on top of the
usual top of file warnings.

This also fixes a problem with sources.list.d being non-executable,
which Puppet seems to ignore, but seems better to keep consistent.