### PR TITLE
(MAINT) Update docker image names

### DIFF
--- a/provision.yaml
+++ b/provision.yaml
@@ -1,16 +1,16 @@
 ---
 default:
   provisioner: docker 
-  images: ['waffleimage/debian8']
+  images: ['litmusimage/debian:8']
 vagrant:
   provisioner: vagrant
   images: ['centos/7', 'generic/ubuntu1804'] 
 travis_deb:
   provisioner: docker 
-  images: ['waffleimage/debian9', 'waffleimage/debian10']
+  images: ['litmusimage/debian:9', 'litmusimage/debian:10']
 travis_ub:
   provisioner: docker 
-  images: ['ubuntu:16.04', 'ubuntu:18.04']
+  images: ['litmusimage/ubuntu:16.04', 'litmusimage/ubuntu:18.04']
 travis_el6:
   provisioner: docker 
   images: []


### PR DESCRIPTION
Prior to this commit the provision file referenced the old
waffleimage repo for CI docker images to use. This commit
updates the file to point at litmusimage, which is the repo
the latest images are released to.