### PR TITLE
Allow to configure environment variables for apt-get update command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,17 @@ class { 'apt':
 }
 ```
 
+Update command is executed with [exec](https://puppet.com/docs/puppet/7/types/exec.html#exec-attribute-environment) resource and no environment variables are passed to it by default. However there is a way how to configure some via $::apt::update['environment'] argument.
+
+```puppet
+class { 'apt':
+  update => {
+    frequency    => 'daily',
+    environment  => ['HOME=/root'],
+  },
+}
+```
+
 > **NOTE:** Every `Exec['apt_update']` run will generate a corrective change, even if the apt caches are not updated. For example, setting an update frequency of `always` can result in every Puppet run resulting in a corrective change. This is a known issue. For details, see [MODULES-10763](https://tickets.puppetlabs.com/browse/MODULES-10763).
 
 <a id="pin-a-specific-release"></a>

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -47,10 +47,11 @@ class apt::params {
   }
 
   $update_defaults = {
-    'frequency' => 'reluctantly',
-    'loglevel'  => undef,
-    'timeout'   => undef,
-    'tries'     => undef,
+    'environment' => [],
+    'frequency'   => 'reluctantly',
+    'loglevel'    => undef,
+    'timeout'     => undef,
+    'tries'       => undef,
   }
 
   $proxy_defaults = {

--- a/manifests/update.pp
+++ b/manifests/update.pp
@@ -58,6 +58,7 @@ class apt::update {
   }
   exec { 'apt_update':
     command     => "${::apt::provider} update",
+    environment => $::apt::_update['environment'],
     loglevel    => $::apt::_update['loglevel'],
     logoutput   => 'on_failure',
     refreshonly => $_refresh,


### PR DESCRIPTION
Hello all,

We are using custom APT transport for an internal mirror.
However our transport is configurable via environment variables.
In current state no ENV vars are available for update command.
This PR introduce argument option `$::apt::update['environment']` to configure required ENV variables for APT update command.

BR