### PR TITLE
fix apt-mark syntax

### DIFF
--- a/manifests/mark.pp
+++ b/manifests/mark.pp
@@ -13,7 +13,7 @@ define apt::mark (
       $unless_cmd = undef
     }
     default: {
-      $unless_cmd = "/usr/bin/apt-mark showm${setting} ${title} | /bin/fgrep -qs ${title}"
+      $unless_cmd = "/usr/bin/apt-mark show${setting} ${title} | /bin/fgrep -qs ${title}"
     }
   }
   exec { "/usr/bin/apt-mark ${setting} ${title}":


### PR DESCRIPTION
apt-mark supports the following syntax:

 * showauto
 * showmanual
 * showhold

Signed-off-by: Vadim Chernyshev <tryfunc@gmail.com>