### PR TITLE
(CONT-493) PPA validation adjustment

### DIFF
--- a/manifests/ppa.pp
+++ b/manifests/ppa.pp
@@ -40,7 +40,7 @@ define apt::ppa (
   }
 
   # Validate the resource name
-  if $name !~ /^ppa:([a-zA-Z0-9\-_]+)\/([a-zA-z0-9\-_\.]+)$/ {
+  if $name !~ /^ppa:([a-zA-Z0-9\-_.]+)\/([a-zA-z0-9\-_\.]+)$/ {
     fail("Invalid PPA name: ${name}")
   }
 

--- a/spec/defines/ppa_spec.rb
+++ b/spec/defines/ppa_spec.rb
@@ -78,7 +78,7 @@ describe 'apt::ppa' do
   [
     'ppa:foo!/bar',
     'ppa:foo/bar!',
-    'ppa:foo1.0/bar',
+    'ppa:foo1,0/bar',
     'ppa:foo/bar/foobar',
     '|| ls -la ||',
     '|| touch /tmp/foo.txt ||',


### PR DESCRIPTION
Prior to this commit, one of our updates (https://github.com/puppetlabs/puppetlabs-apt/pull/1052) implemented a regex validation for ppa packages that were to be installed. However, this validation did not account for resource names that were dotted.

This commit aims to fix this bug in our validation process so that it works as intended. This PR should fix https://github.com/puppetlabs/puppetlabs-apt/issues/1084.