### PR TITLE
Fix typo in weak_ssl documentation

### DIFF
--- a/lib/puppet/type/apt_key.rb
+++ b/lib/puppet/type/apt_key.rb
@@ -83,7 +83,7 @@ Puppet::Type.newtype(:apt_key) do
   end
 
   newparam(:weak_ssl, boolean: true, parent: Puppet::Parameter::Boolean) do
-    desc 'When true and source uses https, accepts download of keys without SSL verfication'
+    desc 'When true and source uses https, accepts download of keys without SSL verification'
     defaultto false
   end
 


### PR DESCRIPTION
`verification` instead of `verfication`.