### PR TITLE
(GH-1518) - Declare minimum Puppet version 6.24.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -33,7 +33,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 6.0.0 < 8.0.0"
+      "version_requirement": ">= 6.24.0 < 8.0.0"
     }
   ],
   "template-url": "https://github.com/puppetlabs/pdk-templates.git#main",


### PR DESCRIPTION
In codebase hardening efforts the commands are passed as an array, but this feature was only introduced in Puppet 6.24.0[1]. This raises the minimum version to match, since it's no longer possible to use the module on anything older.

[1]: https://puppet.com/docs/puppet/6/release_notes_puppet.html#enhancements_puppet_x-7-9-0-PUP-5704