### PR TITLE
(MODULES-10763) Remove frequency collector

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -267,12 +267,6 @@ class apt (
     default => file,
   }
 
-  if $_update['frequency'] == 'always' {
-    Exec <| title=='apt_update' |> {
-      refreshonly => false,
-    }
-  }
-
   apt::setting { 'conf-update-stamp':
     priority => 15,
     content  => "${confheadertmp}${updatestamptmp}",

--- a/spec/classes/apt_update_spec.rb
+++ b/spec/classes/apt_update_spec.rb
@@ -61,6 +61,36 @@ describe 'apt::update', type: :class do
         is_expected.to contain_exec('apt_update').with('refreshonly' => false)
       end
     end
+    context 'and Exec[apt_update] refreshonly is overridden to true and has recent run' do
+      let(:facts) do
+        {
+          os: {
+            family: 'Debian',
+            name: 'Debian',
+            release: {
+              major: '8',
+              full: '8.0',
+            },
+            distro: {
+              codename: 'jessie',
+              id: 'Debian',
+            },
+          },
+          apt_update_last_success: Time.now.to_i,
+        }
+      end
+      let(:pre_condition) do
+        "
+        class{'::apt': update => {'frequency' => 'always' },}
+        Exec <| title=='apt_update' |> { refreshonly => true }
+        "
+      end
+
+      it 'skips an apt-get update run' do
+        # set the apt_update exec's refreshonly attribute to false
+        is_expected.to contain_exec('apt_update').with('refreshonly' => true)
+      end
+    end
   end
   context "when apt::update['frequency']='reluctantly'" do
     {


### PR DESCRIPTION
The case logic in apt::update adequately covers the 'always' case and
the collector causes issues in acceptance testing.