### PR TITLE
Require stdlib 9.0.0 or newer

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.16.0 < 10.0.0"
+      "version_requirement": ">= 9.0.0 < 10.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Since c0b8640fc6a7c3381877863960e02da3fa1fe640, we use the namespaced version of `stdlib::ensure_packages`, which appeared in version 9.0.0 of the stdlib module.

Adjust the version requirement accordingly.
