### PR TITLE
[MODULES-9695] - Add support for signed-by in source entries

### DIFF
--- a/spec/defines/source_spec.rb
+++ b/spec/defines/source_spec.rb
@@ -154,6 +154,38 @@ describe 'apt::source' do
     }
   end
 
+  context 'with keyring set' do
+    let :params do
+      {
+        location: 'hello.there',
+        keyring: '/usr/share/keyrings/foo-archive-keyring.gpg',
+      }
+    end
+
+    it {
+      is_expected.to contain_apt__setting('list-my_source')
+        .with(ensure: 'present')
+        .with_content(%r{# my_source\ndeb \[signed-by=/usr/share/keyrings/foo-archive-keyring.gpg\] hello.there jessie main\n})
+    }
+  end
+
+  context 'with keyring, architecture and allow_unsigned set' do
+    let :params do
+      {
+        location: 'hello.there',
+        architecture: 'amd64',
+        allow_unsigned: true,
+        keyring: '/usr/share/keyrings/foo-archive-keyring.gpg',
+      }
+    end
+
+    it {
+      is_expected.to contain_apt__setting('list-my_source')
+        .with(ensure: 'present')
+        .with_content(%r{# my_source\ndeb \[arch=amd64 trusted=yes signed-by=/usr/share/keyrings/foo-archive-keyring.gpg\] hello.there jessie main\n})
+    }
+  end
+
   context 'with a https location, install apt-transport-https' do
     let :params do
       {

--- a/templates/source.list.epp
+++ b/templates/source.list.epp
@@ -1,10 +1,8 @@
-<%- | String $comment, Hash $includes, $opt_architecture, Boolean $allow_unsigned, $location, $release, String $repos | -%>
+<%- | String $comment, Hash $includes, Hash $options, $location, $release, String $repos | -%>
 # <%= $comment %>
 <%- if $includes['deb'] { -%>
-deb <%- if ($opt_architecture or $allow_unsigned) {-%>
- [<%- if ($opt_architecture) {%>arch=<%= $opt_architecture %><% } %><%if ($opt_architecture and $allow_unsigned) {%> <% }%><% if ($allow_unsigned) {%>trusted=yes<% } %>] <%- } %> <%= $location %> <%= $release %> <%= $repos %>
+deb <% if !$options.empty() { -%>[<%=  $options.map |$key, $value| { "${key}=${value}" }.join(" ") %>] <% } -%> <%= $location %> <%= $release %> <%= $repos %>
 <%- } -%>
 <%- if $includes['src'] { -%>
-deb-src <%- if $opt_architecture or $allow_unsigned { -%>
- [<%- if ($opt_architecture) {%>arch=<%= $opt_architecture %><% } %><%if ($opt_architecture and $allow_unsigned) {%> <% }%><% if ($allow_unsigned) {%>trusted=yes<% } %>] <%- } %> <%= $location %> <%= $release %> <%= $repos %>
+deb-src <% if !$options.empty() { -%>[<%=  $options.map |$key, $value| { "${key}=${value}" }.join(" ") %>] <% } -%> <%= $location %> <%= $release %> <%= $repos %>
 <%- } -%>


### PR DESCRIPTION
This is a first step toward fixing [MODULES-9695](https://tickets.puppetlabs.com/browse/MODULES-9695).

I refactored the option list as an hash, as per [Antoine’s comment](https://tickets.puppetlabs.com/browse/MODULES-9695?focusedCommentId=719431&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-719431).