### PR TITLE
(MODULES-10971) - Ensure `apt::keyserver` is considered when creating a default apt:source

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -153,8 +153,15 @@ class apt (
   String $preferences_d         = $apt::params::preferences_d,
   String $apt_conf_d            = $apt::params::apt_conf_d,
   Hash $config_files            = $apt::params::config_files,
-  Hash $source_key_defaults     = $apt::params::source_key_defaults,
   Boolean $sources_list_force   = $apt::params::sources_list_force,
+
+  Hash $source_key_defaults = {
+    'server'  => $keyserver,
+    'options' => undef,
+    'content' => undef,
+    'source'  => undef,
+  }
+
 ) inherits apt::params {
 
   if $facts['os']['family'] != 'Debian' {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -71,13 +71,6 @@ class apt::params {
     'apt.conf.d'     => false,
   }
 
-  $source_key_defaults = {
-    'server'  => $keyserver,
-    'options' => undef,
-    'content' => undef,
-    'source'  => undef,
-  }
-
   $include_defaults = {
     'deb' => true,
     'src' => false,


### PR DESCRIPTION
As it stands the source_key_defaults point towards the default `keyserver` value set within the params. This change makes it so that it will instead use the `keyserver` value set in the init, which will in turn default to the params value if none has been given.