### PR TITLE
(GH-1057) Regex fix to allow dotted resources

### DIFF
--- a/manifests/ppa.pp
+++ b/manifests/ppa.pp
@@ -40,7 +40,7 @@ define apt::ppa (
   }
 
   # Validate the resource name
-  if $name !~ /^ppa:([a-zA-Z0-9\-_]+)\/([a-zA-z0-9\-_]+)$/ {
+  if $name !~ /^ppa:([a-zA-Z0-9\-_]+)\/([a-zA-z0-9\-_\.]+)$/ {
     fail("Invalid PPA name: ${name}")
   }
 

--- a/spec/defines/ppa_spec.rb
+++ b/spec/defines/ppa_spec.rb
@@ -43,6 +43,69 @@ describe 'apt::ppa' do
     }
   end
 
+  [
+    'ppa:foo/bar',
+    'ppa:foo/bar1.0',
+    'ppa:foo10/bar10',
+    'ppa:foo-/bar_',
+  ].each do |value|
+    describe 'valid resource names' do
+      let :facts do
+        {
+          os: {
+            family: 'Debian',
+            name: 'Ubuntu',
+            release: {
+              major: '18',
+              full: '18.04',
+            },
+            distro: {
+              codename: 'trusty',
+              id: 'Ubuntu',
+            },
+          },
+        }
+      end
+
+      let(:title) { value }
+
+      it { is_expected.not_to raise_error }
+      it { is_expected.to contain_exec("add-apt-repository-#{value}") }
+    end
+  end
+
+  [
+    'ppa:foo!/bar',
+    'ppa:foo/bar!',
+    'ppa:foo1.0/bar',
+    'ppa:foo/bar/foobar',
+    '|| ls -la ||',
+    '|| touch /tmp/foo.txt ||',
+  ].each do |value|
+    describe 'invalid resource names' do
+      let :facts do
+        {
+          os: {
+            family: 'Debian',
+            name: 'Ubuntu',
+            release: {
+              major: '18',
+              full: '18.04',
+            },
+            distro: {
+              codename: 'trusty',
+              id: 'Ubuntu',
+            },
+          },
+        }
+      end
+
+      let(:title) { value }
+
+      it { is_expected.to raise_error(Puppet::PreformattedError, %r{Invalid PPA name: #{value}}) }
+    end
+  end
+
   describe 'Ubuntu 15.10 sources.list filename' do
     let :facts do
       {


### PR DESCRIPTION
Prior to this commit, one of our recent module updates introduced a
regex validation step for the resource names in our ppa.pp manifest
which would raise an issue if a valid resource name contained a dot (.).

This commit aims to slightly adjust the regex validation so that it
allows for dotted resource names. This PR should fix issue #1057.