### PR TITLE
Allow setting keyserver options (like proxy) when using source

### DIFF
--- a/lib/puppet/provider/apt_key/apt_key.rb
+++ b/lib/puppet/provider/apt_key/apt_key.rb
@@ -205,6 +205,9 @@ Puppet::Type.type(:apt_key).provide(:apt_key) do
     elsif resource[:source]
       key_file = source_to_file(resource[:source])
       command.push('add', key_file.path)
+      unless resource[:options].nil?
+        command.push('--keyserver-options', resource[:options])
+      end
     # In case we really screwed up, better safe than sorry.
     else
       raise(_('an unexpected condition occurred while trying to add the key: %{_resource}') % { _resource: resource[:id] })


### PR DESCRIPTION
fixes #1102