### PR TITLE
enable allow-insecure for apt::source defined types, includes new tes…

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -935,6 +935,7 @@ The following parameters are available in the `apt::source` defined type:
 * [`pin`](#pin)
 * [`architecture`](#architecture)
 * [`allow_unsigned`](#allow_unsigned)
+* [`allow_insecure`](#allow_insecure)
 * [`notify_update`](#notify_update)
 
 ##### <a name="location"></a>`location`
@@ -1033,6 +1034,16 @@ Default value: ``undef``
 Data type: `Boolean`
 
 Specifies whether to authenticate packages from this release, even if the Release file is not signed or the signature can't be checked.
+
+Default value: ``false``
+
+##### <a name="allow_insecure"></a>`allow_insecure`
+
+Data type: `Boolean`
+
+Specifies whether to authenticate packages from this release, even if the Release file is not signed or the signature can't be checked.
+Unlike the `allow_unsigned` (trusted=yes) option, this should throw a warning that the interaction is insecure.  
+See [this comment](https://unix.stackexchange.com/a/480550) for a brief discussion of the difference and why this option might be preferable to `allow_unsigned`.
 
 Default value: ``false``
 

--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -70,6 +70,7 @@ define apt::source(
   Optional[Variant[Hash, Numeric, String]] $pin = undef,
   Optional[String] $architecture                = undef,
   Boolean $allow_unsigned                       = false,
+  Boolean $allow_insecure                       = false,
   Boolean $notify_update                        = true,
 ) {
 
@@ -129,9 +130,10 @@ define apt::source(
     'comment'          => $comment,
     'includes'         => $includes,
     'options'          => delete_undef_values({
-      'arch'      => $architecture,
-      'trusted'   => $allow_unsigned ? {true => "yes", false => undef},
-      'signed-by' => $keyring,
+      'arch'           => $architecture,
+      'trusted'        => $allow_unsigned ? {true => "yes", false => undef},
+      'allow-insecure' => $allow_insecure ? {true => "yes", false => undef},
+      'signed-by'      => $keyring,
     }),
     'location'         => $_location,
     'release'          => $_release,

--- a/spec/defines/source_compat_spec.rb
+++ b/spec/defines/source_compat_spec.rb
@@ -71,6 +71,18 @@ describe 'apt::source', type: :define do
     }
   end
 
+  context 'when allow_insecure true' do
+    let :params do
+      {
+        'include'        => { 'src' => false },
+        'location'       => 'http://debian.mirror.iweb.ca/debian/',
+        'allow_insecure' => true,
+      }
+    end
+
+    it { is_expected.to contain_apt__setting('list-my_source').with_content(%r{# my_source\ndeb \[allow-insecure=yes\] http://debian.mirror.iweb.ca/debian/ jessie main\n}) }
+  end
+
   context 'when allow_unsigned true' do
     let :params do
       {

--- a/spec/defines/source_spec.rb
+++ b/spec/defines/source_spec.rb
@@ -145,6 +145,19 @@ describe 'apt::source' do
     end
   end
 
+  context 'with allow_insecure true' do
+    let :params do
+      {
+        location: 'hello.there',
+        allow_insecure: true,
+      }
+    end
+
+    it {
+      is_expected.to contain_apt__setting('list-my_source').with(ensure: 'present').with_content(%r{# my_source\ndeb \[allow-insecure=yes\] hello.there jessie main\n})
+    }
+  end
+
   context 'with allow_unsigned true' do
     let :params do
       {


### PR DESCRIPTION
enable allow-insecure for apt::source defined types, includes new tests, documentation