### PR TITLE
Replace sks-keyservers.net as is deprecated

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -397,7 +397,7 @@ class { 'apt::backports':
   repos    => 'main universe multiverse restricted',
   key      => {
     id     => '630239CC130E1A7FD81A27B140976EAF437D05B5',
-    server => 'hkps.pool.sks-keyservers.net',
+    server => 'keyserver.ubuntu.com',
   },
 }
 ```
@@ -541,7 +541,7 @@ Manages the GPG keys that Apt uses to authenticate packages.
 ```puppet
 apt::key { 'puppetlabs':
   id      => '6F6B15509CF8E59E6E469F327F438280EF8D349F',
-  server  => 'hkps.pool.sks-keyservers.net',
+  server  => 'keyserver.ubuntu.com',
   options => 'http-proxy="http://proxyuser:proxypass@example.org:3128"',
 }
 ```
@@ -914,7 +914,7 @@ apt::source { 'puppetlabs':
   repos    => 'main',
   key      => {
     id     => '6F6B15509CF8E59E6E469F327F438280EF8D349F',
-    server => 'hkps.pool.sks-keyservers.net',
+    server => 'keyserver.ubuntu.com',
   },
 }
 ```

--- a/examples/backports.pp
+++ b/examples/backports.pp
@@ -6,6 +6,6 @@ class { 'apt::backports':
   repos    => 'main universe multiverse restricted',
   key      => {
     id     => '630239CC130E1A7FD81A27B140976EAF437D05B5',
-    server => 'hkps.pool.sks-keyservers.net',
+    server => 'keyserver.ubuntu.com',
   },
 }

--- a/examples/key.pp
+++ b/examples/key.pp
@@ -1,6 +1,6 @@
 # Declare Apt key for apt.puppetlabs.com source
 apt::key { 'puppetlabs':
   id      => 'D6811ED3ADEEB8441AF5AA8F4528B6CD9E61EF26',
-  server  => 'hkps.pool.sks-keyservers.net',
+  server  => 'keyserver.ubuntu.com',
   options => 'http-proxy="http://proxyuser:proxypass@example.org:3128"',
 }

--- a/examples/source.pp
+++ b/examples/source.pp
@@ -8,7 +8,7 @@ apt::source { 'puppetlabs':
   repos    => 'main',
   key      => {
     id     => '6F6B15509CF8E59E6E469F327F438280EF8D349F',
-    server => 'hkps.pool.sks-keyservers.net',
+    server => 'keyserver.ubuntu.com',
   },
 }
 
@@ -19,7 +19,7 @@ apt::source { 'debian_testing':
   repos    => 'main contrib non-free',
   key      => {
     id     => 'A1BD8E9D78F7FE5C3E65D8AF8B48AD6246925553',
-    server => 'hkps.pool.sks-keyservers.net',
+    server => 'keyserver.ubuntu.com',
   },
   pin      => '-10',
 }
@@ -29,7 +29,7 @@ apt::source { 'debian_unstable':
   repos    => 'main contrib non-free',
   key      => {
     id     => 'A1BD8E9D78F7FE5C3E65D8AF8B48AD6246925553',
-    server => 'hkps.pool.sks-keyservers.net',
+    server => 'keyserver.ubuntu.com',
   },
   pin      => '-10',
 }

--- a/manifests/backports.pp
+++ b/manifests/backports.pp
@@ -7,7 +7,7 @@
 #     repos    => 'main universe multiverse restricted',
 #     key      => {
 #       id     => '630239CC130E1A7FD81A27B140976EAF437D05B5',
-#       server => 'hkps.pool.sks-keyservers.net',
+#       server => 'keyserver.ubuntu.com',
 #     },
 #   }
 #

--- a/manifests/key.pp
+++ b/manifests/key.pp
@@ -6,7 +6,7 @@
 # @example Declare Apt key for apt.puppetlabs.com source
 #   apt::key { 'puppetlabs':
 #     id      => '6F6B15509CF8E59E6E469F327F438280EF8D349F',
-#     server  => 'hkps.pool.sks-keyservers.net',
+#     server  => 'keyserver.ubuntu.com',
 #     options => 'http-proxy="http://proxyuser:proxypass@example.org:3128"',
 #   }
 #

--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -6,7 +6,7 @@
 #     repos    => 'main',
 #     key      => {
 #       id     => '6F6B15509CF8E59E6E469F327F438280EF8D349F',
-#       server => 'hkps.pool.sks-keyservers.net',
+#       server => 'keyserver.ubuntu.com',
 #     },
 #   }
 #

--- a/spec/acceptance/apt_spec.rb
+++ b/spec/acceptance/apt_spec.rb
@@ -10,7 +10,7 @@ everything_everything_pp = <<-MANIFEST
           'repos'    => 'main',
           'key'      => {
             'id'     => '6F6B15509CF8E59E6E469F327F438280EF8D349F',
-            'server' => 'pool.sks-keyservers.net',
+            'server' => 'keyserver.ubuntu.com',
           },
         },
       }


### PR DESCRIPTION
sks-keyservers.net is deprecated. This means it is no longer maintained, and new HKPS certificates will not be issued. 
See: https://sks-keyservers.net/status/