### PR TITLE
(IAC-1597) Increasing MAX_RETRY_COUNT

### DIFF
--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 UNSUPPORTED_PLATFORMS = ['RedHat', 'Suse', 'windows', 'AIX', 'Solaris'].freeze
-MAX_RETRY_COUNT       = 5
 RETRY_WAIT            = 3
 ERROR_MATCHER         = %r{(no valid OpenPGP data found|keyserver timed out|keyserver receive failed)}.freeze
+MAX_RETRY_COUNT       = 10
 
 RSpec.configure do |c|
   c.before :suite do


### PR DESCRIPTION
Currently CI runs are seeing transient failures in testing on Ubuntu18 as the keyserver is not installed yet. This issue is consistent and this week has been seen on 2/5 nightlies. Bumping the MAx_RETRIES for Ubuntu18 to 10 to see if this resolves the issue. 

This issue will be resolved when there are 5 nightly runs consecutively passing without the error being thrown.

Extended change to all OS as the same issue was seen on Debian 9.