### PR TITLE
Make auth.conf contents Sensitive

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -329,7 +329,7 @@ class apt (
       owner   => $auth_conf_owner,
       group   => 'root',
       mode    => '0600',
-      content => "${confheadertmp}${auth_conf_tmp}",
+      content => Sensitive("${confheadertmp}${auth_conf_tmp}"),
       notify  => Class['apt::update'],
     }
   }

--- a/spec/classes/apt_spec.rb
+++ b/spec/classes/apt_spec.rb
@@ -365,7 +365,7 @@ machine apt.example.com login aptlogin password supersecret
                                                                    group: 'root',
                                                                    mode: '0600',
                                                                    notify: 'Class[Apt::Update]',
-                                                                   content: auth_conf_content)
+                                                                   content: sensitive(auth_conf_content))
           }
         end
 


### PR DESCRIPTION
This wraps the contents of the `/etc/apt/auth.conf` File resource as Sensitive so any credentials in that file are not exposed during report submissions or logged.

With this small update, changing anything in the apt::auth_conf_entries parameter just looks like this instead of exposing credentials:

```
Notice: /Stage[apt]/Apt/File[/etc/apt/auth.conf]/content: [diff redacted]
Info: Computing checksum on file /etc/apt/auth.conf
Info: /Stage[apt]/Apt/File[/etc/apt/auth.conf]: Filebucketed /etc/apt/auth.conf to puppet with sum 3d54e011cdf7ed574c9af84375a27093
Notice: /Stage[apt]/Apt/File[/etc/apt/auth.conf]/content: changed [redacted] to [redacted]
Info: /Stage[apt]/Apt/File[/etc/apt/auth.conf]: Scheduling refresh of Class[Apt::Update]
Info: Class[Apt::Update]: Scheduling refresh of Exec[apt_update]
Notice: /Stage[apt]/Apt::Update/Exec[apt_update]: Triggered 'refresh' from 1 event
```