### PR TITLE
(GH-1055) Fix hardcoded cache path

### DIFF
--- a/manifests/ppa.pp
+++ b/manifests/ppa.pp
@@ -67,8 +67,9 @@ define apt::ppa (
     $trusted_gpg_d_filename = "${dash_filename_no_specialchars}.gpg"
   }
 
-  # This is the location of our main exec script  
-  $script_path = "/opt/puppetlabs/puppet/cache/add-apt-repository-${dash_filename_no_specialchars}-${release}.sh"
+  # This is the location of our main exec script.
+  $cache_path = $facts['puppet_vardir']
+  $script_path = "${cache_path}/add-apt-repository-${dash_filename_no_specialchars}-${release}.sh"
 
   if $ensure == 'present' {
     if $package_manage {

--- a/spec/defines/ppa_spec.rb
+++ b/spec/defines/ppa_spec.rb
@@ -30,6 +30,7 @@ describe 'apt::ppa' do
             id: 'Ubuntu',
           },
         },
+        puppet_vardir: '/opt/puppetlabs/puppet/cache'
       }
     end
 
@@ -58,6 +59,7 @@ describe 'apt::ppa' do
             id: 'Ubuntu',
           },
         },
+        puppet_vardir: '/opt/puppetlabs/puppet/cache',
       }
     end
 
@@ -96,6 +98,7 @@ describe 'apt::ppa' do
             id: 'Ubuntu',
           },
         },
+        puppet_vardir: '/opt/puppetlabs/puppet/cache',
       }
     end
 
@@ -128,6 +131,7 @@ describe 'apt::ppa' do
             id: 'Ubuntu',
           },
         },
+        puppet_vardir: '/opt/puppetlabs/puppet/cache',
       }
     end
 
@@ -168,6 +172,7 @@ describe 'apt::ppa' do
             id: 'Ubuntu',
           },
         },
+        puppet_vardir: '/opt/puppetlabs/puppet/cache',
       }
     end
 
@@ -210,6 +215,7 @@ describe 'apt::ppa' do
             id: 'Ubuntu',
           },
         },
+        puppet_vardir: '/opt/puppetlabs/puppet/cache',
       }
     end
 
@@ -250,6 +256,7 @@ describe 'apt::ppa' do
             id: 'Ubuntu',
           },
         },
+        puppet_vardir: '/opt/puppetlabs/puppet/cache',
       }
     end
 
@@ -290,6 +297,7 @@ describe 'apt::ppa' do
             id: 'Ubuntu',
           },
         },
+        puppet_vardir: '/opt/puppetlabs/puppet/cache',
       }
     end
 
@@ -328,6 +336,7 @@ describe 'apt::ppa' do
             id: 'Ubuntu',
           },
         },
+        puppet_vardir: '/opt/puppetlabs/puppet/cache',
       }
     end
 


### PR DESCRIPTION
Prior to this PR the cache path used to create the script file resource was hardcoded to `/opt/puppetlabs/puppet/cache`.

This PR fixes that by using the `puppet_vardir` fact provided by stdlib so that we will always get the correct path for the OS that is executing the code.

Additionally, if for some reason the `puppet_vardir` fact is not available we will fall back to `tmp`.

Fixes #1055 