### PR TITLE
Adopt new parameter defaults in template

### DIFF
--- a/templates/pin.pref.epp
+++ b/templates/pin.pref.epp
@@ -3,12 +3,12 @@
 $pin =
 if $pin_release != '' {
   $options = [
-    if $release != ''         { "a=${release}" },
-    if $codename != ''        { "n=${codename}" },
-    if $release_version != '' { "v=${release_version}"},
-    if $component != ''       { "c=${component}" },
-    if $originator != ''      { "o=${originator}" },
-    if $label != ''           { "l=${label}" },
+    unless $release =~ Undef         { "a=${release}" },
+    unless $codename =~ Undef        { "n=${codename}" },
+    unless $release_version =~ Undef { "v=${release_version}"},
+    unless $component =~ Undef       { "c=${component}" },
+    unless $originator =~ Undef      { "o=${originator}" },
+    unless $label =~ Undef           { "l=${label}" },
     ].filter |$x| { $x != undef }
    "release ${options.join(', ')}" }
 


### PR DESCRIPTION
the apt::pin define has switched from empty string to Undef. But the template was not updated.

fixes #1089