### PR TITLE
(maint) Update apt custom facts

### DIFF
--- a/lib/facter/apt_updates.rb
+++ b/lib/facter/apt_updates.rb
@@ -26,23 +26,27 @@ def get_updates(upgrade_option)
       end
     end
   end
-
-  setcode do
-    if !apt_updates.nil? && apt_updates.length == 2
-      apt_updates != [[], []]
-    end
-  end
   apt_updates
 end
 
 Facter.add('apt_has_updates') do
   confine osfamily: 'Debian'
-  apt_package_updates = get_updates('upgrade')
+  setcode do
+    apt_package_updates = get_updates('upgrade')
+    if !apt_package_updates.nil? && apt_package_updates.length == 2
+      apt_package_updates != [[], []]
+    end
+  end
 end
 
 Facter.add('apt_has_dist_updates') do
   confine osfamily: 'Debian'
-  apt_dist_updates = get_updates('dist-upgrade')
+  setcode do
+    apt_dist_updates = get_updates('dist-upgrade')
+    if !apt_dist_updates.nil? && apt_dist_updates.length == 2
+      apt_dist_updates != [[], []]
+    end
+  end
 end
 
 Facter.add('apt_package_updates') do


### PR DESCRIPTION
This commit updates apt custom facts because the evaluation
of custom facts code has changed between facter 2 and facter 4.
In facter 2, when a custom fact is loaded, the code in `add` block
was not executed.
In facter 4, when a custom fact is loaded, the code outside `setcode`
block is executed(same as Facter 3).