### PR TITLE
(GH-cat-9) Update module to match current syntax standard

### DIFF
--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -1,9 +1,2 @@
 --relative
---no-top_scope_facts-check
---no-topscope_variable-check
---no-relative_classname_inclusion-check
---no-parameter_documentation-check
 --no-anchor_resource-check
---no-strict_indent-check
---no-unquoted_string_in_case-check
---no-optional_default-check

--- a/.sync.yml
+++ b/.sync.yml
@@ -33,11 +33,4 @@ spec/spec_helper.rb:
 changelog_since_tag: '5.0.1'
 Rakefile:
   extra_disabled_lint_checks:
-    - top_scope_facts
-    - topscope_variable
-    - relative_classname_inclusion
-    - parameter_documentation
     - anchor_resource
-    - strict_indent
-    - unquoted_string_in_case
-    - optional_default

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -605,7 +605,7 @@ Data type: `Pattern[/\A((hkp|hkps|http|https):\/\/)?([a-z\d])([a-z\d-]{0,61}\.)+
 Specifies a keyserver to provide the GPG key. Valid options: a string containing a domain name or a full URL (http://, https://,
 hkp:// or hkps://). The hkps:// protocol is currently only supported on Ubuntu 18.04.
 
-Default value: `$::apt::keyserver`
+Default value: `$apt::keyserver`
 
 ##### <a name="weak_ssl"></a>`weak_ssl`
 
@@ -621,7 +621,7 @@ Data type: `Optional[String]`
 
 Passes additional options to `apt-key adv --keyserver-options`.
 
-Default value: `$::apt::key_options`
+Default value: `$apt::key_options`
 
 ### <a name="aptmark"></a>`apt::mark`
 
@@ -809,7 +809,7 @@ Data type: `Optional[Array[String]]`
 
 Supplies options to be passed to the `add-apt-repository` command. Default: '-y'.
 
-Default value: `$::apt::ppa_options`
+Default value: `$apt::ppa_options`
 
 ##### <a name="release"></a>`release`
 
@@ -835,7 +835,7 @@ Data type: `Optional[String]`
 
 Names the package that provides the `apt-add-repository` command. Default: 'software-properties-common'.
 
-Default value: `$::apt::ppa_package`
+Default value: `$apt::ppa_package`
 
 ##### <a name="package_manage"></a>`package_manage`
 

--- a/Rakefile
+++ b/Rakefile
@@ -42,15 +42,7 @@ def changelog_future_release
 end
 
 PuppetLint.configuration.send('disable_relative')
-PuppetLint.configuration.send('disable_top_scope_facts')
-PuppetLint.configuration.send('disable_topscope_variable')
-PuppetLint.configuration.send('disable_relative_classname_inclusion')
-PuppetLint.configuration.send('disable_parameter_documentation')
 PuppetLint.configuration.send('disable_anchor_resource')
-PuppetLint.configuration.send('disable_strict_indent')
-PuppetLint.configuration.send('disable_unquoted_string_in_case')
-PuppetLint.configuration.send('disable_optional_default')
-
 
 if Bundler.rubygems.find_name('github_changelog_generator').any?
   GitHubChangelogGenerator::RakeTask.new :changelog do |config|

--- a/manifests/backports.pp
+++ b/manifests/backports.pp
@@ -76,7 +76,7 @@ class apt::backports (
     }
   }
   unless $location {
-    $_location = $::apt::backports['location']
+    $_location = $apt::backports['location']
   }
   unless $release {
     if fact('os.distro.codename') {
@@ -86,10 +86,10 @@ class apt::backports (
     }
   }
   unless $repos {
-    $_repos = $::apt::backports['repos']
+    $_repos = $apt::backports['repos']
   }
   unless $key {
-    $_key =  $::apt::backports['key']
+    $_key =  $apt::backports['key']
   }
 
   if $pin =~ Hash {

--- a/manifests/key.pp
+++ b/manifests/key.pp
@@ -40,10 +40,10 @@ define apt::key (
   Enum['present', 'absent', 'refreshed'] $ensure                                                                        = present,
   Optional[String] $content                                                                                             = undef,
   Optional[Pattern[/\Ahttps?:\/\//, /\Aftp:\/\//, /\A\/\w+/]] $source                                                   = undef,
-  Pattern[/\A((hkp|hkps|http|https):\/\/)?([a-z\d])([a-z\d-]{0,61}\.)+[a-z\d]+(:\d{2,5})?(\/[a-zA-Z\d\-_.]+)*\/?$/] $server = $::apt::keyserver,
+  Pattern[/\A((hkp|hkps|http|https):\/\/)?([a-z\d])([a-z\d-]{0,61}\.)+[a-z\d]+(:\d{2,5})?(\/[a-zA-Z\d\-_.]+)*\/?$/] $server = $apt::keyserver,
   Boolean $weak_ssl                                                                                                     = false,
-  Optional[String] $options                                                                                             = $::apt::key_options,
-  ) {
+  Optional[String] $options                                                                                             = $apt::key_options,
+) {
   case $ensure {
     /^(refreshed|present)$/: {
       if defined(Anchor["apt_key ${id} absent"]) {
@@ -82,7 +82,7 @@ define apt::key (
       }
     }
 
-    absent: {
+    /^absent$/: {
       if defined(Anchor["apt_key ${id} present"]) {
         fail("key with id ${id} already ensured as present")
       }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -77,10 +77,10 @@ class apt::params {
 
   case $facts['os']['name'] {
     'Debian': {
-          $backports = {
-            'location' => 'http://deb.debian.org/debian',
-            'repos'    => 'main contrib non-free',
-          }
+      $backports = {
+        'location' => 'http://deb.debian.org/debian',
+        'repos'    => 'main contrib non-free',
+      }
       $ppa_options = undef
       $ppa_package = undef
       $auth_conf_owner = '_apt'

--- a/manifests/pin.pp
+++ b/manifests/pin.pp
@@ -33,20 +33,29 @@
 # @param label
 #   Names the label of the packages in the directory tree of the Release file.
 #
+# @param origin
+#   The package origin
+#
+# @param version
+#   The version of the package
+#
+# @param codename
+#   The codename of the package
+#
 define apt::pin (
-  Enum['file', 'present', 'absent'] $ensure           = present,
-  Optional[String] $explanation                       = undef,
-  Variant[Integer] $order                             = 50,
-  Variant[String, Array] $packages                    = '*',
-  Variant[Numeric, String] $priority                  = 0,
-  Optional[String] $release                           = '', # a=
-  Optional[String] $origin                            = '',
-  Optional[String] $version                           = '',
-  Optional[String] $codename                          = '', # n=
-  Optional[String] $release_version                   = '', # v=
-  Optional[String] $component                         = '', # c=
-  Optional[String] $originator                        = '', # o=
-  Optional[String] $label                             = '',  # l=
+  Enum['file', 'present', 'absent'] $ensure = present,
+  Optional[String] $explanation             = undef,
+  Variant[Integer] $order                   = 50,
+  Variant[String, Array] $packages          = '*',
+  Variant[Numeric, String] $priority        = 0,
+  Optional[String] $release                 = undef, # a=
+  Optional[String] $origin                  = undef,
+  Optional[String] $version                 = undef,
+  Optional[String] $codename                = undef, # n=
+  Optional[String] $release_version         = undef, # v=
+  Optional[String] $component               = undef, # c=
+  Optional[String] $originator              = undef, # o=
+  Optional[String] $label                   = undef,  # l=
 ) {
   if $explanation {
     $_explanation = $explanation
@@ -78,15 +87,15 @@ define apt::pin (
   }
 
   if $packages_string != '*' { # specific form
-    if ( $pin_release != '' and ( $origin != '' or $version != '' )) or
-      ( $version != '' and ( $pin_release != '' or $origin != '' )) {
+    if ( $pin_release != '' and ( $origin or $version )) or
+    ( $version and ( $pin_release != '' or $origin )) {
       fail('parameters release, origin, and version are mutually exclusive')
     }
   } else { # general form
-    if $version != '' {
+    if $version {
       fail('parameter version cannot be used in general form')
     }
-    if ( $pin_release != '' and $origin != '' ) {
+    if ( $pin_release != '' and $origin ) {
       fail('parameters release and origin are mutually exclusive')
     }
   }

--- a/manifests/ppa.pp
+++ b/manifests/ppa.pp
@@ -25,10 +25,10 @@
 #
 define apt::ppa (
   String $ensure                        = 'present',
-  Optional[Array[String]] $options      = $::apt::ppa_options,
+  Optional[Array[String]] $options      = $apt::ppa_options,
   Optional[String] $release             = fact('os.distro.codename'),
   Optional[String] $dist                = $facts['os']['name'],
-  Optional[String] $package_name        = $::apt::ppa_package,
+  Optional[String] $package_name        = $apt::ppa_package,
   Boolean $package_manage               = false,
 ) {
   unless $release {
@@ -61,7 +61,7 @@ define apt::ppa (
   $sources_list_d_filename  = "${dash_filename_no_specialchars}-${release}.list"
 
   if versioncmp($facts['os']['release']['full'], '15.10') >= 0 and
-    versioncmp($facts['os']['release']['full'], '21.04') < 0 {
+  versioncmp($facts['os']['release']['full'], '21.04') < 0 {
     $trusted_gpg_d_filename = "${underscore_filename_no_specialchars}.gpg"
   } else {
     $trusted_gpg_d_filename = "${dash_filename_no_specialchars}.gpg"
@@ -78,7 +78,7 @@ define apt::ppa (
       $_require = File['sources.list.d']
     }
 
-    $_proxy = $::apt::_proxy
+    $_proxy = $apt::_proxy
     if $_proxy['host'] {
       if $_proxy['https'] {
         $_proxy_env = ["http_proxy=http://${$_proxy['host']}:${$_proxy['port']}", "https_proxy=https://${$_proxy['host']}:${$_proxy['port']}"]
@@ -91,10 +91,11 @@ define apt::ppa (
 
     unless $sources_list_d_filename in $facts['apt_sources'] {
       $script_content = epp('apt/add-apt-repository.sh.epp', {
-        command                 => ['/usr/bin/add-apt-repository', shell_join($options), $name],
-        sources_list_d_path     => $::apt::sources_list_d,
-        sources_list_d_filename => $sources_list_d_filename,
-      })
+          command                 => ['/usr/bin/add-apt-repository', shell_join($options), $name],
+          sources_list_d_path     => $apt::sources_list_d,
+          sources_list_d_filename => $sources_list_d_filename,
+        }
+      )
 
       file { "add-apt-repository-script-${name}":
         ensure  => 'file',
@@ -118,7 +119,7 @@ define apt::ppa (
     }
 
     tidy { "remove-apt-repository-${name}":
-      path   => "${::apt::sources_list_d}/${sources_list_d_filename}",
+      path   => "${apt::sources_list_d}/${sources_list_d_filename}",
       notify => Class['apt::update'],
     }
   }

--- a/manifests/setting.pp
+++ b/manifests/setting.pp
@@ -55,8 +55,8 @@ define apt::setting (
     $_priority = $priority
   }
 
-  $_path = $::apt::config_files[$setting_type]['path']
-  $_ext  = $::apt::config_files[$setting_type]['ext']
+  $_path = $apt::config_files[$setting_type]['path']
+  $_ext  = $apt::config_files[$setting_type]['ext']
 
   if $notify_update {
     $_notify = Class['apt::update']

--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -80,7 +80,7 @@ define apt::source (
   Boolean $notify_update                        = true,
   Boolean $check_valid_until                    = true,
 ) {
-  include ::apt
+  include apt
 
   $_before = Apt::Setting["list-${title}"]
 
@@ -98,7 +98,7 @@ define apt::source (
     if ! $location {
       fail('cannot create a source entry without specifying a location')
     }
-    elsif ($::apt::proxy['https_acng']) and ($location =~ /(?i:^https:\/\/)/) {
+    elsif ($apt::proxy['https_acng']) and ($location =~ /(?i:^https:\/\/)/) {
       $_location = regsubst($location, 'https://','http://HTTPS///')
     }
     else {
@@ -114,7 +114,7 @@ define apt::source (
     $_location = undef
   }
 
-  $includes = merge($::apt::include_defaults, $include)
+  $includes = merge($apt::include_defaults, $include)
 
   if $key and $keyring {
     fail('parameters key and keyring are mutualy exclusive')
@@ -125,7 +125,7 @@ define apt::source (
       unless $key['id'] {
         fail('key hash must contain at least an id entry')
       }
-      $_key = merge($::apt::source_key_defaults, $key)
+      $_key = merge($apt::source_key_defaults, $key)
     } else {
       $_key = { 'id' => assert_type(String[1], $key) }
     }
@@ -140,20 +140,21 @@ define apt::source (
   }
 
   $sourcelist = epp('apt/source.list.epp', {
-    'comment'          => $comment,
-    'includes'         => $includes,
-    'options'          => delete_undef_values( {
-        'arch'              => $architecture,
-        'trusted'           => $allow_unsigned ? { true => 'yes', false => undef },
-        'allow-insecure'    => $allow_insecure ? { true => 'yes', false => undef },
-        'signed-by'         => $keyring,
-        'check-valid-until' => $check_valid_until? { true => undef, false => 'false' },
-      },
-    ),
-    'location'         => $_location,
-    'release'          => $_release,
-    'repos'            => $repos,
-  })
+      'comment'          => $comment,
+      'includes'         => $includes,
+      'options'          => delete_undef_values( {
+          'arch'              => $architecture,
+          'trusted'           => $allow_unsigned ? { true => 'yes', false => undef },
+          'allow-insecure'    => $allow_insecure ? { true => 'yes', false => undef },
+          'signed-by'         => $keyring,
+          'check-valid-until' => $check_valid_until? { true => undef, false => 'false' },
+        },
+      ),
+      'location'         => $_location,
+      'release'          => $_release,
+      'repos'            => $repos,
+    }
+  )
 
   apt::setting { "list-${name}":
     ensure        => $ensure,

--- a/manifests/update.pp
+++ b/manifests/update.pp
@@ -5,12 +5,12 @@
 class apt::update {
   assert_private()
 
-  #TODO: to catch if $::apt_update_last_success has the value of -1 here. If we
+  #TODO: to catch if $apt_update_last_success has the value of -1 here. If we
   #opt to do this, a info/warn would likely be all you'd need likely to happen
   #on the first run, but if it's not run in awhile something is likely borked
   #with apt and we'd want to know about it.
 
-  case $::apt::_update['frequency'] {
+  case $apt::_update['frequency'] {
     'always': {
       $_kick_apt = true
     }
@@ -18,8 +18,8 @@ class apt::update {
       #compare current date with the apt_update_last_success fact to determine
       #if we should kick apt_update.
       $daily_threshold = (Integer(Timestamp().strftime('%s')) - 86400)
-      if $::apt_update_last_success {
-        if $::apt_update_last_success + 0 < $daily_threshold {
+      if $apt::apt_update_last_success {
+        if $apt::apt_update_last_success + 0 < $daily_threshold {
           $_kick_apt = true
         } else {
           $_kick_apt = false
@@ -33,8 +33,8 @@ class apt::update {
       #compare current date with the apt_update_last_success fact to determine
       #if we should kick apt_update.
       $weekly_threshold = (Integer(Timestamp().strftime('%s')) - 604800)
-      if $::apt_update_last_success {
-        if ( $::apt_update_last_success + 0 < $weekly_threshold ) {
+      if $apt::apt_update_last_success {
+        if ( $apt::apt_update_last_success + 0 < $weekly_threshold ) {
           $_kick_apt = true
         } else {
           $_kick_apt = false
@@ -57,12 +57,12 @@ class apt::update {
     $_refresh = true
   }
   exec { 'apt_update':
-    command     => "${::apt::provider} update",
-    loglevel    => $::apt::_update['loglevel'],
+    command     => "${apt::provider} update",
+    loglevel    => $apt::_update['loglevel'],
     logoutput   => 'on_failure',
     refreshonly => $_refresh,
-    timeout     => $::apt::_update['timeout'],
-    tries       => $::apt::_update['tries'],
+    timeout     => $apt::_update['timeout'],
+    tries       => $apt::_update['tries'],
     try_sleep   => 1,
   }
 }

--- a/spec/classes/apt_update_spec.rb
+++ b/spec/classes/apt_update_spec.rb
@@ -9,7 +9,7 @@ describe 'apt::update', type: :class do
       'we are due for a run'                         => 1_406_660_561,
       'the update-success-stamp file does not exist' => -1,
     }.each_pair do |desc, factval|
-      context "when $::apt_update_last_success indicates #{desc}" do
+      context "when $apt_update_last_success indicates #{desc}" do
         let(:facts) do
           {
             os: {
@@ -24,7 +24,7 @@ describe 'apt::update', type: :class do
                 id: 'Debian',
               },
             },
-            apt_update_last_success: factval,
+            'apt::apt_update_last_success': factval,
           }
         end
         let(:pre_condition) do
@@ -37,7 +37,7 @@ describe 'apt::update', type: :class do
         end
       end
     end
-    context 'when $::apt_update_last_success is nil' do
+    context 'when $apt_update_last_success is nil' do
       let(:facts) do
         {
           os: {
@@ -76,7 +76,7 @@ describe 'apt::update', type: :class do
               id: 'Debian',
             },
           },
-          apt_update_last_success: Time.now.to_i,
+          'apt::apt_update_last_success': Time.now.to_i,
         }
       end
       let(:pre_condition) do
@@ -98,7 +98,7 @@ describe 'apt::update', type: :class do
       'we are due for a run'                         => 1_406_660_561,
       'the update-success-stamp file does not exist' => -1,
     }.each_pair do |desc, factval|
-      context "when $::apt_update_last_success indicates #{desc}" do
+      context "when $apt_update_last_success indicates #{desc}" do
         let(:facts) do
           {
             os: {
@@ -113,7 +113,7 @@ describe 'apt::update', type: :class do
                 id: 'Debian',
               },
             },
-            apt_update_last_success: factval,
+            'apt::apt_update_last_success': factval,
           }
         end
         let(:pre_condition) { "class{ '::apt': update => {'frequency' => 'reluctantly' },}" }
@@ -124,7 +124,7 @@ describe 'apt::update', type: :class do
         end
       end
     end
-    context 'when $::apt_update_last_success is nil' do
+    context 'when $apt_update_last_success is nil' do
       let(:facts) do
         {
           os: {
@@ -152,7 +152,7 @@ describe 'apt::update', type: :class do
   ['daily', 'weekly'].each do |update_frequency|
     context "when apt::update['frequency'] has the value of #{update_frequency}" do
       { 'we are due for a run' => 1_406_660_561, 'the update-success-stamp file does not exist' => -1 }.each_pair do |desc, factval|
-        context "when $::apt_update_last_success indicates #{desc}" do
+        context "when $apt_update_last_success indicates #{desc}" do
           let(:facts) do
             {
               os: {
@@ -167,7 +167,7 @@ describe 'apt::update', type: :class do
                   id: 'Debian',
                 },
               },
-              apt_update_last_success: factval,
+              'apt::apt_update_last_success': factval,
             }
           end
           let(:pre_condition) { "class{ '::apt': update => {'frequency' => '#{update_frequency}',} }" }
@@ -178,7 +178,7 @@ describe 'apt::update', type: :class do
           end
         end
       end
-      context 'when the $::apt_update_last_success fact has a recent value' do
+      context 'when the $apt_update_last_success fact has a recent value' do
         let(:facts) do
           {
             os: {
@@ -193,7 +193,7 @@ describe 'apt::update', type: :class do
                 id: 'Debian',
               },
             },
-            apt_update_last_success: Time.now.to_i,
+            'apt::apt_update_last_success': Time.now.to_i,
           }
         end
         let(:pre_condition) { "class{ '::apt': update => {'frequency' => '#{update_frequency}',} }" }
@@ -203,7 +203,7 @@ describe 'apt::update', type: :class do
           is_expected.to contain_exec('apt_update').with('refreshonly' => true)
         end
       end
-      context 'when $::apt_update_last_success is nil' do
+      context 'when $apt_update_last_success is nil' do
         let(:facts) do
           {
             os: {
@@ -218,7 +218,7 @@ describe 'apt::update', type: :class do
                 id: 'Debian',
               },
             },
-            apt_update_last_success: nil,
+            'apt::apt_update_last_success': nil,
           }
         end
         let(:pre_condition) { "class{ '::apt': update => {'frequency' => '#{update_frequency}',} }" }


### PR DESCRIPTION
Module is now in compliance with the following rules:
- optional_default
- strict_indent
- unquoted_string_in_case
- parameter_documentation
- relative_classname_inclusion
- no-top_scope_facts-check
- no-top_scope_variable-check
- variable_scope

The below exception has been left in place:
- disable_anchor_resource