### PR TITLE
(MODULES-10804) option to force purge source.lists file

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,28 +8,29 @@ class apt::params {
     fail(translate('This module only works on Debian or derivatives like Ubuntu'))
   }
 
-  $root           = '/etc/apt'
-  $provider       = '/usr/bin/apt-get'
-  $sources_list   = "${root}/sources.list"
-  $sources_list_d = "${root}/sources.list.d"
-  $trusted_gpg_d  = "${root}/trusted.gpg.d"
-  $conf_d         = "${root}/apt.conf.d"
-  $preferences    = "${root}/preferences"
-  $preferences_d  = "${root}/preferences.d"
-  $apt_conf_d     = "${root}/apt.conf.d"
-  $keyserver      = 'keyserver.ubuntu.com'
-  $key_options    = undef
-  $confs          = {}
-  $update         = {}
-  $purge          = {}
-  $proxy          = {}
-  $sources        = {}
-  $keys           = {}
-  $ppas           = {}
-  $pins           = {}
-  $settings       = {}
-  $manage_auth_conf = true
-  $auth_conf_entries = []
+  $root                 = '/etc/apt'
+  $provider             = '/usr/bin/apt-get'
+  $sources_list         = "${root}/sources.list"
+  $sources_list_force   = false
+  $sources_list_d       = "${root}/sources.list.d"
+  $trusted_gpg_d        = "${root}/trusted.gpg.d"
+  $conf_d               = "${root}/apt.conf.d"
+  $preferences          = "${root}/preferences"
+  $preferences_d        = "${root}/preferences.d"
+  $apt_conf_d           = "${root}/apt.conf.d"
+  $keyserver            = 'keyserver.ubuntu.com'
+  $key_options          = undef
+  $confs                = {}
+  $update               = {}
+  $purge                = {}
+  $proxy                = {}
+  $sources              = {}
+  $keys                 = {}
+  $ppas                 = {}
+  $pins                 = {}
+  $settings             = {}
+  $manage_auth_conf     = true
+  $auth_conf_entries    = []
 
   $config_files = {
     'conf'   => {

--- a/spec/classes/apt_spec.rb
+++ b/spec/classes/apt_spec.rb
@@ -200,6 +200,74 @@ describe 'apt' do
     }
   end
 
+  context 'with lots of non-defaults' do
+    let :params do
+      {
+        update: { 'frequency' => 'always', 'timeout' => 1, 'tries' => 3 },
+        purge: { 'sources.list' => true, 'sources.list.d' => true,
+                 'preferences' => true, 'preferences.d' => true,
+                 'apt.conf.d' => true },
+      }
+    end
+
+    it {
+      is_expected.to contain_file('sources.list').with(content: "# Repos managed by puppet.\n")
+    }
+
+    it {
+      is_expected.to contain_file('sources.list.d').with(purge: true,
+                                                         recurse: true)
+    }
+
+    it {
+      is_expected.to contain_file('preferences').with(ensure: 'absent')
+    }
+
+    it {
+      is_expected.to contain_file('preferences.d').with(purge: true,
+                                                        recurse: true)
+    }
+
+    it {
+      is_expected.to contain_file('apt.conf.d').with(purge: true,
+                                                     recurse: true)
+    }
+
+    it {
+      is_expected.to contain_exec('apt_update').with(refreshonly: false,
+                                                     timeout: 1,
+                                                     tries: 3)
+    }
+  end
+
+  context 'with defaults for sources_list_force' do
+    let :params do
+      {
+        update: { 'frequency' => 'always', 'timeout' => 1, 'tries' => 3 },
+        purge: { 'sources.list' => true },
+        sources_list_force: false,
+      }
+    end
+
+    it {
+      is_expected.to contain_file('sources.list').with(content: "# Repos managed by puppet.\n")
+    }
+  end
+
+  context 'with non defaults for sources_list_force' do
+    let :params do
+      {
+        update: { 'frequency' => 'always', 'timeout' => 1, 'tries' => 3 },
+        purge: { 'sources.list' => true },
+        sources_list_force: true,
+      }
+    end
+
+    it {
+      is_expected.to contain_file('sources.list').with(ensure: 'absent')
+    }
+  end
+
   context 'with entries for /etc/apt/auth.conf' do
     facts_hash = {
       'Ubuntu 14.04' => {

--- a/spec/unit/facter/apt_dist_has_updates_spec.rb
+++ b/spec/unit/facter/apt_dist_has_updates_spec.rb
@@ -7,6 +7,8 @@ describe 'apt_has_dist_updates fact' do
 
   describe 'on non-Debian distro' do
     before(:each) do
+      # Adding temporary workaround for this ticket https://tickets.puppetlabs.com/browse/IAC-1143
+      Facter.clear
       allow(Facter.fact(:osfamily)).to receive(:value).once.and_return('Redhat')
     end
     it { is_expected.to be_nil }


### PR DESCRIPTION
Request for a review
This PR addressed the ticket https://tickets.puppetlabs.com/browse/MODULES-10804
Added changes for both behaviour by adding new parameter `sources_list_force`  for force purge.By default its set to false.
Added unit tests to verify the changes.
As of now the unit tests are failing on apt module on main branch, A ticket is opened for the failures. https://tickets.puppetlabs.com/browse/IAC-1143
Added temporary workaround as mentioned in the above ticket.
Submitting the changes for review since the unit tests failures are not from this PR.
Attaching the release check from both puppet agent 5 and puppet agent 6
![Screenshot 2020-09-11 at 10 50 18](https://user-images.githubusercontent.com/20660680/93083762-fedc6d80-f68a-11ea-82a2-7ed1240b8b37.png)
![Screenshot 2020-09-11 at 11 24 38](https://user-images.githubusercontent.com/20660680/93083773-01d75e00-f68b-11ea-8dd1-624b1cddc831.png)
