### PR TITLE
pdksync - (CONT-130) Dropping Support for Debian 9

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -17,7 +17,6 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "9",
         "10",
         "11"
       ]


### PR DESCRIPTION
Dropping Support for Debian 9
pdk version: `2.4.0` 
