### PR TITLE
Do not remove PPA sources.list.d files if purge is enabled

### DIFF
--- a/manifests/ppa.pp
+++ b/manifests/ppa.pp
@@ -114,7 +114,9 @@ define apt::ppa (
       }
     }
 
-    file { "${apt::sources_list_d}/${sources_list_d_filename}": }
+    file { "${apt::sources_list_d}/${sources_list_d_filename}":
+      require => Exec["add-apt-repository-${name}"],
+    }
   }
   else {
     tidy { "remove-apt-repository-script-${name}":

--- a/manifests/ppa.pp
+++ b/manifests/ppa.pp
@@ -111,12 +111,11 @@ define apt::ppa (
         logoutput   => 'on_failure',
         notify      => Class['apt::update'],
         require     => $_require,
+        before      => File["${apt::sources_list_d}/${sources_list_d_filename}"],
       }
     }
 
-    file { "${apt::sources_list_d}/${sources_list_d_filename}":
-      require => Exec["add-apt-repository-${name}"],
-    }
+    file { "${apt::sources_list_d}/${sources_list_d_filename}": }
   }
   else {
     tidy { "remove-apt-repository-script-${name}":

--- a/manifests/ppa.pp
+++ b/manifests/ppa.pp
@@ -113,6 +113,8 @@ define apt::ppa (
         require     => $_require,
       }
     }
+
+    file { "${apt::sources_list_d}/${sources_list_d_filename}": }
   }
   else {
     tidy { "remove-apt-repository-script-${name}":


### PR DESCRIPTION
As described in #1064, if enabling purge for sources.list.d, files created by add-apt-repository executed by `apt::ppa` are removed and re-added on the next Puppet run.

This PR should fix that issue by adding a file resource for the sources.list.d file created by add-apt-repository.