### PR TITLE
backports.pp: correct example

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -350,10 +350,10 @@ Manages backports.
 
 #### Examples
 
-##### Set up a backport for linuxmint qiana
+##### Set up a backport source for Linux Mint qiana
 
 ```puppet
-apt::backports { 'qiana':
+class { 'apt::backports':
   location => 'http://us.archive.ubuntu.com/ubuntu',
   release  => 'trusty-backports',
   repos    => 'main universe multiverse restricted',

--- a/manifests/backports.pp
+++ b/manifests/backports.pp
@@ -1,7 +1,7 @@
 # @summary Manages backports.
 #
-# @example Set up a backport for linuxmint qiana
-#   apt::backports { 'qiana':
+# @example Set up a backport source for Linux Mint qiana
+#   class { 'apt::backports':
 #     location => 'http://us.archive.ubuntu.com/ubuntu',
 #     release  => 'trusty-backports',
 #     repos    => 'main universe multiverse restricted',


### PR DESCRIPTION
The example treated this like a defined type, but it's a class.