### PR TITLE
Use fact() function for all os.distro.* facts

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -432,7 +432,7 @@ Default value: ``undef``
 Data type: `Optional[String]`
 
 Specifies a distribution of the Apt repository containing the backports to manage. Used in populating the `source.list` configuration file.
-Default: on Debian and Ubuntu, `${facts['os']['distro']['codename']}-backports`. We recommend keeping this default, except on other operating
+Default: on Debian and Ubuntu, `${fact('os.distro.codename')}-backports`. We recommend keeping this default, except on other operating
 systems.
 
 Default value: ``undef``
@@ -814,7 +814,7 @@ Data type: `Optional[String]`
 Specifies the operating system of your node. Valid options: a string containing a valid LSB distribution codename.
 Optional if `puppet facts show os.distro.codename` returns your correct distribution release codename.
 
-Default value: `$facts['os']['distro']['codename']`
+Default value: `fact('os.distro.codename')`
 
 ##### <a name="dist"></a>`dist`
 
@@ -935,8 +935,8 @@ The following parameters are available in the `apt::source` defined type:
 * [`pin`](#pin)
 * [`architecture`](#architecture)
 * [`allow_unsigned`](#allow_unsigned)
-* [`allow_insecure`](#allow_insecure)
 * [`notify_update`](#notify_update)
+* [`allow_insecure`](#allow_insecure)
 
 ##### <a name="location"></a>`location`
 
@@ -1037,16 +1037,6 @@ Specifies whether to authenticate packages from this release, even if the Releas
 
 Default value: ``false``
 
-##### <a name="allow_insecure"></a>`allow_insecure`
-
-Data type: `Boolean`
-
-Specifies whether to authenticate packages from this release, even if the Release file is not signed or the signature can't be checked.
-Unlike the `allow_unsigned` (trusted=yes) option, this should throw a warning that the interaction is insecure.  
-See [this comment](https://unix.stackexchange.com/a/480550) for a brief discussion of the difference and why this option might be preferable to `allow_unsigned`.
-
-Default value: ``false``
-
 ##### <a name="notify_update"></a>`notify_update`
 
 Data type: `Boolean`
@@ -1054,6 +1044,14 @@ Data type: `Boolean`
 Specifies whether to trigger an `apt-get update` run.
 
 Default value: ``true``
+
+##### <a name="allow_insecure"></a>`allow_insecure`
+
+Data type: `Boolean`
+
+
+
+Default value: ``false``
 
 ## Resource types
 

--- a/manifests/backports.pp
+++ b/manifests/backports.pp
@@ -21,7 +21,7 @@
 #
 # @param release
 #   Specifies a distribution of the Apt repository containing the backports to manage. Used in populating the `source.list` configuration file.
-#   Default: on Debian and Ubuntu, `${facts['os']['distro']['codename']}-backports`. We recommend keeping this default, except on other operating
+#   Default: on Debian and Ubuntu, `${fact('os.distro.codename')}-backports`. We recommend keeping this default, except on other operating
 #   systems.
 #
 # @param repos
@@ -79,7 +79,11 @@ class apt::backports (
     $_location = $::apt::backports['location']
   }
   unless $release {
-    $_release = "${facts['os']['distro']['codename']}-backports"
+    if fact('os.distro.codename') {
+      $_release = "${fact('os.distro.codename')}-backports"
+    } else {
+      fail('os.distro.codename fact not available: release parameter required')
+    }
   }
   unless $repos {
     $_repos = $::apt::backports['repos']

--- a/manifests/ppa.pp
+++ b/manifests/ppa.pp
@@ -26,7 +26,7 @@
 define apt::ppa(
   String $ensure                 = 'present',
   Optional[String] $options      = $::apt::ppa_options,
-  Optional[String] $release      = $facts['os']['distro']['codename'],
+  Optional[String] $release      = fact('os.distro.codename'),
   Optional[String] $dist         = $facts['os']['name'],
   Optional[String] $package_name = $::apt::ppa_package,
   Boolean $package_manage        = false,

--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -79,8 +79,8 @@ define apt::source(
   $_before = Apt::Setting["list-${title}"]
 
   if !$release {
-    if $facts['os']['distro']['codename'] {
-      $_release = $facts['os']['distro']['codename']
+    if fact('os.distro.codename') {
+      $_release = fact('os.distro.codename')
     } else {
       fail('os.distro.codename fact not available: release parameter required')
     }
@@ -100,7 +100,7 @@ define apt::source(
     }
     # Newer oses, do not need the package for HTTPS transport.
     $_transport_https_releases = [ 'wheezy', 'jessie', 'stretch', 'trusty', 'xenial' ]
-    if ($facts['os']['distro']['codename'] in $_transport_https_releases) and $_location =~ /(?i:^https:\/\/)/ {
+    if (fact('os.distro.codename') in $_transport_https_releases) and $_location =~ /(?i:^https:\/\/)/ {
       ensure_packages('apt-transport-https')
       Package['apt-transport-https'] -> Class['apt::update']
     }

--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -99,8 +99,8 @@ define apt::source(
       $_location = $location
     }
     # Newer oses, do not need the package for HTTPS transport.
-    $_transport_https_releases = [ 'wheezy', 'jessie', 'stretch', 'trusty', 'xenial' ]
-    if (fact('os.distro.codename') in $_transport_https_releases) and $_location =~ /(?i:^https:\/\/)/ {
+    $_transport_https_releases = [ '7', '8', '9', '14.04', '16.04' ]
+    if (fact('os.release.major') in $_transport_https_releases) and $_location =~ /(?i:^https:\/\/)/ {
       ensure_packages('apt-transport-https')
       Package['apt-transport-https'] -> Class['apt::update']
     }


### PR DESCRIPTION
* On Puppet 6 facter 3.x requires `lsb-release` to resolve os.distro.* facts which may not always be available. Using $facts hash cause errors like "Evaluation Error: Operator '[]' is not applicable to an Undef Value." because os.distro is undefined causing the catalog to fail. Use fact() to identify Undef facts and throw an error to the user.

Releated:

* https://github.com/voxpupuli/beaker-hostgenerator/pull/244