### PR TITLE
pdksync - (IAC-973) - Update travis/appveyor to run on new default branch main

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,7 +84,7 @@ jobs:
       stage: spec
 branches:
   only:
-    - master
+    - main
     - /^v\d/
     - release
 notifications:


### PR DESCRIPTION
(IAC-973) - Update travis/appveyor to run on new default branch main
pdk version: `1.17.0` 
