### PR TITLE
apt::source: pass the weak_ssl param to apt::key

### DIFF
--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -36,8 +36,8 @@
 #
 # @param key
 #   Creates a declaration of the apt::key defined type. Valid options: a string to be passed to the `id` parameter of the `apt::key`
-#   defined type, or a hash of `parameter => value` pairs to be passed to `apt::key`'s `id`, `server`, `content`, `source`, and/or
-#   `options` parameters.
+#   defined type, or a hash of `parameter => value` pairs to be passed to `apt::key`'s `id`, `server`, `content`, `source`, `weak_ssl`,
+#   and/or `options` parameters.
 #
 # @param pin
 #   Creates a declaration of the apt::pin defined type. Valid options: a number or string to be passed to the `id` parameter of the
@@ -160,13 +160,14 @@ define apt::source(
       }
 
       apt::key { "Add key: ${$_key['id']} from Apt::Source ${title}":
-        ensure  => $_ensure,
-        id      => $_key['id'],
-        server  => $_key['server'],
-        content => $_key['content'],
-        source  => $_key['source'],
-        options => $_key['options'],
-        before  => $_before,
+        ensure   => $_ensure,
+        id       => $_key['id'],
+        server   => $_key['server'],
+        content  => $_key['content'],
+        source   => $_key['source'],
+        options  => $_key['options'],
+        weak_ssl => $_key['weak_ssl'],
+        before   => $_before,
       }
     }
   }

--- a/spec/defines/source_spec.rb
+++ b/spec/defines/source_spec.rb
@@ -109,11 +109,14 @@ describe 'apt::source' do
           location: 'http://debian.mirror.iweb.ca/debian/',
           release: 'sid',
           repos: 'testing',
-          key: { 'ensure' => 'refreshed',
-                 'id' => GPG_KEY_ID,
-                 'server' => 'pgp.mit.edu',
-                 'content' => 'GPG key content',
-                 'source'  => 'http://apt.puppetlabs.com/pubkey.gpg' },
+          key: {
+            'ensure' => 'refreshed',
+            'id' => GPG_KEY_ID,
+            'server' => 'pgp.mit.edu',
+            'content' => 'GPG key content',
+            'source'  => 'http://apt.puppetlabs.com/pubkey.gpg',
+            'weak_ssl' => true,
+          },
           pin: '10',
           architecture: 'x86_64',
           allow_unsigned: true,
@@ -136,7 +139,8 @@ describe 'apt::source' do
                                                                                                                                                     id: GPG_KEY_ID,
                                                                                                                                                     server: 'pgp.mit.edu',
                                                                                                                                                     content: 'GPG key content',
-                                                                                                                                                    source: 'http://apt.puppetlabs.com/pubkey.gpg')
+                                                                                                                                                    source: 'http://apt.puppetlabs.com/pubkey.gpg',
+                                                                                                                                                    weak_ssl: true)
       }
     end
   end


### PR DESCRIPTION
If you're creating `apt::source` resources with hiera, without this commit, there's no way to pass the `weak_ssl` parameter to the `apt::key` resource.

Also added `weak_ssl` to a test.