### PR TITLE
Harden PPA defined type

### DIFF
--- a/examples/ppa.pp
+++ b/examples/ppa.pp
@@ -1,4 +1,4 @@
 class { 'apt': }
 
 # Example declaration of an Apt PPA
-apt::ppa { 'ppa:openstack-ppa/bleeding-edge': }
+apt::ppa { 'ppa:ubuntuhandbook1/apps': }

--- a/lib/facter/apt_sources.rb
+++ b/lib/facter/apt_sources.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# This fact lists the .list filenames that are used by apt.
+Facter.add(:apt_sources) do
+  confine osfamily: 'Debian'
+  setcode do
+    sources = ['sources.list']
+    Dir.glob('/etc/apt/sources.list.d/*.list').each do |file|
+      sources.push(File.basename(file))
+    end
+    sources
+  end
+end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -37,10 +37,14 @@
 #   Configures various update settings. Valid options: a hash made up from the following keys:
 #
 # @option update [String] :frequency
-#   Specifies how often to run `apt-get update`. If the exec resource `apt_update` is notified, `apt-get update` runs regardless of this value.
-#   Valid options: 'always' (at every Puppet run); 'daily' (if the value of `apt_update_last_success` is less than current epoch time minus 86400);
-#   'weekly' (if the value of `apt_update_last_success` is less than current epoch time minus 604800); and 'reluctantly' (only if the exec resource
-#   `apt_update` is notified). Default: 'reluctantly'.
+#   Specifies how often to run `apt-get update`. If the exec resource `apt_update` is notified,
+#   `apt-get update` runs regardless of this value.
+#   Valid options:
+#     'always' (at every Puppet run); 
+#      daily' (if the value of `apt_update_last_success` is less than current epoch time minus 86400);
+#     'weekly' (if the value of `apt_update_last_success` is less than current epoch time minus 604800);
+#     'reluctantly' (only if the exec resource `apt_update` is notified).
+#   Default: 'reluctantly'.
 #
 # @option update [Integer] :loglevel
 #   Specifies the log level of logs outputted to the console. Default: undef.
