### PR TITLE
replace stdlib::ensure_packages with package

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -382,12 +382,16 @@ class apt (
   case $facts['os']['name'] {
     'Debian': {
       if versioncmp($facts['os']['release']['major'], '9') >= 0 {
-        stdlib::ensure_packages(['gnupg'])
+        package { 'gnupg':
+          ensure => 'installed',
+        }
       }
     }
     'Ubuntu': {
       if versioncmp($facts['os']['release']['full'], '17.04') >= 0 {
-        stdlib::ensure_packages(['gnupg'])
+        package { 'gnupg':
+          ensure => 'installed',
+        }
       }
     }
     default: {

--- a/manifests/key.pp
+++ b/manifests/key.pp
@@ -65,13 +65,17 @@ define apt::key (
         case $facts['os']['name'] {
           'Debian': {
             if versioncmp($facts['os']['release']['major'], '9') >= 0 {
-              stdlib::ensure_packages(['gnupg'])
+              package { 'gnupg':
+                ensure => 'installed',
+              }
               Apt::Key<| title == $title |>
             }
           }
           'Ubuntu': {
             if versioncmp($facts['os']['release']['full'], '17.04') >= 0 {
-              stdlib::ensure_packages(['gnupg'])
+              package { 'gnupg':
+                ensure => 'installed',
+              }
               Apt::Key<| title == $title |>
             }
           }

--- a/manifests/ppa.pp
+++ b/manifests/ppa.pp
@@ -73,7 +73,9 @@ define apt::ppa (
 
   if $ensure == 'present' {
     if $package_manage {
-      stdlib::ensure_packages($package_name)
+      package { $package_manage:
+        ensure => installed,
+      }
       $_require = [File['sources.list.d'], Package[$package_name]]
     } else {
       $_require = File['sources.list.d']

--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -107,7 +107,9 @@ define apt::source (
     # Newer oses, do not need the package for HTTPS transport.
     $_transport_https_releases = ['9']
     if (fact('os.release.major') in $_transport_https_releases) and $_location =~ /(?i:^https:\/\/)/ {
-      stdlib::ensure_packages('apt-transport-https')
+      package { 'apt-transport-https':
+        ensure => 'installed',
+      }
       Package['apt-transport-https'] -> Class['apt::update']
     }
   } else {

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 9.0.0 < 10.0.0"
+      "version_requirement": ">= 4.16.0 < 10.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
- as a result, we no longer need to rely exclusively on stdlib 9.0.0+

## Summary
If possible, `puppetlabs-apt` should _allow_ stdlib 9.0.0+ and *not* _require_ it, @smortex.