### PR TITLE
MODULES-10763 Only report apt-get update as a corrective change if /var/cache/apt/pkgcache.bin changes.

### DIFF
--- a/manifests/update.pp
+++ b/manifests/update.pp
@@ -61,10 +61,12 @@ class apt::update {
   # This ensures that Puppet does not report a change if the
   # update command had no effect. See MODULES-10763 for discussion.
   $apt_update_had_no_effect = epp(
-    'apt/update_had_no_effect.sh.epp',
-    'provider' => $apt::provider,
-    'timeout'  => $apt::_update['timeout'],
-    'tries'    => $apt::_update['tries'],
+    "${module_name}/update_had_no_effect.sh.epp",
+    {
+      'provider' => $apt::provider,
+      'timeout'  => $apt::_update['timeout'],
+      'tries'    => $apt::_update['tries'],
+    }
   )
   exec { 'apt_update':
     command     => "echo ${apt::provider} successfully updated the package cache.",

--- a/manifests/update.pp
+++ b/manifests/update.pp
@@ -56,13 +56,25 @@ class apt::update {
   } else {
     $_refresh = true
   }
+  # We perform the update in an `unless` clause of the exec, and
+  # return true only if the package cache file changed.
+  # This ensures that Puppet does not report a change if the
+  # update command had no effect. See MODULES-10763 for discussion.
+  $apt_update_had_no_effect = epp(
+    'apt/update_had_no_effect.sh.epp',
+    'provider' => $apt::provider,
+    'timeout'  => $apt::_update['timeout'],
+    'tries'    => $apt::_update['tries'],
+  )
   exec { 'apt_update':
-    command     => "${apt::provider} update",
+    command     => "echo ${apt::provider} successfully updated the package cache.",
     loglevel    => $apt::_update['loglevel'],
-    logoutput   => 'on_failure',
+    logoutput   => true,
+    provider    => shell,
     refreshonly => $_refresh,
     timeout     => $apt::_update['timeout'],
     tries       => $apt::_update['tries'],
     try_sleep   => 1,
+    unless      => $apt_update_had_no_effect,
   }
 }

--- a/templates/update_had_no_effect.sh.epp
+++ b/templates/update_had_no_effect.sh.epp
@@ -1,0 +1,51 @@
+<%- |
+  String  $provider = 'apt',
+  Integer $timeout = 300,
+  Integer $tries = 1,
+| -%>
+export PATH=/usr/bin:/bin:/usr/sbin:/sbin
+<%# Since `mktemp` might not be available, we choose a reasonable default. -%>
+TMPFILE="$(mktemp)" || TMPFILE=/tmp/.puppetlabs.apt.update_had_no_effect.sh
+<%# Try to prevent command injection by truncating immediately before using. -%>
+cat /dev/null > "$TMPFILE"
+<%# Retrieve the configured apt-cache directory. -%>
+apt-config shell DIR Dir::Cache > "$TMPFILE" && . "$TMPFILE"
+<%# Set a reasonable default in case `apt-config shell` didn't work. -%>
+[ "$DIR" ] || DIR='var/cache/apt'
+<%# Early exit if the cache directory doesn't exist. -%>
+cd "/$DIR" || exit 0
+<%# Try to prevent command injection by truncating immediately before using. -%>
+cat /dev/null > "$TMPFILE"
+<%# Retrieve the configured cache filename. -%>
+apt-config shell CUR DIR::Cache::pkgcache >"$TMPFILE" && . "$TMPFILE"
+<%# Set a reasonable default in case `apt-config shell` didn't work. -%>
+[ "$CUR" ] || CUR=pkgcache.bin
+<%# If the cache file doesn't exist, create it as an empty file. -%>
+[ -e "$CUR" ] || cat /dev/null > "$CUR"
+<%# Copy the cache file contents so we can detect changes. -%>
+cat "$CUR" > "$TMPFILE"
+<%# Loop for the configured number of tries. -%>
+TRIES=<%= $tries %>
+while true; do
+<%# Use the `timeout` command from GNU coretools if available. -%>
+  if timeout 1 true; then
+    timeout <%= $timeout %> <%= $provider %> update && break
+  else
+    <%= $provider %> update && break
+  fi
+<%# Exit if the number of configured tries has been reached. -%>
+  [ $TRIES -le 1 ] && break
+<%# Emulate `try_sleep => 1` from the original `exec` resource -%>
+  sleep 1
+<%# Decrement the loop count -%>
+  TRIES=$(( TRIES - 1 ))
+done
+<%# Set the exit code to failure (1) presuming a change occurred. -%>
+EXITCODE=1
+<%# Guard against a missing package cache file. -%>
+[ -e "$CUR" ] || cat /dev/null > "$CUR"
+<%# Set the exit code to success (0) if no change occurred. -%>
+cmp "$CUR" "$TMPFILE" && EXITCODE=0
+<%# Clean up -%>
+rm -f "$TMPFILE"
+exit $EXITCODE


### PR DESCRIPTION
Instead of running `apt-get update` as an exec directly, we run it as the `unless` attribute of an exec.

After running `apt-get update`, if the content of `/var/cache/apt/pkgcache.bin` is unchanged, the exec does not run, and reports no change.

If the content of `/var/cache/apt/pkgcache.bin` changes, the exec runs and reports a corrective change.

This resolves [MODULES-10763](https://tickets.puppetlabs.com/browse/MODULES-10763).