### PR TITLE
(GH-1038) add support for `check-valid-until` configuration

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -937,6 +937,7 @@ The following parameters are available in the `apt::source` defined type:
 * [`allow_unsigned`](#allow_unsigned)
 * [`notify_update`](#notify_update)
 * [`allow_insecure`](#allow_insecure)
+* [`check_valid_until`](#check_valid_until)
 
 ##### <a name="location"></a>`location`
 
@@ -1049,9 +1050,17 @@ Default value: ``true``
 
 Data type: `Boolean`
 
-
+Specifies whether to allow downloads from insecure repositories.
 
 Default value: ``false``
+
+##### <a name="check_valid_until"></a>`check_valid_until`
+
+Data type: `Boolean`
+
+Specifies whether to check if the package release date is valid. Defaults to `True`.
+
+Default value: ``true``
 
 ## Resource types
 

--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -55,8 +55,14 @@
 # @param allow_unsigned
 #   Specifies whether to authenticate packages from this release, even if the Release file is not signed or the signature can't be checked.
 #
+# @param allow_insecure
+#   Specifies whether to allow downloads from insecure repositories.
+#
 # @param notify_update
 #   Specifies whether to trigger an `apt-get update` run.
+#
+# @param check_valid_until
+#   Specifies whether to check if the package release date is valid. Defaults to `True`.
 #
 define apt::source (
   Optional[String] $location                    = undef,
@@ -72,6 +78,7 @@ define apt::source (
   Boolean $allow_unsigned                       = false,
   Boolean $allow_insecure                       = false,
   Boolean $notify_update                        = true,
+  Boolean $check_valid_until                    = true,
 ) {
   include ::apt
 
@@ -136,10 +143,11 @@ define apt::source (
     'comment'          => $comment,
     'includes'         => $includes,
     'options'          => delete_undef_values( {
-        'arch'           => $architecture,
-        'trusted'        => $allow_unsigned ? { true => 'yes', false => undef },
-        'allow-insecure' => $allow_insecure ? { true => 'yes', false => undef },
-        'signed-by'      => $keyring,
+        'arch'              => $architecture,
+        'trusted'           => $allow_unsigned ? { true => 'yes', false => undef },
+        'allow-insecure'    => $allow_insecure ? { true => 'yes', false => undef },
+        'signed-by'         => $keyring,
+        'check-valid-until' => $check_valid_until? { true => undef, false => 'false' },
       },
     ),
     'location'         => $_location,

--- a/spec/defines/source_spec.rb
+++ b/spec/defines/source_spec.rb
@@ -171,6 +171,32 @@ describe 'apt::source' do
     }
   end
 
+  context 'with check_valid_until false' do
+    let :params do
+      {
+        location: 'hello.there',
+        check_valid_until: false,
+      }
+    end
+
+    it {
+      is_expected.to contain_apt__setting('list-my_source').with(ensure: 'present').with_content(%r{# my_source\ndeb \[check-valid-until=false\] hello.there stretch main\n})
+    }
+  end
+
+  context 'with check_valid_until true' do
+    let :params do
+      {
+        location: 'hello.there',
+        check_valid_until: true,
+      }
+    end
+
+    it {
+      is_expected.to contain_apt__setting('list-my_source').with(ensure: 'present').with_content(%r{# my_source\ndeb hello.there stretch main\n})
+    }
+  end
+
   context 'with keyring set' do
     let :params do
       {


### PR DESCRIPTION
Add's additional configuration to `apt::source` to allow the user to specify whether or not to check if  the repository that they are accessing has a valid release ate.
Defaults to `True`