### PR TITLE
(MODULES-11301) Don't install gnupg if not needed

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -361,7 +361,4 @@ class apt (
   if $pins {
     create_resources('apt::pin', $pins)
   }
-
-  # required for adding GPG keys on Debian 9 (and derivatives)
-  ensure_packages(['gnupg'])
 }


### PR DESCRIPTION
apt::key has the needed ensure_packages() to bring gnupg only
when needed.

Signed-off-by: Simon Deziel <simon@sdeziel.info>