### PR TITLE
(main) Allow stdlib 8.0.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.16.0 < 8.0.0"
+      "version_requirement": ">= 4.16.0 < 9.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
We recently released stdlib 8.0.0.  This module is comptatible with this version of stdlib.
