### PR TITLE
Fixed gpg file for Ubuntu versions 21.04 and later.

### DIFF
--- a/manifests/ppa.pp
+++ b/manifests/ppa.pp
@@ -55,7 +55,8 @@ define apt::ppa(
 
   $sources_list_d_filename  = "${dash_filename_no_specialchars}-${release}.list"
 
-  if versioncmp($facts['os']['release']['full'], '15.10') >= 0 {
+  if versioncmp($facts['os']['release']['full'], '15.10') >= 0 and
+    versioncmp($facts['os']['release']['full'], '21.04') < 0 {
     $trusted_gpg_d_filename = "${underscore_filename_no_specialchars}.gpg"
   } else {
     $trusted_gpg_d_filename = "${dash_filename_no_specialchars}.gpg"


### PR DESCRIPTION
As of Ubuntu 21.04, Canonical has again changed the filename of the gpg files going back to dashes
instead of using underscores.

I have tested this change for Ubuntu 21.04 and 21.10.  I also checked Ubuntu 20.04 just to make sure it didn't break previous versions.