### PR TITLE
Add apt::keyring defined type

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,23 @@ include apt
 <a id="add-gpg-keys"></a>
 
 ### Add GPG keys
+You can fetch GPG keys via HTTP, Puppet URI, or local filesystem. The key must be in binary format for apt to read it properly.
+
+#### Fetch via HTTP
+```puppet
+apt::keyring {'puppetlabs-keyring.gpg':
+  source => 'https://apt.puppetlabs.com/keyring.gpg',
+}
+```
+#### Fetch via Puppet URI
+```puppet
+apt::keyring {'puppetlabs-keyring.gpg':
+  source => 'puppet:///modules/my_module/local_puppetlabs-keyring.gpg',
+}
+```
+Alternatively `apt::key` can be used.
+
+**Warning** `apt::key` is deprecated in the latest Debian and Ubuntu releases. Please use apt::keyring instead.
 
 **Warning:** Using short key IDs presents a serious security issue, potentially leaving you open to collision attacks. We recommend you always use full fingerprints to identify your GPG keys. This module allows short keys, but issues a security warning if you use them.
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -88,6 +88,9 @@
 # @param keys
 #   Creates new `apt::key` resources. Valid options: a hash to be passed to the create_resources function linked above.
 #
+# @param keyrings
+#   Creates new `apt::keyring` resources. Valid options: a hash to be passed to the create_resources function linked above.
+#
 # @param ppas
 #   Creates new `apt::ppa` resources. Valid options: a hash to be passed to the create_resources function linked above.
 #
@@ -159,6 +162,7 @@ class apt (
   Apt::Proxy $proxy                               = $apt::params::proxy,
   Hash $sources                                   = $apt::params::sources,
   Hash $keys                                      = $apt::params::keys,
+  Hash $keyrings                                  = $apt::params::keyrings,
   Hash $ppas                                      = $apt::params::ppas,
   Hash $pins                                      = $apt::params::pins,
   Hash $settings                                  = $apt::params::settings,
@@ -346,6 +350,10 @@ class apt (
   # manage keys if present
   if $keys {
     create_resources('apt::key', $keys)
+  }
+  # manage keyrings if present
+  if $keyrings {
+    create_resources('apt::keyring', $keyrings)
   }
   # manage ppas if present
   if $ppas {

--- a/manifests/keyring.pp
+++ b/manifests/keyring.pp
@@ -42,7 +42,7 @@ define apt::keyring (
 ) {
   ensure_resource('file', $keyring_dir, { ensure => 'directory', mode => '0755', })
   if $source and $content {
-    fail("Parameters \'source\' and \'content\' are mutualy exclusive")
+    fail("Parameters 'source' and 'content' are mutually exclusive")
   }
   case $ensure {
     'present': {
@@ -59,7 +59,7 @@ define apt::keyring (
       }
     }
     default: {
-      fail("Invalid \'ensure\' value \'${ensure}\' for apt::keyring")
+      fail("Invalid 'ensure' value '${ensure}' for apt::keyring")
     }
   }
 }

--- a/manifests/keyring.pp
+++ b/manifests/keyring.pp
@@ -1,0 +1,65 @@
+# @summary Manage GPG keyrings for apt repositories
+#
+# @example Install the puppetlabs apt source with keyring.
+#     apt::source { 'puppet7-release':
+#       location => 'http://apt.puppetlabs.com',
+#       repos    => 'main',
+#       keyring  => '/etc/apt/keyrings/puppetlabs-keyring.gpg',
+#     }
+#     apt::keyring {'puppetlabs-keyring.gpg':
+#       source => 'https://apt.puppetlabs.com/keyring.gpg',
+#     }
+#
+# @param keyring_dir
+#   Path to the directory where the keyring will be stored.
+#
+# @param keyring_filename
+#   Optional filename for the keyring.
+#
+# @param keyring_file
+#   File path of the keyring.
+#
+# @param keyring_file_mode
+#   File permissions of the keyring.
+#
+# @param source
+#   Source of the keyring file. Mutually exclusive with 'content'.
+#
+# @param content
+#   Content of the keyring file. Mutually exclusive with 'source'.
+#
+# @param ensure
+#   Ensure presence or absence of the resource.
+#
+define apt::keyring (
+  Stdlib::Absolutepath $keyring_dir = '/etc/apt/keyrings',
+  Optional[String] $keyring_filename = $name,
+  Stdlib::Absolutepath $keyring_file = "${keyring_dir}/${keyring_filename}",
+  String  $keyring_file_mode = '0644',
+  Optional[Stdlib::Filesource] $source = undef,
+  Optional[String] $content = undef,
+  Enum['present','absent'] $ensure = 'present',
+) {
+  ensure_resource('file', $keyring_dir, { ensure => 'directory', mode => '0755', })
+  if $source and $content {
+    fail("Parameters \'source\' and \'content\' are mutualy exclusive")
+  }
+  case $ensure {
+    'present': {
+      file { $keyring_file:
+        ensure  => 'file',
+        mode    => $keyring_file_mode,
+        source  => $source,
+        content => $content,
+      }
+    }
+    'absent': {
+      file { $keyring_file:
+        ensure => $ensure,
+      }
+    }
+    default: {
+      fail("Invalid \'ensure\' value \'${ensure}\' for apt::keyring")
+    }
+  }
+}

--- a/manifests/keyring.pp
+++ b/manifests/keyring.pp
@@ -43,6 +43,8 @@ define apt::keyring (
   ensure_resource('file', $keyring_dir, { ensure => 'directory', mode => '0755', })
   if $source and $content {
     fail("Parameters 'source' and 'content' are mutually exclusive")
+  } elsif ! $source and ! $content {
+    fail("One of 'source' or 'content' parameters are required")
   }
   case $ensure {
     'present': {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -25,6 +25,7 @@ class apt::params {
   $proxy                = {}
   $sources              = {}
   $keys                 = {}
+  $keyrings             = {}
   $ppas                 = {}
   $pins                 = {}
   $settings             = {}

--- a/spec/defines/keyring_spec.rb
+++ b/spec/defines/keyring_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'apt::keyring' do
+  let(:title) { 'namevar' }
+  let(:params) do
+    {}
+  end
+
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it { is_expected.to compile }
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Add a new defined type for adding GPG keyrings.

## Additional Context
apt-key is deprecated in the latest Debian and Ubuntu releases. Therefore we should move away from the old `apt::key` defined type which relies on it.
With this we can manage apt keyrings directly with the apt module. Further work would be required to integrate this directly into the `apt::source` like how `apt::key` is currently.
Reference - https://wiki.debian.org/DebianRepository/UseThirdParty

## Related Issues (if any)
#1034

## Checklist
- [x] 🟢 Spec tests - I don't have much experience with this, so I've simply generated the bare-minumum one with pdk.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)