### PR TITLE
pdksync - (GH-cat-11) Add Support for Ubuntu 22.04

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -26,7 +26,8 @@
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "18.04",
-        "20.04"
+        "20.04",
+        "22.04"
       ]
     }
   ],


### PR DESCRIPTION
(GH-cat-11) Add Support for Ubuntu 22.04
pdk version: `2.3.0` 
