### PR TITLE
pdksync - (GH-cat-12) Add Support for Redhat 9

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -28,6 +28,12 @@
         "18.04",
         "20.04"
       ]
+    },
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "9"
+      ]
     }
   ],
   "requirements": [


### PR DESCRIPTION
(GH-cat-12) Add Support for Redhat 9
pdk version: `2.4.0` 
