### PR TITLE
(MODULES-10583) Revert "MODULES-10548: make files readonly"

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -230,7 +230,7 @@ class apt (
     path   => $::apt::sources_list,
     owner  => root,
     group  => root,
-    mode   => '0444',
+    mode   => '0644',
     notify => Class['apt::update'],
   }
 
@@ -239,7 +239,7 @@ class apt (
     path    => $::apt::sources_list_d,
     owner   => root,
     group   => root,
-    mode    => '0555',
+    mode    => '0644',
     purge   => $_purge['sources.list.d'],
     recurse => $_purge['sources.list.d'],
     notify  => Class['apt::update'],
@@ -250,7 +250,7 @@ class apt (
     path   => $::apt::preferences,
     owner  => root,
     group  => root,
-    mode   => '0444',
+    mode   => '0644',
     notify => Class['apt::update'],
   }
 
@@ -259,7 +259,7 @@ class apt (
     path    => $::apt::preferences_d,
     owner   => root,
     group   => root,
-    mode    => '0555',
+    mode    => '0644',
     purge   => $_purge['preferences.d'],
     recurse => $_purge['preferences.d'],
     notify  => Class['apt::update'],
@@ -308,7 +308,7 @@ class apt (
       ensure  => $auth_conf_ensure,
       owner   => $auth_conf_owner,
       group   => 'root',
-      mode    => '0400',
+      mode    => '0600',
       content => "${confheadertmp}${auth_conf_tmp}",
       notify  => Class['apt::update'],
     }

--- a/manifests/setting.pp
+++ b/manifests/setting.pp
@@ -69,7 +69,7 @@ define apt::setting (
     ensure  => $ensure,
     owner   => 'root',
     group   => 'root',
-    mode    => '0444',
+    mode    => '0644',
     content => $content,
     source  => $source,
     notify  => $_notify,

--- a/spec/classes/apt_spec.rb
+++ b/spec/classes/apt_spec.rb
@@ -4,14 +4,14 @@ sources_list = {  ensure: 'file',
                   path: '/etc/apt/sources.list',
                   owner: 'root',
                   group: 'root',
-                  mode: '0444',
+                  mode: '0644',
                   notify: 'Class[Apt::Update]' }
 
 sources_list_d = { ensure: 'directory',
                    path: '/etc/apt/sources.list.d',
                    owner: 'root',
                    group: 'root',
-                   mode: '0555',
+                   mode: '0644',
                    purge: false,
                    recurse: false,
                    notify: 'Class[Apt::Update]' }
@@ -20,14 +20,14 @@ preferences = { ensure: 'file',
                 path: '/etc/apt/preferences',
                 owner: 'root',
                 group: 'root',
-                mode: '0444',
+                mode: '0644',
                 notify: 'Class[Apt::Update]' }
 
 preferences_d = { ensure: 'directory',
                   path: '/etc/apt/preferences.d',
                   owner: 'root',
                   group: 'root',
-                  mode: '0555',
+                  mode: '0644',
                   purge: false,
                   recurse: false,
                   notify: 'Class[Apt::Update]' }
@@ -76,7 +76,7 @@ describe 'apt' do
 
     it 'lays down /etc/apt/apt.conf.d/15update-stamp' do
       is_expected.to contain_file('/etc/apt/apt.conf.d/15update-stamp').with(group: 'root',
-                                                                             mode: '0444',
+                                                                             mode: '0644',
                                                                              owner: 'root').with_content(
                                                                                %r{APT::Update::Post-Invoke-Success {"touch /var/lib/apt/periodic/update-success-stamp 2>/dev/null || true";};},
                                                                              )
@@ -301,7 +301,7 @@ machine apt.example.com login aptlogin password supersecret
             is_expected.to contain_file('/etc/apt/auth.conf').with(ensure: 'present',
                                                                    owner: auth_conf_owner,
                                                                    group: 'root',
-                                                                   mode: '0400',
+                                                                   mode: '0600',
                                                                    notify: 'Class[Apt::Update]',
                                                                    content: auth_conf_content)
           }

--- a/spec/defines/conf_spec.rb
+++ b/spec/defines/conf_spec.rb
@@ -35,7 +35,7 @@ describe 'apt::conf', type: :define do
                                                  'content'   => %r{Apt::Install-Recommends 0;\nApt::AutoRemove::InstallRecommends 1;},
                                                  'owner'     => 'root',
                                                  'group'     => 'root',
-                                                 'mode'      => '0444')
+                                                 'mode'      => '0644')
     }
 
     context 'with notify_update = true (default)' do
@@ -83,7 +83,7 @@ describe 'apt::conf', type: :define do
       is_expected.to contain_file(filename).with('ensure' => 'absent',
                                                  'owner'     => 'root',
                                                  'group'     => 'root',
-                                                 'mode'      => '0444')
+                                                 'mode'      => '0644')
     }
   end
 end

--- a/spec/defines/setting_spec.rb
+++ b/spec/defines/setting_spec.rb
@@ -50,7 +50,7 @@ describe 'apt::setting' do
         is_expected.to contain_file('/etc/apt/apt.conf.d/50teddybear').that_notifies('Class[Apt::Update]').with(ensure: 'file',
                                                                                                                 owner: 'root',
                                                                                                                 group: 'root',
-                                                                                                                mode: '0444',
+                                                                                                                mode: '0644',
                                                                                                                 source: params[:source].to_s)
       }
     end
@@ -62,7 +62,7 @@ describe 'apt::setting' do
         is_expected.to contain_file('/etc/apt/apt.conf.d/50teddybear').that_notifies('Class[Apt::Update]').with(ensure: 'file',
                                                                                                                 owner: 'root',
                                                                                                                 group: 'root',
-                                                                                                                mode: '0444',
+                                                                                                                mode: '0644',
                                                                                                                 content: params[:content].to_s)
       }
     end


### PR DESCRIPTION
This reverts commit ab2e06b72f2be8dc38d6e3ecec68dc2cdacbce4e.

These changes are causing the module to cause undesired behaviour according to ticket MODULES-10583.