### PR TITLE
Replace `arm64` for `aarch64` in `::apt::source`

### DIFF
--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -125,11 +125,17 @@ define apt::source(
 
   $header = epp('apt/_header.epp')
 
+  if $architecture {
+    $_architecture = regsubst($architecture, '\baarch64\b', 'arm64')
+  } else {
+    $_architecture = undef
+  }
+
   $sourcelist = epp('apt/source.list.epp', {
     'comment'          => $comment,
     'includes'         => $includes,
     'options'          => delete_undef_values({
-      'arch'      => $architecture,
+      'arch'      => $_architecture,
       'trusted'   => $allow_unsigned ? {true => "yes", false => undef},
       'signed-by' => $keyring,
     }),


### PR DESCRIPTION
`arm64` is a rather new player in the server market: AWS Gravitron instances use it, but it is also used when running Linux-based VMs on Apple's new M1 chips.

As [someone explained on StackOverflow](https://stackoverflow.com/a/47274698), the Linux Kernel uses `aarch64` at the name for this architecture, and that's what is reported by Facter.

Apt, however, uses the `arm64` architecture name for this platform. 

This mismatch can cause bugs as in [puppetlabs/docker](https://github.com/puppetlabs/puppetlabs-docker/issues/494), and thus my suggestion is to fix it here in a central location.

I am not familiar with Ruby programming and rspec-based acceptance tests. So, if that's a requirement for getting this merged, any help is greatly appreciated.

