### PR TITLE
(ISSUE-1036) Conditional `gnupg` include added to init.pp

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -358,4 +358,20 @@ class apt (
   if $pins {
     create_resources('apt::pin', $pins)
   }
+
+  case $facts['os']['name'] {
+    'Debian': {
+      if versioncmp($facts['os']['release']['major'], '9') >= 0 {
+        ensure_packages(['gnupg'])
+      }
+    }
+    'Ubuntu': {
+      if versioncmp($facts['os']['release']['full'], '17.04') >= 0 {
+        ensure_packages(['gnupg'])
+      }
+    }
+    default: {
+      # Nothing in here
+    }
+  }
 }


### PR DESCRIPTION
Originally removed as it was causing `gnupg` to be installed in all OS when it wasn't needed, removing it seems to have caused a dependency cycle in the relevant Debian family OS for certain community members.
Adding the include back within a conditional statement to solve the issue while still preventing it from being included when unneeded.