### PR TITLE
Omit empty options in source.list template to fix MODULES-11174

### DIFF
--- a/templates/source.list.epp
+++ b/templates/source.list.epp
@@ -1,8 +1,8 @@
 <%- | String $comment, Hash $includes, Hash $options, $location, $release, String $repos | -%>
 # <%= $comment %>
 <%- if $includes['deb'] { -%>
-deb <% if !$options.empty() { -%>[<%=  $options.map |$key, $value| { "${key}=${value}" }.join(" ") %>] <% } -%> <%= $location %> <%= $release %> <%= $repos %>
+deb <% if !$options.empty() { -%>[<%=  $options.map |$key, $value| { if !$value.empty() { "${key}=${value}" } }.join(" ") %>] <% } -%> <%= $location %> <%= $release %> <%= $repos %>
 <%- } -%>
 <%- if $includes['src'] { -%>
-deb-src <% if !$options.empty() { -%>[<%=  $options.map |$key, $value| { "${key}=${value}" }.join(" ") %>] <% } -%> <%= $location %> <%= $release %> <%= $repos %>
+deb-src <% if !$options.empty() { -%>[<%=  $options.map |$key, $value| { if !$value.empty() { "${key}=${value}" } }.join(" ") %>] <% } -%> <%= $location %> <%= $release %> <%= $repos %>
 <%- } -%>


### PR DESCRIPTION
Empty `[name= ...]` options in a soures list lead to Apt parsing errors.

This change skips such empty options, resolving https://tickets.puppetlabs.com/browse/MODULES-11174.