### PR TITLE
(maint) Fix resource ordering when apt-transport-https is needed

### DIFF
--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -102,6 +102,7 @@ define apt::source(
     $_transport_https_releases = [ 'wheezy', 'jessie', 'stretch', 'trusty', 'xenial' ]
     if ($facts['os']['distro']['codename'] in $_transport_https_releases) and $_location =~ /(?i:^https:\/\/)/ {
       ensure_packages('apt-transport-https')
+      Package['apt-transport-https'] -> Class['apt::update']
     }
   } else {
     $_location = undef


### PR DESCRIPTION
On older Debian / Ubuntu releases, the apt-transport-https package is
required to download from an https:// source.  This package dependency
is ensured by ensure_packages() but no ordering is set, possibly
resulting of the resource being applied in a non-working order:

1. Setup a https:// source
2. Trigger apt update (this will fail)
3. Install apt-transport-https

Add a dependency to ensure apt-transport-https is installed when the
repositories are updated.
