### PR TITLE
fix: remove `apt::` prefix from fact variables

### DIFF
--- a/manifests/update.pp
+++ b/manifests/update.pp
@@ -5,7 +5,7 @@
 class apt::update {
   assert_private()
 
-  #TODO: to catch if $apt_update_last_success has the value of -1 here. If we
+  #TODO: to catch if apt_update_last_success has the value of -1 here. If we
   #opt to do this, a info/warn would likely be all you'd need likely to happen
   #on the first run, but if it's not run in awhile something is likely borked
   #with apt and we'd want to know about it.
@@ -18,8 +18,8 @@ class apt::update {
       #compare current date with the apt_update_last_success fact to determine
       #if we should kick apt_update.
       $daily_threshold = (Integer(Timestamp().strftime('%s')) - 86400)
-      if $apt::apt_update_last_success {
-        if $apt::apt_update_last_success + 0 < $daily_threshold {
+      if $facts['apt_update_last_success'] {
+        if $facts['apt_update_last_success'] + 0 < $daily_threshold {
           $_kick_apt = true
         } else {
           $_kick_apt = false
@@ -33,8 +33,8 @@ class apt::update {
       #compare current date with the apt_update_last_success fact to determine
       #if we should kick apt_update.
       $weekly_threshold = (Integer(Timestamp().strftime('%s')) - 604800)
-      if $apt::apt_update_last_success {
-        if ( $apt::apt_update_last_success + 0 < $weekly_threshold ) {
+      if $facts['apt_update_last_success'] {
+        if $facts['apt_update_last_success'] + 0 < $weekly_threshold {
           $_kick_apt = true
         } else {
           $_kick_apt = false

--- a/spec/classes/apt_update_spec.rb
+++ b/spec/classes/apt_update_spec.rb
@@ -24,7 +24,7 @@ describe 'apt::update', type: :class do
                 id: 'Debian',
               },
             },
-            'apt::apt_update_last_success': factval,
+            'apt_update_last_success': factval,
           }
         end
         let(:pre_condition) do
@@ -76,7 +76,7 @@ describe 'apt::update', type: :class do
               id: 'Debian',
             },
           },
-          'apt::apt_update_last_success': Time.now.to_i,
+          'apt_update_last_success': Time.now.to_i,
         }
       end
       let(:pre_condition) do
@@ -113,7 +113,7 @@ describe 'apt::update', type: :class do
                 id: 'Debian',
               },
             },
-            'apt::apt_update_last_success': factval,
+            'apt_update_last_success': factval,
           }
         end
         let(:pre_condition) { "class{ '::apt': update => {'frequency' => 'reluctantly' },}" }
@@ -167,7 +167,7 @@ describe 'apt::update', type: :class do
                   id: 'Debian',
                 },
               },
-              'apt::apt_update_last_success': factval,
+              'apt_update_last_success': factval,
             }
           end
           let(:pre_condition) { "class{ '::apt': update => {'frequency' => '#{update_frequency}',} }" }
@@ -193,7 +193,7 @@ describe 'apt::update', type: :class do
                 id: 'Debian',
               },
             },
-            'apt::apt_update_last_success': Time.now.to_i,
+            'apt_update_last_success': Time.now.to_i,
           }
         end
         let(:pre_condition) { "class{ '::apt': update => {'frequency' => '#{update_frequency}',} }" }
@@ -218,7 +218,7 @@ describe 'apt::update', type: :class do
                 id: 'Debian',
               },
             },
-            'apt::apt_update_last_success': nil,
+            'apt_update_last_success': nil,
           }
         end
         let(:pre_condition) { "class{ '::apt': update => {'frequency' => '#{update_frequency}',} }" }


### PR DESCRIPTION
Fact variables are top-scopped and should not be prefixed by module name.

This bug was introduced by cb6e58cedbd6d7a9bfc63c97c83d51eb39e9c7dc.