### PR TITLE
MODULES-10956 remove redundant code in provider apt_key

### DIFF
--- a/lib/puppet/provider/apt_key/apt_key.rb
+++ b/lib/puppet/provider/apt_key/apt_key.rb
@@ -177,29 +177,7 @@ Puppet::Type.type(:apt_key).provide(:apt_key) do
     file
   end
 
-  # Update a key if it is expired
-  def update_expired_key
-    # Return without doing anything if refresh or expired is false
-    return unless resource[:refresh] == true && resource[:expired] == true
-
-    # Execute command to update key
-    command = []
-
-    unless resource[:source].nil? && resource[:content].nil?
-      raise(_('an unexpected condition occurred while trying to add the key: %{_resource}') % { _resource: resource[:id] })
-    end
-
-    # Breaking up the command like this is needed because it blows up
-    # if --recv-keys isn't the last argument.
-    command.push('adv', '--no-tty', '--keyserver', resource[:server])
-    unless resource[:options].nil?
-      command.push('--keyserver-options', resource[:options])
-    end
-    command.push('--recv-keys', resource[:id])
-  end
-
   def exists?
-    update_expired_key
     # report expired keys as non-existing when refresh => true
     @property_hash[:ensure] == :present && !(resource[:refresh] && @property_hash[:expired])
   end


### PR DESCRIPTION
The code in function `update_expired_key` is redundant to the logic in
the function `create`. The call to function `exist` will mark the key as
absent, in case it has expired and refres is set to true.

I debugged for hours why my keys weren't updated until I realized, that
the functionality is elsewhere.