### PR TITLE
(maint) Set DEBIAN_FRONTEND=noninteractive on upgrade

### DIFF
--- a/tasks/init.rb
+++ b/tasks/init.rb
@@ -8,6 +8,7 @@ require 'puppet'
 def apt_get(action)
   cmd = ['apt-get', action]
   cmd << '-y' if ['upgrade', 'dist-upgrade', 'autoremove'].include?(action)
+  ENV['DEBIAN_FRONTEND'] = 'noninteractive' if ['upgrade', 'dist-upgrade'].include?(action)
   stdout, stderr, status = Open3.capture3(*cmd)
   raise Puppet::Error, stderr if status != 0
   { status: stdout.strip }

--- a/tasks/init.rb
+++ b/tasks/init.rb
@@ -8,7 +8,13 @@ require 'puppet'
 def apt_get(action)
   cmd = ['apt-get', action]
   cmd << '-y' if ['upgrade', 'dist-upgrade', 'autoremove'].include?(action)
-  ENV['DEBIAN_FRONTEND'] = 'noninteractive' if ['upgrade', 'dist-upgrade'].include?(action)
+  if ['upgrade', 'dist-upgrade'].include?(action)
+    ENV['DEBIAN_FRONTEND'] = 'noninteractive'
+    cmd << '-o'
+    cmd << 'Dpkg::Options="--force-confdef"'
+    cmd << '-o'
+    cmd << 'Dpkg::Options="--force-confold"'
+  end
   stdout, stderr, status = Open3.capture3(*cmd)
   raise Puppet::Error, stderr if status != 0
   { status: stdout.strip }


### PR DESCRIPTION
When upgrading Debian packages, the system sometimes what to prompt the user about what action to perform.  Since a tasks is supposed to be non-interactive, we should disable such prompts.

This help when updating some packages, e.g. postfix.
