### PR TITLE
patch-acng-ssl-support

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -54,11 +54,12 @@ class apt::params {
   }
 
   $proxy_defaults = {
-    'ensure' => undef,
-    'host'   => undef,
-    'port'   => 8080,
-    'https'  => false,
-    'direct' => false,
+    'ensure'     => undef,
+    'host'       => undef,
+    'port'       => 8080,
+    'https'      => false,
+    'https_acng' => false,
+    'direct'     => false,
   }
 
   $purge_defaults = {

--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -86,9 +86,15 @@ define apt::source(
     if ! $location {
       fail(translate('cannot create a source entry without specifying a location'))
     }
+    elsif ($::apt::proxy['https_acng']) and ($location =~ /(?i:^https:\/\/)/) {
+      $_location = regsubst($location, 'https://','http://HTTPS///')
+    }
+    else {
+      $_location = $location
+    }
     # Newer oses, do not need the package for HTTPS transport.
     $_transport_https_releases = [ 'wheezy', 'jessie', 'stretch', 'trusty', 'xenial' ]
-    if ($facts['lsbdistcodename'] in $_transport_https_releases) and $location =~ /(?i:^https:\/\/)/ {
+    if ($facts['lsbdistcodename'] in $_transport_https_releases) and $_location =~ /(?i:^https:\/\/)/ {
       ensure_packages('apt-transport-https')
     }
   }
@@ -113,7 +119,7 @@ define apt::source(
     'includes'         => $includes,
     'opt_architecture' => $architecture,
     'allow_unsigned'   => $allow_unsigned,
-    'location'         => $location,
+    'location'         => $_location,
     'release'          => $_release,
     'repos'            => $repos,
   })

--- a/types/proxy.pp
+++ b/types/proxy.pp
@@ -17,10 +17,11 @@
 #
 type Apt::Proxy = Struct[
   {
-    ensure => Optional[Enum['file', 'present', 'absent']],
-    host   => Optional[String],
-    port   => Optional[Integer[0, 65535]],
-    https  => Optional[Boolean],
-    direct => Optional[Boolean],
+    ensure     => Optional[Enum['file', 'present', 'absent']],
+    host       => Optional[String],
+    port       => Optional[Integer[0, 65535]],
+    https      => Optional[Boolean],
+    https_acng => Optional[Boolean],
+    direct     => Optional[Boolean],
   }
 ]


### PR DESCRIPTION
Support for https repositories via caching proxy apt-cacher-ng using the "tell-me-what-you-need" method as described in the documentation:
- https://www.unix-ag.uni-kl.de/~bloch/acng/html/howtos.html#ssluse