### PR TITLE
(MODULES-11173) Add per-host overrides for apt::proxy

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -41,6 +41,7 @@ be manipulated through the `apt-key` command.
 
 * [`Apt::Auth_conf_entry`](#aptauth_conf_entry): Login configuration settings that are recorded in the file `/etc/apt/auth.conf`.
 * [`Apt::Proxy`](#aptproxy): Configures Apt to connect to a proxy server.
+* [`Apt::Proxy_Per_Host`](#aptproxy_per_host): Adds per-host overrides to the system default APT proxy configuration
 
 ### Tasks
 
@@ -1099,6 +1100,7 @@ Struct[{
     https      => Optional[Boolean],
     https_acng => Optional[Boolean],
     direct     => Optional[Boolean],
+    perhost    => Optional[Array[Apt::Proxy_Per_Host]],
   }]
 ```
 
@@ -1131,6 +1133,52 @@ Specifies whether to enable https proxies.
 ##### <a name="direct"></a>`direct`
 
 Specifies whether or not to use a `DIRECT` https proxy if http proxy is used but https is not.
+
+### <a name="aptproxy_per_host"></a>`Apt::Proxy_Per_Host`
+
+Adds per-host overrides to the system default APT proxy configuration
+
+Alias of
+
+```puppet
+Struct[{
+    scope      => String,
+    host       => Optional[String],
+    port       => Optional[Integer[1, 65535]],
+    https      => Optional[Boolean],
+    direct     => Optional[Boolean],
+  }]
+```
+
+#### Parameters
+
+The following parameters are available in the `Apt::Proxy_Per_Host` data type:
+
+* [`scope`](#scope)
+* [`host`](#host)
+* [`port`](#port)
+* [`https`](#https)
+* [`direct`](#direct)
+
+##### <a name="scope"></a>`scope`
+
+Specifies the scope of the override.  Valid options: a string containing a hostname.
+
+##### <a name="host"></a>`host`
+
+Specifies a proxy host to be stored in `/etc/apt/apt.conf.d/01proxy`. Valid options: a string containing a hostname.
+
+##### <a name="port"></a>`port`
+
+Specifies a proxy port to be stored in `/etc/apt/apt.conf.d/01proxy`. Valid options: an integer containing a port number.
+
+##### <a name="https"></a>`https`
+
+Specifies whether to enable https for this override.
+
+##### <a name="direct"></a>`direct`
+
+Specifies whether or not to use a `DIRECT` target to bypass the system default proxy.
 
 ## Tasks
 

--- a/spec/classes/apt_spec.rb
+++ b/spec/classes/apt_spec.rb
@@ -101,7 +101,69 @@ describe 'apt' do
         is_expected.to contain_apt__setting('conf-proxy').with(priority: '01').with_content(
           %r{Acquire::http::proxy "http://localhost:8080/";},
         ).without_content(
-          %r{Acquire::https::proxy},
+          %r{Acquire::https::proxy },
+        )
+      }
+    end
+
+    context 'when host=localhost and per-host[proxyscope]=proxyhost' do
+      let(:params) { { proxy: { 'host' => 'localhost', 'perhost' => [{ 'scope' => 'proxyscope', 'host' => 'proxyhost' }] } } }
+
+      it {
+        is_expected.to contain_apt__setting('conf-proxy').with(priority: '01').with_content(
+          %r{Acquire::http::proxy::proxyscope "http://proxyhost:8080/";},
+        )
+      }
+    end
+
+    context 'when host=localhost and per-host[proxyscope]=proxyhost:8081' do
+      let(:params) { { proxy: { 'host' => 'localhost', 'perhost' => [{ 'scope' => 'proxyscope', 'host' => 'proxyhost', 'port' => 8081 }] } } }
+
+      it {
+        is_expected.to contain_apt__setting('conf-proxy').with(priority: '01').with_content(
+          %r{Acquire::http::proxy::proxyscope "http://proxyhost:8081/";},
+        )
+      }
+    end
+
+    context 'when host=localhost and per-host[proxyscope]=[https]proxyhost' do
+      let(:params) { { proxy: { 'host' => 'localhost', 'perhost' => [{ 'scope' => 'proxyscope', 'host' => 'proxyhost', 'https' => true }] } } }
+
+      it {
+        is_expected.to contain_apt__setting('conf-proxy').with(priority: '01').with_content(
+          %r{Acquire::https::proxy::proxyscope "https://proxyhost:8080/";},
+        )
+      }
+    end
+
+    context 'when host=localhost and per-host[proxyscope]=[direct]' do
+      let(:params) { { proxy: { 'host' => 'localhost', 'perhost' => [{ 'scope' => 'proxyscope', 'direct' => true }] } } }
+
+      it {
+        is_expected.to contain_apt__setting('conf-proxy').with(priority: '01').with_content(
+          %r{Acquire::http::proxy::proxyscope "DIRECT";},
+        )
+      }
+    end
+
+    context 'when host=localhost and per-host[proxyscope]=[https][direct]' do
+      let(:params) { { proxy: { 'host' => 'localhost', 'perhost' => [{ 'scope' => 'proxyscope', 'https' => true, 'direct' => true }] } } }
+
+      it {
+        is_expected.to contain_apt__setting('conf-proxy').with(priority: '01').with_content(
+          %r{Acquire::https::proxy::proxyscope "DIRECT";},
+        )
+      }
+    end
+
+    context 'when host=localhost and per-host[proxyscope]=proxyhost and per-host[proxyscope2]=proxyhost2' do
+      let(:params) { { proxy: { 'host' => 'localhost', 'perhost' => [{ 'scope' => 'proxyscope', 'host' => 'proxyhost' }, { 'scope' => 'proxyscope2', 'host' => 'proxyhost2' }] } } }
+
+      it {
+        is_expected.to contain_apt__setting('conf-proxy').with(priority: '01').with_content(
+          %r{Acquire::http::proxy::proxyscope "http://proxyhost:8080/";},
+        ).with_content(
+          %r{Acquire::http::proxy::proxyscope2 "http://proxyhost2:8080/";},
         )
       }
     end
@@ -113,7 +175,7 @@ describe 'apt' do
         is_expected.to contain_apt__setting('conf-proxy').with(priority: '01').with_content(
           %r{Acquire::http::proxy "http://localhost:8180/";},
         ).without_content(
-          %r{Acquire::https::proxy},
+          %r{Acquire::https::proxy },
         )
       }
     end

--- a/templates/proxy.epp
+++ b/templates/proxy.epp
@@ -1,4 +1,7 @@
 <%- | Hash $proxies | -%>
+<% $proxies['perhost'].each |$proxy| { -%>
+Acquire::<%= $proxy['scheme'] %>::proxy::<%= $proxy['scope'] %> "<%= $proxy['target'] %>";
+<% } -%>
 Acquire::http::proxy "http://<%= $proxies['host'] %>:<%= $proxies['port'] %>/";
 <%- if $proxies['https'] { %>
 Acquire::https::proxy "https://<%= $proxies['host'] %>:<%= $proxies['port'] %>/";

--- a/types/proxy.pp
+++ b/types/proxy.pp
@@ -23,5 +23,6 @@ type Apt::Proxy = Struct[
     https      => Optional[Boolean],
     https_acng => Optional[Boolean],
     direct     => Optional[Boolean],
+    perhost    => Optional[Array[Apt::Proxy_Per_Host]],
   }
 ]

--- a/types/proxy_per_host.pp
+++ b/types/proxy_per_host.pp
@@ -1,0 +1,26 @@
+# @summary Adds per-host overrides to the system default APT proxy configuration
+#
+# @param scope
+#   Specifies the scope of the override.  Valid options: a string containing a hostname.
+#
+# @param host
+#   Specifies a proxy host to be stored in `/etc/apt/apt.conf.d/01proxy`. Valid options: a string containing a hostname.
+#
+# @param port
+#   Specifies a proxy port to be stored in `/etc/apt/apt.conf.d/01proxy`. Valid options: an integer containing a port number.
+#
+# @param https
+#   Specifies whether to enable https for this override.
+#
+# @param direct
+#   Specifies whether or not to use a `DIRECT` target to bypass the system default proxy.
+#
+type Apt::Proxy_Per_Host = Struct[
+  {
+    scope      => String,
+    host       => Optional[String],
+    port       => Optional[Integer[1, 65535]],
+    https      => Optional[Boolean],
+    direct     => Optional[Boolean],
+  }
+]


### PR DESCRIPTION
Add support for optional apt::proxy::perhost array to configure bypass (DIRECT) or alternative proxy for specific repository hosts.