### PR TITLE
Properly fail if the codename fact is unavailable

### DIFF
--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -79,7 +79,7 @@ define apt::source(
   $_before = Apt::Setting["list-${title}"]
 
   if !$release {
-    if $facts['os']['distro']['codename'] {
+    if fact('os.distro.codename') {
       $_release = $facts['os']['distro']['codename']
     } else {
       fail('os.distro.codename fact not available: release parameter required')


### PR DESCRIPTION
On Facter 3 the lsb-release package is needed for the os.distro fact to be present. If it's not, $facts['os']['distro']['codename'] is essentially undef['codename'] which then fails to compile.

Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Operator '[]' is not applicable to an Undef Value.

The fact() function from stdlib doesn't have this problem and properly returns undef on missing facts. Prior to 7e31732abd277c852564c10011099bdf6967dc4f this wasn't a problem because it used $facts['lsbdistcodename'] which also returned undef.