@@ -122,38 +126,37 @@
 #   Specifies whether to perform force purge or delete. Default false.
 #
 class apt (
-  Hash $update_defaults         = $apt::params::update_defaults,
-  Hash $purge_defaults          = $apt::params::purge_defaults,
-  Hash $proxy_defaults          = $apt::params::proxy_defaults,
-  Hash $include_defaults        = $apt::params::include_defaults,
-  String $provider              = $apt::params::provider,
-  String $keyserver             = $apt::params::keyserver,
-  Optional[String] $key_options = $apt::params::key_options,
-  Optional[String] $ppa_options = $apt::params::ppa_options,
-  Optional[String] $ppa_package = $apt::params::ppa_package,
-  Optional[Hash] $backports     = $apt::params::backports,
-  Hash $confs                   = $apt::params::confs,
-  Hash $update                  = $apt::params::update,
-  Hash $purge                   = $apt::params::purge,
-  Apt::Proxy $proxy             = $apt::params::proxy,
-  Hash $sources                 = $apt::params::sources,
-  Hash $keys                    = $apt::params::keys,
-  Hash $ppas                    = $apt::params::ppas,
-  Hash $pins                    = $apt::params::pins,
-  Hash $settings                = $apt::params::settings,
-  Boolean $manage_auth_conf     = $apt::params::manage_auth_conf,
-  Array[Apt::Auth_conf_entry]
-  $auth_conf_entries            = $apt::params::auth_conf_entries,
-  String $auth_conf_owner       = $apt::params::auth_conf_owner,
-  String $root                  = $apt::params::root,
-  String $sources_list          = $apt::params::sources_list,
-  String $sources_list_d        = $apt::params::sources_list_d,
-  String $conf_d                = $apt::params::conf_d,
-  String $preferences           = $apt::params::preferences,
-  String $preferences_d         = $apt::params::preferences_d,
-  String $apt_conf_d            = $apt::params::apt_conf_d,
-  Hash $config_files            = $apt::params::config_files,
-  Boolean $sources_list_force   = $apt::params::sources_list_force,
+  Hash $update_defaults                           = $apt::params::update_defaults,
+  Hash $purge_defaults                            = $apt::params::purge_defaults,
+  Hash $proxy_defaults                            = $apt::params::proxy_defaults,
+  Hash $include_defaults                          = $apt::params::include_defaults,
+  String $provider                                = $apt::params::provider,
+  String $keyserver                               = $apt::params::keyserver,
+  Optional[String] $key_options                   = $apt::params::key_options,
+  Optional[Array[String]] $ppa_options            = $apt::params::ppa_options,
+  Optional[String] $ppa_package                   = $apt::params::ppa_package,
+  Optional[Hash] $backports                       = $apt::params::backports,
+  Hash $confs                                     = $apt::params::confs,
+  Hash $update                                    = $apt::params::update,
+  Hash $purge                                     = $apt::params::purge,
+  Apt::Proxy $proxy                               = $apt::params::proxy,
+  Hash $sources                                   = $apt::params::sources,
+  Hash $keys                                      = $apt::params::keys,
+  Hash $ppas                                      = $apt::params::ppas,
+  Hash $pins                                      = $apt::params::pins,
+  Hash $settings                                  = $apt::params::settings,
+  Boolean $manage_auth_conf                       = $apt::params::manage_auth_conf,
+  Array[Apt::Auth_conf_entry] $auth_conf_entries  = $apt::params::auth_conf_entries,
+  String $auth_conf_owner                         = $apt::params::auth_conf_owner,
+  String $root                                    = $apt::params::root,
+  String $sources_list                            = $apt::params::sources_list,
+  String $sources_list_d                          = $apt::params::sources_list_d,
+  String $conf_d                                  = $apt::params::conf_d,
+  String $preferences                             = $apt::params::preferences,
+  String $preferences_d                           = $apt::params::preferences_d,
+  String $apt_conf_d                              = $apt::params::apt_conf_d,
+  Hash $config_files                              = $apt::params::config_files,
+  Boolean $sources_list_force                     = $apt::params::sources_list_force,
 
   Hash $source_key_defaults = {
     'server'  => $keyserver,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -91,7 +91,7 @@ class apt::params {
         'key'      => '630239CC130E1A7FD81A27B140976EAF437D05B5',
         'repos'    => 'main universe multiverse restricted',
       }
-      $ppa_options        = '-y'
+      $ppa_options        = ['-y']
       $ppa_package        = 'software-properties-common'
       $auth_conf_owner = '_apt'
     }

--- a/manifests/ppa.pp
+++ b/manifests/ppa.pp
@@ -24,12 +24,12 @@
 #   Specifies whether Puppet should manage the package that provides `apt-add-repository`.
 #
 define apt::ppa (
-  String $ensure                 = 'present',
-  Optional[String] $options      = $::apt::ppa_options,
-  Optional[String] $release      = fact('os.distro.codename'),
-  Optional[String] $dist         = $facts['os']['name'],
-  Optional[String] $package_name = $::apt::ppa_package,
-  Boolean $package_manage        = false,
+  String $ensure                        = 'present',
+  Optional[Array[String]] $options      = $::apt::ppa_options,
+  Optional[String] $release             = fact('os.distro.codename'),
+  Optional[String] $dist                = $facts['os']['name'],
+  Optional[String] $package_name        = $::apt::ppa_package,
+  Boolean $package_manage               = false,
 ) {
   unless $release {
     fail('os.distro.codename fact not available: release parameter required')
@@ -37,6 +37,11 @@ define apt::ppa (
 
   if $dist == 'Debian' {
     fail('apt::ppa is not currently supported on Debian.')
+  }
+
+  # Validate the resource name
+  if $name !~ /^ppa:([a-zA-Z0-9\-_]+)\/([a-zA-z0-9\-_]+)$/ {
+    fail("Invalid PPA name: ${name}")
   }
 
   if versioncmp($facts['os']['release']['full'], '14.10') >= 0 {
@@ -62,6 +67,9 @@ define apt::ppa (
     $trusted_gpg_d_filename = "${dash_filename_no_specialchars}.gpg"
   }
 
+  # This is the location of our main exec script  
+  $script_path = "/opt/puppetlabs/puppet/cache/add-apt-repository-${dash_filename_no_specialchars}-${release}.sh"
+
   if $ensure == 'present' {
     if $package_manage {
       ensure_packages($package_name)
@@ -81,24 +89,36 @@ define apt::ppa (
       $_proxy_env = []
     }
 
-    exec { "add-apt-repository-${name}":
-      environment => $_proxy_env,
-      command     => "/usr/bin/add-apt-repository ${options} ${name} || (rm ${::apt::sources_list_d}/${sources_list_d_filename} && false)",
-      unless      => "/usr/bin/test -f ${::apt::sources_list_d}/${sources_list_d_filename} && /usr/bin/test -f ${::apt::trusted_gpg_d}/${trusted_gpg_d_filename}",
-      user        => 'root',
-      logoutput   => 'on_failure',
-      notify      => Class['apt::update'],
-      require     => $_require,
-    }
+    unless $sources_list_d_filename in $facts['apt_sources'] {
+      $script_content = epp('apt/add-apt-repository.sh.epp', {
+        command                 => ['/usr/bin/add-apt-repository', shell_join($options), $name],
+        sources_list_d_path     => $::apt::sources_list_d,
+        sources_list_d_filename => $sources_list_d_filename,
+      })
 
-    file { "${::apt::sources_list_d}/${sources_list_d_filename}":
-      ensure  => file,
-      require => Exec["add-apt-repository-${name}"],
+      file { "add-apt-repository-script-${name}":
+        ensure  => 'file',
+        path    => $script_path,
+        content => $script_content,
+        mode    => '0755',
+      }
+
+      exec { "add-apt-repository-${name}":
+        environment => $_proxy_env,
+        command     => $script_path,
+        logoutput   => 'on_failure',
+        notify      => Class['apt::update'],
+        require     => $_require,
+      }
     }
   }
   else {
-    file { "${::apt::sources_list_d}/${sources_list_d_filename}":
-      ensure => 'absent',
+    tidy { "remove-apt-repository-script-${name}":
+      path => $script_path,
+    }
+
+    tidy { "remove-apt-repository-${name}":
+      path   => "${::apt::sources_list_d}/${sources_list_d_filename}",
       notify => Class['apt::update'],
     }
   }

--- a/spec/defines/ppa_spec.rb
+++ b/spec/defines/ppa_spec.rb
@@ -1,6 +1,15 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+
+def ppa_exec_params(user, repo, distro = 'trusty', environment = [])
+  [
+    environment: environment,
+    command: "/opt/puppetlabs/puppet/cache/add-apt-repository-#{user}-ubuntu-#{repo}-#{distro}.sh",
+    logoutput: 'on_failure',
+  ]
+end
+
 describe 'apt::ppa' do
   let :pre_condition do
     'class { "apt": }'
@@ -24,15 +33,13 @@ describe 'apt::ppa' do
       }
     end
 
-    let(:title) { 'ppa:needs/such.substitution/wow+type' }
+    let(:title) { 'ppa:needs/substitution' }
 
     it { is_expected.not_to contain_package('python-software-properties') }
     it {
-      is_expected.to contain_exec('add-apt-repository-ppa:needs/such.substitution/wow+type').that_notifies('Class[Apt::Update]').with(environment: [],
-                                                                                                                                      command: '/usr/bin/add-apt-repository -y ppa:needs/such.substitution/wow+type || (rm /etc/apt/sources.list.d/needs-ubuntu-such_substitution-wow_type-trusty.list && false)', # rubocop:disable Layout/LineLength
-                                                                                                                                      unless: '/usr/bin/test -f /etc/apt/sources.list.d/needs-ubuntu-such_substitution-wow_type-trusty.list && /usr/bin/test -f /etc/apt/trusted.gpg.d/needs_ubuntu_such_substitution-wow_type.gpg', # rubocop:disable Layout/LineLength
-                                                                                                                                      user: 'root',
-                                                                                                                                      logoutput: 'on_failure')
+      is_expected.to contain_exec('add-apt-repository-ppa:needs/substitution')
+        .that_notifies('Class[Apt::Update]')
+        .with(*ppa_exec_params('needs', 'substitution'))
     }
   end
 
@@ -57,11 +64,9 @@ describe 'apt::ppa' do
     let(:title) { 'ppa:user/foo' }
 
     it {
-      is_expected.to contain_exec('add-apt-repository-ppa:user/foo').that_notifies('Class[Apt::Update]').with(environment: [],
-                                                                                                              command: '/usr/bin/add-apt-repository -y ppa:user/foo || (rm /etc/apt/sources.list.d/user-ubuntu-foo-wily.list && false)', # rubocop:disable Layout/LineLength
-                                                                                                              unless: '/usr/bin/test -f /etc/apt/sources.list.d/user-ubuntu-foo-wily.list && /usr/bin/test -f /etc/apt/trusted.gpg.d/user_ubuntu_foo.gpg', # rubocop:disable Layout/LineLength
-                                                                                                              user: 'root',
-                                                                                                              logoutput: 'on_failure')
+      is_expected.to contain_exec('add-apt-repository-ppa:user/foo')
+        .that_notifies('Class[Apt::Update]')
+        .with(*ppa_exec_params('user', 'foo', 'wily'))
     }
   end
 
@@ -69,12 +74,14 @@ describe 'apt::ppa' do
     let :pre_condition do
       'class { "apt": }'
     end
+
     let :params do
       {
         package_name: 'software-properties-common',
         package_manage: true,
       }
     end
+
     let :facts do
       {
         os: {
@@ -92,19 +99,13 @@ describe 'apt::ppa' do
       }
     end
 
-    let(:title) { 'ppa:needs/such.substitution/wow' }
+    let(:title) { 'ppa:needs/substitution' }
 
     it { is_expected.to contain_package('software-properties-common') }
     it {
-      is_expected.to contain_exec('add-apt-repository-ppa:needs/such.substitution/wow').that_notifies('Class[Apt::Update]').with('environment' => [],
-                                                                                                                                 'command'     => '/usr/bin/add-apt-repository -y ppa:needs/such.substitution/wow || (rm /etc/apt/sources.list.d/needs-ubuntu-such_substitution-wow-trusty.list && false)', # rubocop:disable Layout/LineLength
-                                                                                                                                 'unless'      => '/usr/bin/test -f /etc/apt/sources.list.d/needs-ubuntu-such_substitution-wow-trusty.list && /usr/bin/test -f /etc/apt/trusted.gpg.d/needs_ubuntu_such_substitution-wow.gpg', # rubocop:disable Layout/LineLength
-                                                                                                                                 'user'        => 'root',
-                                                                                                                                 'logoutput'   => 'on_failure')
-    }
-
-    it {
-      is_expected.to contain_file('/etc/apt/sources.list.d/needs-ubuntu-such_substitution-wow-trusty.list').that_requires('Exec[add-apt-repository-ppa:needs/such.substitution/wow]').with('ensure' => 'file') # rubocop:disable Layout/LineLength
+      is_expected.to contain_exec('add-apt-repository-ppa:needs/substitution')
+        .that_notifies('Class[Apt::Update]')
+        .with(*ppa_exec_params('needs', 'substitution'))
     }
   end
 
@@ -112,6 +113,7 @@ describe 'apt::ppa' do
     let :pre_condition do
       'class { "apt": }'
     end
+
     let :facts do
       {
         os: {
@@ -128,25 +130,20 @@ describe 'apt::ppa' do
         },
       }
     end
+
     let :params do
       {
         package_manage: false,
       }
     end
 
-    let(:title) { 'ppa:needs/such.substitution/wow' }
+    let(:title) { 'ppa:needs/substitution' }
 
     it { is_expected.not_to contain_package('python-software-properties') }
     it {
-      is_expected.to contain_exec('add-apt-repository-ppa:needs/such.substitution/wow').that_notifies('Class[Apt::Update]').with('environment' => [],
-                                                                                                                                 'command'     => '/usr/bin/add-apt-repository -y ppa:needs/such.substitution/wow || (rm /etc/apt/sources.list.d/needs-ubuntu-such_substitution-wow-trusty.list && false)', # rubocop:disable Layout/LineLength
-                                                                                                                                 'unless'      => '/usr/bin/test -f /etc/apt/sources.list.d/needs-ubuntu-such_substitution-wow-trusty.list && /usr/bin/test -f /etc/apt/trusted.gpg.d/needs_ubuntu_such_substitution-wow.gpg', # rubocop:disable Layout/LineLength
-                                                                                                                                 'user'        => 'root',
-                                                                                                                                 'logoutput'   => 'on_failure')
-    }
-
-    it {
-      is_expected.to contain_file('/etc/apt/sources.list.d/needs-ubuntu-such_substitution-wow-trusty.list').that_requires('Exec[add-apt-repository-ppa:needs/such.substitution/wow]').with('ensure' => 'file') # rubocop:disable Layout/LineLength
+      is_expected.to contain_exec('add-apt-repository-ppa:needs/substitution')
+        .that_notifies('Class[Apt::Update]')
+        .with(*ppa_exec_params('needs', 'substitution'))
     }
   end
 
@@ -156,6 +153,7 @@ describe 'apt::ppa' do
       apt::ppa { "ppa:user/foo2": }
       '
     end
+
     let :facts do
       {
         os: {
@@ -172,23 +170,22 @@ describe 'apt::ppa' do
         },
       }
     end
+
     let :params do
       {
-        options: '',
         package_manage: true,
         require: 'Apt::Ppa[ppa:user/foo2]',
       }
     end
+
     let(:title) { 'ppa:user/foo' }
 
     it { is_expected.to compile.with_all_deps }
     it { is_expected.to contain_package('software-properties-common') }
     it {
-      is_expected.to contain_exec('add-apt-repository-ppa:user/foo').that_notifies('Class[Apt::Update]').with(environment: [],
-                                                                                                              command: '/usr/bin/add-apt-repository  ppa:user/foo || (rm /etc/apt/sources.list.d/user-ubuntu-foo-trusty.list && false)', # rubocop:disable Layout/LineLength
-                                                                                                              unless: '/usr/bin/test -f /etc/apt/sources.list.d/user-ubuntu-foo-trusty.list && /usr/bin/test -f /etc/apt/trusted.gpg.d/user_ubuntu_foo.gpg', # rubocop:disable Layout/LineLength
-                                                                                                              user: 'root',
-                                                                                                              logoutput: 'on_failure')
+      is_expected.to contain_exec('add-apt-repository-ppa:user/foo')
+        .that_notifies('Class[Apt::Update]')
+        .with(*ppa_exec_params('user', 'foo'))
     }
   end
 
@@ -198,6 +195,7 @@ describe 'apt::ppa' do
         proxy => { "host" => "localhost" },
       }'
     end
+
     let :facts do
       {
         os: {
@@ -214,21 +212,20 @@ describe 'apt::ppa' do
         },
       }
     end
+
     let :params do
       {
-        'options' => '',
         'package_manage' => true,
       }
     end
+
     let(:title) { 'ppa:user/foo' }
 
     it { is_expected.to contain_package('software-properties-common') }
     it {
-      is_expected.to contain_exec('add-apt-repository-ppa:user/foo').that_notifies('Class[Apt::Update]').with(environment: ['http_proxy=http://localhost:8080'],
-                                                                                                              command: '/usr/bin/add-apt-repository  ppa:user/foo || (rm /etc/apt/sources.list.d/user-ubuntu-foo-trusty.list && false)', # rubocop:disable Layout/LineLength
-                                                                                                              unless: '/usr/bin/test -f /etc/apt/sources.list.d/user-ubuntu-foo-trusty.list && /usr/bin/test -f /etc/apt/trusted.gpg.d/user_ubuntu_foo.gpg', # rubocop:disable Layout/LineLength
-                                                                                                              user: 'root',
-                                                                                                              logoutput: 'on_failure')
+      is_expected.to contain_exec('add-apt-repository-ppa:user/foo')
+        .that_notifies('Class[Apt::Update]')
+        .with(*ppa_exec_params('user', 'foo', 'trusty', ['http_proxy=http://localhost:8080']))
     }
   end
 
@@ -238,6 +235,7 @@ describe 'apt::ppa' do
         proxy => { "host" => "localhost", "port" => 8180 },
       }'
     end
+
     let :facts do
       {
         os: {
@@ -254,21 +252,20 @@ describe 'apt::ppa' do
         },
       }
     end
+
     let :params do
       {
-        options: '',
         package_manage: true,
       }
     end
+
     let(:title) { 'ppa:user/foo' }
 
     it { is_expected.to contain_package('software-properties-common') }
     it {
-      is_expected.to contain_exec('add-apt-repository-ppa:user/foo').that_notifies('Class[Apt::Update]').with(environment: ['http_proxy=http://localhost:8180'],
-                                                                                                              command: '/usr/bin/add-apt-repository  ppa:user/foo || (rm /etc/apt/sources.list.d/user-ubuntu-foo-trusty.list && false)', # rubocop:disable Layout/LineLength
-                                                                                                              unless: '/usr/bin/test -f /etc/apt/sources.list.d/user-ubuntu-foo-trusty.list && /usr/bin/test -f /etc/apt/trusted.gpg.d/user_ubuntu_foo.gpg', # rubocop:disable Layout/LineLength
-                                                                                                              user: 'root',
-                                                                                                              logoutput: 'on_failure')
+      is_expected.to contain_exec('add-apt-repository-ppa:user/foo')
+        .that_notifies('Class[Apt::Update]')
+        .with(*ppa_exec_params('user', 'foo', 'trusty', ['http_proxy=http://localhost:8180']))
     }
   end
 
@@ -278,6 +275,7 @@ describe 'apt::ppa' do
         proxy => { "host" => "localhost", "port" => 8180, "https" => true },
       }'
     end
+
     let :facts do
       {
         os: {
@@ -294,21 +292,20 @@ describe 'apt::ppa' do
         },
       }
     end
+
     let :params do
       {
-        options: '',
         package_manage: true,
       }
     end
+
     let(:title) { 'ppa:user/foo' }
 
     it { is_expected.to contain_package('software-properties-common') }
     it {
-      is_expected.to contain_exec('add-apt-repository-ppa:user/foo').that_notifies('Class[Apt::Update]').with(environment: ['http_proxy=http://localhost:8180', 'https_proxy=https://localhost:8180'],
-                                                                                                              command: '/usr/bin/add-apt-repository  ppa:user/foo || (rm /etc/apt/sources.list.d/user-ubuntu-foo-trusty.list && false)', # rubocop:disable Layout/LineLength
-                                                                                                              unless: '/usr/bin/test -f /etc/apt/sources.list.d/user-ubuntu-foo-trusty.list && /usr/bin/test -f /etc/apt/trusted.gpg.d/user_ubuntu_foo.gpg', # rubocop:disable Layout/LineLength
-                                                                                                              user: 'root',
-                                                                                                              logoutput: 'on_failure')
+      is_expected.to contain_exec('add-apt-repository-ppa:user/foo')
+        .that_notifies('Class[Apt::Update]')
+        .with(*ppa_exec_params('user', 'foo', 'trusty', ['http_proxy=http://localhost:8180', 'https_proxy=https://localhost:8180']))
     }
   end
 
@@ -316,6 +313,7 @@ describe 'apt::ppa' do
     let :pre_condition do
       'class { "apt": }'
     end
+
     let :facts do
       {
         os: {
@@ -332,7 +330,9 @@ describe 'apt::ppa' do
         },
       }
     end
+
     let(:title) { 'ppa:user/foo' }
+
     let :params do
       {
         ensure: 'absent',
@@ -340,7 +340,12 @@ describe 'apt::ppa' do
     end
 
     it {
-      is_expected.to contain_file('/etc/apt/sources.list.d/user-ubuntu-foo-trusty.list').that_notifies('Class[Apt::Update]').with(ensure: 'absent')
+      is_expected.to contain_tidy("remove-apt-repository-script-#{title}")
+        .with('path' => '/opt/puppetlabs/puppet/cache/add-apt-repository-user-ubuntu-foo-trusty.sh')
+
+      is_expected.to contain_tidy("remove-apt-repository-#{title}")
+        .with('path' => '/etc/apt/sources.list.d/user-ubuntu-foo-trusty.list')
+        .that_notifies('Class[Apt::Update]')
     }
   end
 
@@ -362,6 +367,7 @@ describe 'apt::ppa' do
           },
         }
       end
+
       let(:title) { 'ppa:user/foo' }
 
       it do
@@ -386,6 +392,7 @@ describe 'apt::ppa' do
           },
         }
       end
+
       let(:title) { 'ppa:user/foo' }
 
       it do

--- a/spec/unit/facter/apt_sources_spec.rb
+++ b/spec/unit/facter/apt_sources_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'apt_sources fact' do
+  subject { Facter.fact(:apt_sources).value }
+
+  before(:each) { Facter.clear }
+
+  describe 'returns a list of .list files' do
+    let(:sources_raw) { ['/etc/apt/sources.list.d/puppet-tools.list', '/etc/apt/sources.list.d/some-cli.list'] }
+    let(:sources_want) { ['sources.list', 'puppet-tools.list', 'some-cli.list'] }
+
+    before(:each) do
+      allow(Dir).to receive(:glob).and_return(sources_raw)
+    end
+
+    it { is_expected.to eq(sources_want) }
+  end
+end

--- a/templates/add-apt-repository.sh.epp
+++ b/templates/add-apt-repository.sh.epp
@@ -1,0 +1,8 @@
+<%- | Array $command, String $sources_list_d_path, String $sources_list_d_filename | -%>
+
+<%= $command.join(' ') %>
+
+if [ $? -gt 0 ]; then
+   rm <%= $sources_list_d_path %>/<%= $sources_list_d_filename %>
+   exit 1
+fi


### PR DESCRIPTION
Prior to this PR there was a possibility that malformed strings could be passed as the resources name.
This could lead to unsafe executions on a remote system.

This was also a possibility for the options parameter as it was constrained to a string.

In addition, commands were not properly broken out in to arrays of arguments when passed to the exec resource.

This PR fixes the above by adding validation to the resource name ensuring that the given ppa name conforms to expectation.

Also, commands are now broken down in to arrays of arguments appropriately. This ensures safer execution on the remote system.

Given that the options parameter, passed as a raw string, could lead to unsafe code execution it was reasonable to change the accepted type to an `Optional[Array[String]]`. 

This means that an array of options can now be passed to the exec resource inside the original command.