### PR TITLE
(maint) Add support for Debian 11

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -19,7 +19,8 @@
       "operatingsystemrelease": [
         "8",
         "9",
-        "10"
+        "10",
+        "11"
       ]
     },
     {


### PR DESCRIPTION
Debian 11 was recently released.  Update metadata.json to indicate that this version is supported by the module.
