### PR TITLE
Add support for modern keyrings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ group :development do
   gem "voxpupuli-puppet-lint-plugins", '~> 4.0', require: false
   gem "facterdb", '~> 1.18',                     require: false
   gem "metadata-json-lint", '~> 3.0',            require: false
-  gem "puppetlabs_spec_helper", '~> 6.0',        require: false
+  gem "puppetlabs_spec_helper", '~> 7.0',        require: false
   gem "rspec-puppet-facts", '~> 2.0',            require: false
   gem "codecov", '~> 0.2',                       require: false
   gem "dependency_checker", '~> 1.0.0',          require: false

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ You can fetch GPG keys via HTTP, Puppet URI, or local filesystem. The key can be
 
 #### Fetch via HTTP
 ```puppet
-apt::keyring {'puppetlabs-keyring.gpg':
+apt::keyring { 'puppetlabs-keyring.gpg':
   source => 'https://apt.puppetlabs.com/keyring.gpg',
 }
 ```

--- a/README.md
+++ b/README.md
@@ -65,6 +65,25 @@ include apt
 <a id="add-gpg-keys"></a>
 
 ### Add GPG keys
+You can fetch GPG keys via HTTP, Puppet URI, or local filesystem. The key can be in GPG binary format, or ASCII armored, but the filename should have the appropriate extension (`.gpg` or `.asc`)
+
+#### Fetch via HTTP
+```puppet
+apt::keyring {'puppetlabs-keyring.gpg':
+  source => 'https://apt.puppetlabs.com/keyring.gpg',
+}
+```
+
+#### Fetch via Puppet URI
+```puppet
+apt::keyring {'puppetlabs-keyring.gpg':
+  source => 'puppet:///modules/my_module/local_puppetlabs-keyring.gpg',
+}
+```
+
+Alternatively `apt::key` can be used.
+
+**Warning** `apt::key` is deprecated in the latest Debian and Ubuntu releases. Please use apt::keyring instead.
 
 **Warning:** Using short key IDs presents a serious security issue, potentially leaving you open to collision attacks. We recommend you always use full fingerprints to identify your GPG keys. This module allows short keys, but issues a security warning if you use them.
 
@@ -180,6 +199,22 @@ apt::source { 'puppetlabs':
   key      => {
     'id'     => '6F6B15509CF8E59E6E469F327F438280EF8D349F',
     'server' => 'pgp.mit.edu',
+  },
+}
+```
+
+### Adding name and source to the key parameter of apt::source, which then manages modern apt gpg keyrings
+
+The name parameter of key hash should contain name with extensions (such as puppetlabs.gpg), Absence of extension will result in creation of file with just name and no extension.
+
+```puppet
+apt::source { 'puppetlabs':
+  comment  => 'Puppet8',
+  location => 'https://apt.puppetlabs.com/',
+  repos    => 'puppet8',
+  key      => {
+    'name'   => 'puppetlabs.gpg',
+    'source' => 'https://apt.puppetlabs.com/keyring.gpg',
   },
 }
 ```

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ apt::keyring {'puppetlabs-keyring.gpg':
 
 #### Fetch via Puppet URI
 ```puppet
-apt::keyring {'puppetlabs-keyring.gpg':
+apt::keyring { 'puppetlabs-keyring.gpg':
   source => 'puppet:///modules/my_module/local_puppetlabs-keyring.gpg',
 }
 ```

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ include apt
 You can fetch GPG keys via HTTP, Puppet URI, or local filesystem. The key can be in GPG binary format, or ASCII armored, but the filename should have the appropriate extension (`.gpg` or `.asc`).
 
 #### Fetch via HTTP
+
 ```puppet
 apt::keyring { 'puppetlabs-keyring.gpg':
   source => 'https://apt.puppetlabs.com/keyring.gpg',

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ apt::source { 'puppetlabs':
 
 ### Adding name and source to the key parameter of apt::source, which then manages modern apt gpg keyrings
 
-The name parameter of key hash should contain name with extensions (such as puppetlabs.gpg), Absence of extension will result in creation of file with just name and no extension.
+The `name` parameter of key hash should contain the filename with extension (such as `puppetlabs.gpg`).
 
 ```puppet
 apt::source { 'puppetlabs':

--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ include apt
 <a id="add-gpg-keys"></a>
 
 ### Add GPG keys
-You can fetch GPG keys via HTTP, Puppet URI, or local filesystem. The key can be in GPG binary format, or ASCII armored, but the filename should have the appropriate extension (`.gpg` or `.asc`)
+
+You can fetch GPG keys via HTTP, Puppet URI, or local filesystem. The key can be in GPG binary format, or ASCII armored, but the filename should have the appropriate extension (`.gpg` or `.asc`).
 
 #### Fetch via HTTP
 ```puppet

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ apt::keyring { 'puppetlabs-keyring.gpg':
 ```
 
 #### Fetch via Puppet URI
+
 ```puppet
 apt::keyring { 'puppetlabs-keyring.gpg':
   source => 'puppet:///modules/my_module/local_puppetlabs-keyring.gpg',

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ include apt
 
 ### Add GPG keys
 
-You can fetch GPG keys via HTTP, Puppet URI, or local filesystem. The key can be in GPG binary format, or ASCII armored, but the filename should have the appropriate extension (`.gpg` or `.asc`).
+You can fetch GPG keys via HTTP, Puppet URI, or local filesystem. The key can be in GPG binary format, or ASCII armored, but the filename should have the appropriate extension (`.gpg` for keys in binary format; or `.asc` for ASCII armored keys).
 
 #### Fetch via HTTP
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -9,7 +9,7 @@
 #### Public Classes
 
 * [`apt`](#apt): Main class, includes all other classes.
-* [`apt::backports`](#aptbackports): Manages backports.
+* [`apt::backports`](#apt--backports): Manages backports.
 
 #### Private Classes
 
@@ -18,19 +18,16 @@
 
 ### Defined types
 
-* [`apt::conf`](#aptconf): Specifies a custom Apt configuration file.
-* [`apt::key`](#aptkey): Manages the GPG keys that Apt uses to authenticate packages.
-* [`apt::keyring`](#aptkeyring): Manage GPG keyrings for apt repositories
-* [`apt::mark`](#aptmark): Manages apt-mark settings
-* [`apt::pin`](#aptpin): Manages Apt pins. Does not trigger an apt-get update run.
-* [`apt::ppa`](#aptppa): Manages PPA repositories using `add-apt-repository`. Not supported on Debian.
-* [`apt::setting`](#aptsetting): Manages Apt configuration files.
-* [`apt::source`](#aptsource): Manages the Apt sources in /etc/apt/sources.list.d/.
+* [`apt::conf`](#apt--conf): Specifies a custom Apt configuration file.
+* [`apt::key`](#apt--key): Manages the GPG keys that Apt uses to authenticate packages.
+* [`apt::keyring`](#apt--keyring): Manage GPG keyrings for apt repositories
+* [`apt::mark`](#apt--mark): Manages apt-mark settings
+* [`apt::pin`](#apt--pin): Manages Apt pins. Does not trigger an apt-get update run.
+* [`apt::ppa`](#apt--ppa): Manages PPA repositories using `add-apt-repository`. Not supported on Debian.
+* [`apt::setting`](#apt--setting): Manages Apt configuration files.
+* [`apt::source`](#apt--source): Manages the Apt sources in /etc/apt/sources.list.d/.
 
 ### Resource types
-
-#### Public Resource types
-
 
 #### Private Resource types
 
@@ -40,9 +37,9 @@ be manipulated through the `apt-key` command.
 
 ### Data types
 
-* [`Apt::Auth_conf_entry`](#aptauth_conf_entry): Login configuration settings that are recorded in the file `/etc/apt/auth.conf`.
-* [`Apt::Proxy`](#aptproxy): Configures Apt to connect to a proxy server.
-* [`Apt::Proxy_Per_Host`](#aptproxy_per_host): Adds per-host overrides to the system default APT proxy configuration
+* [`Apt::Auth_conf_entry`](#Apt--Auth_conf_entry): Login configuration settings that are recorded in the file `/etc/apt/auth.conf`.
+* [`Apt::Proxy`](#Apt--Proxy): Configures Apt to connect to a proxy server.
+* [`Apt::Proxy_Per_Host`](#Apt--Proxy_Per_Host): Adds per-host overrides to the system default APT proxy configuration
 
 ### Tasks
 
@@ -62,41 +59,41 @@ Main class, includes all other classes.
 
 The following parameters are available in the `apt` class:
 
-* [`provider`](#provider)
-* [`keyserver`](#keyserver)
-* [`key_options`](#key_options)
-* [`ppa_options`](#ppa_options)
-* [`ppa_package`](#ppa_package)
-* [`backports`](#backports)
-* [`confs`](#confs)
-* [`update`](#update)
-* [`update_defaults`](#update_defaults)
-* [`purge`](#purge)
-* [`purge_defaults`](#purge_defaults)
-* [`proxy`](#proxy)
-* [`proxy_defaults`](#proxy_defaults)
-* [`sources`](#sources)
-* [`keys`](#keys)
-* [`keyrings`](#keyrings)
-* [`ppas`](#ppas)
-* [`pins`](#pins)
-* [`settings`](#settings)
-* [`manage_auth_conf`](#manage_auth_conf)
-* [`auth_conf_entries`](#auth_conf_entries)
-* [`auth_conf_owner`](#auth_conf_owner)
-* [`root`](#root)
-* [`sources_list`](#sources_list)
-* [`sources_list_d`](#sources_list_d)
-* [`conf_d`](#conf_d)
-* [`preferences`](#preferences)
-* [`preferences_d`](#preferences_d)
-* [`config_files`](#config_files)
-* [`sources_list_force`](#sources_list_force)
-* [`include_defaults`](#include_defaults)
-* [`apt_conf_d`](#apt_conf_d)
-* [`source_key_defaults`](#source_key_defaults)
+* [`provider`](#-apt--provider)
+* [`keyserver`](#-apt--keyserver)
+* [`key_options`](#-apt--key_options)
+* [`ppa_options`](#-apt--ppa_options)
+* [`ppa_package`](#-apt--ppa_package)
+* [`backports`](#-apt--backports)
+* [`confs`](#-apt--confs)
+* [`update`](#-apt--update)
+* [`update_defaults`](#-apt--update_defaults)
+* [`purge`](#-apt--purge)
+* [`purge_defaults`](#-apt--purge_defaults)
+* [`proxy`](#-apt--proxy)
+* [`proxy_defaults`](#-apt--proxy_defaults)
+* [`sources`](#-apt--sources)
+* [`keys`](#-apt--keys)
+* [`keyrings`](#-apt--keyrings)
+* [`ppas`](#-apt--ppas)
+* [`pins`](#-apt--pins)
+* [`settings`](#-apt--settings)
+* [`manage_auth_conf`](#-apt--manage_auth_conf)
+* [`auth_conf_entries`](#-apt--auth_conf_entries)
+* [`auth_conf_owner`](#-apt--auth_conf_owner)
+* [`root`](#-apt--root)
+* [`sources_list`](#-apt--sources_list)
+* [`sources_list_d`](#-apt--sources_list_d)
+* [`conf_d`](#-apt--conf_d)
+* [`preferences`](#-apt--preferences)
+* [`preferences_d`](#-apt--preferences_d)
+* [`config_files`](#-apt--config_files)
+* [`sources_list_force`](#-apt--sources_list_force)
+* [`include_defaults`](#-apt--include_defaults)
+* [`apt_conf_d`](#-apt--apt_conf_d)
+* [`source_key_defaults`](#-apt--source_key_defaults)
 
-##### <a name="provider"></a>`provider`
+##### <a name="-apt--provider"></a>`provider`
 
 Data type: `String`
 
@@ -104,7 +101,7 @@ Specifies the provider that should be used by apt::update.
 
 Default value: `$apt::params::provider`
 
-##### <a name="keyserver"></a>`keyserver`
+##### <a name="-apt--keyserver"></a>`keyserver`
 
 Data type: `String`
 
@@ -113,7 +110,7 @@ hkp://).
 
 Default value: `$apt::params::keyserver`
 
-##### <a name="key_options"></a>`key_options`
+##### <a name="-apt--key_options"></a>`key_options`
 
 Data type: `Optional[String]`
 
@@ -121,7 +118,7 @@ Specifies the default options for apt::key resources.
 
 Default value: `$apt::params::key_options`
 
-##### <a name="ppa_options"></a>`ppa_options`
+##### <a name="-apt--ppa_options"></a>`ppa_options`
 
 Data type: `Optional[Array[String]]`
 
@@ -129,7 +126,7 @@ Supplies options to be passed to the `add-apt-repository` command.
 
 Default value: `$apt::params::ppa_options`
 
-##### <a name="ppa_package"></a>`ppa_package`
+##### <a name="-apt--ppa_package"></a>`ppa_package`
 
 Data type: `Optional[String]`
 
@@ -137,7 +134,7 @@ Names the package that provides the `apt-add-repository` command.
 
 Default value: `$apt::params::ppa_package`
 
-##### <a name="backports"></a>`backports`
+##### <a name="-apt--backports"></a>`backports`
 
 Data type: `Optional[Hash]`
 
@@ -151,7 +148,7 @@ Options:
 
 Default value: `$apt::params::backports`
 
-##### <a name="confs"></a>`confs`
+##### <a name="-apt--confs"></a>`confs`
 
 Data type: `Hash`
 
@@ -159,7 +156,7 @@ Creates new `apt::conf` resources. Valid options: a hash to be passed to the cre
 
 Default value: `$apt::params::confs`
 
-##### <a name="update"></a>`update`
+##### <a name="-apt--update"></a>`update`
 
 Data type: `Hash`
 
@@ -181,7 +178,7 @@ Default: 'reluctantly'.
 
 Default value: `$apt::params::update`
 
-##### <a name="update_defaults"></a>`update_defaults`
+##### <a name="-apt--update_defaults"></a>`update_defaults`
 
 Data type: `Hash`
 
@@ -189,7 +186,7 @@ The default update settings that are combined and merged with the passed `update
 
 Default value: `$apt::params::update_defaults`
 
-##### <a name="purge"></a>`purge`
+##### <a name="-apt--purge"></a>`purge`
 
 Data type: `Hash`
 
@@ -204,7 +201,7 @@ Options:
 
 Default value: `$apt::params::purge`
 
-##### <a name="purge_defaults"></a>`purge_defaults`
+##### <a name="-apt--purge_defaults"></a>`purge_defaults`
 
 Data type: `Hash`
 
@@ -212,7 +209,7 @@ The default purge settings that are combined and merged with the passed `purge` 
 
 Default value: `$apt::params::purge_defaults`
 
-##### <a name="proxy"></a>`proxy`
+##### <a name="-apt--proxy"></a>`proxy`
 
 Data type: `Apt::Proxy`
 
@@ -220,7 +217,7 @@ Configures Apt to connect to a proxy server. Valid options: a hash matching the 
 
 Default value: `$apt::params::proxy`
 
-##### <a name="proxy_defaults"></a>`proxy_defaults`
+##### <a name="-apt--proxy_defaults"></a>`proxy_defaults`
 
 Data type: `Hash`
 
@@ -228,7 +225,7 @@ The default proxy settings that are combined and merged with the passed `proxy` 
 
 Default value: `$apt::params::proxy_defaults`
 
-##### <a name="sources"></a>`sources`
+##### <a name="-apt--sources"></a>`sources`
 
 Data type: `Hash`
 
@@ -236,7 +233,7 @@ Creates new `apt::source` resources. Valid options: a hash to be passed to the c
 
 Default value: `$apt::params::sources`
 
-##### <a name="keys"></a>`keys`
+##### <a name="-apt--keys"></a>`keys`
 
 Data type: `Hash`
 
@@ -244,15 +241,15 @@ Creates new `apt::key` resources. Valid options: a hash to be passed to the crea
 
 Default value: `$apt::params::keys`
 
-##### <a name="keyrings"></a>`keyrings`
+##### <a name="-apt--keyrings"></a>`keyrings`
 
 Data type: `Hash`
 
-Creates new `apt::keyring` resources. Valid options: a hash to be passed to the create_resources function linked above.
+Hash of `apt::keyring` resources.
 
 Default value: `{}`
 
-##### <a name="ppas"></a>`ppas`
+##### <a name="-apt--ppas"></a>`ppas`
 
 Data type: `Hash`
 
@@ -260,7 +257,7 @@ Creates new `apt::ppa` resources. Valid options: a hash to be passed to the crea
 
 Default value: `$apt::params::ppas`
 
-##### <a name="pins"></a>`pins`
+##### <a name="-apt--pins"></a>`pins`
 
 Data type: `Hash`
 
@@ -268,7 +265,7 @@ Creates new `apt::pin` resources. Valid options: a hash to be passed to the crea
 
 Default value: `$apt::params::pins`
 
-##### <a name="settings"></a>`settings`
+##### <a name="-apt--settings"></a>`settings`
 
 Data type: `Hash`
 
@@ -276,7 +273,7 @@ Creates new `apt::setting` resources. Valid options: a hash to be passed to the 
 
 Default value: `$apt::params::settings`
 
-##### <a name="manage_auth_conf"></a>`manage_auth_conf`
+##### <a name="-apt--manage_auth_conf"></a>`manage_auth_conf`
 
 Data type: `Boolean`
 
@@ -285,7 +282,7 @@ the auth_conf_entries parameter. When false, the file will be ignored (note that
 
 Default value: `$apt::params::manage_auth_conf`
 
-##### <a name="auth_conf_entries"></a>`auth_conf_entries`
+##### <a name="-apt--auth_conf_entries"></a>`auth_conf_entries`
 
 Data type: `Array[Apt::Auth_conf_entry]`
 
@@ -296,7 +293,7 @@ password and no others. Specifying manage_auth_conf and not specifying this para
 
 Default value: `$apt::params::auth_conf_entries`
 
-##### <a name="auth_conf_owner"></a>`auth_conf_owner`
+##### <a name="-apt--auth_conf_owner"></a>`auth_conf_owner`
 
 Data type: `String`
 
@@ -304,7 +301,7 @@ The owner of the file /etc/apt/auth.conf. Default: '_apt' or 'root' on old relea
 
 Default value: `$apt::params::auth_conf_owner`
 
-##### <a name="root"></a>`root`
+##### <a name="-apt--root"></a>`root`
 
 Data type: `String`
 
@@ -312,7 +309,7 @@ Specifies root directory of Apt executable.
 
 Default value: `$apt::params::root`
 
-##### <a name="sources_list"></a>`sources_list`
+##### <a name="-apt--sources_list"></a>`sources_list`
 
 Data type: `String`
 
@@ -320,7 +317,7 @@ Specifies the path of the sources_list file to use.
 
 Default value: `$apt::params::sources_list`
 
-##### <a name="sources_list_d"></a>`sources_list_d`
+##### <a name="-apt--sources_list_d"></a>`sources_list_d`
 
 Data type: `String`
 
@@ -328,7 +325,7 @@ Specifies the path of the sources_list.d file to use.
 
 Default value: `$apt::params::sources_list_d`
 
-##### <a name="conf_d"></a>`conf_d`
+##### <a name="-apt--conf_d"></a>`conf_d`
 
 Data type: `String`
 
@@ -336,7 +333,7 @@ Specifies the path of the conf.d file to use.
 
 Default value: `$apt::params::conf_d`
 
-##### <a name="preferences"></a>`preferences`
+##### <a name="-apt--preferences"></a>`preferences`
 
 Data type: `String`
 
@@ -344,7 +341,7 @@ Specifies the path of the preferences file to use.
 
 Default value: `$apt::params::preferences`
 
-##### <a name="preferences_d"></a>`preferences_d`
+##### <a name="-apt--preferences_d"></a>`preferences_d`
 
 Data type: `String`
 
@@ -352,7 +349,7 @@ Specifies the path of the preferences.d file to use.
 
 Default value: `$apt::params::preferences_d`
 
-##### <a name="config_files"></a>`config_files`
+##### <a name="-apt--config_files"></a>`config_files`
 
 Data type: `Hash`
 
@@ -360,7 +357,7 @@ A hash made up of the various configuration files used by Apt.
 
 Default value: `$apt::params::config_files`
 
-##### <a name="sources_list_force"></a>`sources_list_force`
+##### <a name="-apt--sources_list_force"></a>`sources_list_force`
 
 Data type: `Boolean`
 
@@ -368,7 +365,7 @@ Specifies whether to perform force purge or delete. Default false.
 
 Default value: `$apt::params::sources_list_force`
 
-##### <a name="include_defaults"></a>`include_defaults`
+##### <a name="-apt--include_defaults"></a>`include_defaults`
 
 Data type: `Hash`
 
@@ -376,7 +373,7 @@ Data type: `Hash`
 
 Default value: `$apt::params::include_defaults`
 
-##### <a name="apt_conf_d"></a>`apt_conf_d`
+##### <a name="-apt--apt_conf_d"></a>`apt_conf_d`
 
 Data type: `String`
 
@@ -384,20 +381,24 @@ The path to the file `apt.conf.d`
 
 Default value: `$apt::params::apt_conf_d`
 
-##### <a name="source_key_defaults"></a>`source_key_defaults`
+##### <a name="-apt--source_key_defaults"></a>`source_key_defaults`
 
 Data type: `Hash`
 
-The default `source_key` settings
+The fault `source_key` settings
 
-Default value: `{
+Default value:
+
+```puppet
+{
     'server'  => $keyserver,
     'options' => undef,
     'content' => undef,
     'source'  => undef,
-  }`
+  }
+```
 
-### <a name="aptbackports"></a>`apt::backports`
+### <a name="apt--backports"></a>`apt::backports`
 
 Manages backports.
 
@@ -421,14 +422,14 @@ class { 'apt::backports':
 
 The following parameters are available in the `apt::backports` class:
 
-* [`location`](#location)
-* [`release`](#release)
-* [`repos`](#repos)
-* [`key`](#key)
-* [`pin`](#pin)
-* [`include`](#include)
+* [`location`](#-apt--backports--location)
+* [`release`](#-apt--backports--release)
+* [`repos`](#-apt--backports--repos)
+* [`key`](#-apt--backports--key)
+* [`pin`](#-apt--backports--pin)
+* [`include`](#-apt--backports--include)
 
-##### <a name="location"></a>`location`
+##### <a name="-apt--backports--location"></a>`location`
 
 Data type: `Optional[String]`
 
@@ -439,9 +440,9 @@ Ubuntu varies:
 
 - Ubuntu: 'http://archive.ubuntu.com/ubuntu'
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="release"></a>`release`
+##### <a name="-apt--backports--release"></a>`release`
 
 Data type: `Optional[String]`
 
@@ -449,9 +450,9 @@ Specifies a distribution of the Apt repository containing the backports to manag
 Default: on Debian and Ubuntu, `${fact('os.distro.codename')}-backports`. We recommend keeping this default, except on other operating
 systems.
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="repos"></a>`repos`
+##### <a name="-apt--backports--repos"></a>`repos`
 
 Data type: `Optional[String]`
 
@@ -462,9 +463,9 @@ Default value for Debian and Ubuntu varies:
 
 - Ubuntu: 'main universe multiverse restricted'
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="key"></a>`key`
+##### <a name="-apt--backports--key"></a>`key`
 
 Data type: `Optional[Variant[String, Hash]]`
 
@@ -476,9 +477,9 @@ for Debian and Ubuntu varies:
 
 - Ubuntu: '630239CC130E1A7FD81A27B140976EAF437D05B5'
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="pin"></a>`pin`
+##### <a name="-apt--backports--pin"></a>`pin`
 
 Data type: `Variant[Integer, String, Hash]`
 
@@ -487,7 +488,7 @@ type, or a hash of `parameter => value` pairs to be passed to `apt::pin`'s corre
 
 Default value: `200`
 
-##### <a name="include"></a>`include`
+##### <a name="-apt--backports--include"></a>`include`
 
 Data type: `Variant[Hash]`
 
@@ -497,7 +498,7 @@ Default value: `{}`
 
 ## Defined types
 
-### <a name="aptconf"></a>`apt::conf`
+### <a name="apt--conf"></a>`apt::conf`
 
 Specifies a custom Apt configuration file.
 
@@ -505,20 +506,20 @@ Specifies a custom Apt configuration file.
 
 The following parameters are available in the `apt::conf` defined type:
 
-* [`content`](#content)
-* [`ensure`](#ensure)
-* [`priority`](#priority)
-* [`notify_update`](#notify_update)
+* [`content`](#-apt--conf--content)
+* [`ensure`](#-apt--conf--ensure)
+* [`priority`](#-apt--conf--priority)
+* [`notify_update`](#-apt--conf--notify_update)
 
-##### <a name="content"></a>`content`
+##### <a name="-apt--conf--content"></a>`content`
 
 Data type: `Optional[String]`
 
 Required unless `ensure` is set to 'absent'. Directly supplies content for the configuration file.
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="ensure"></a>`ensure`
+##### <a name="-apt--conf--ensure"></a>`ensure`
 
 Data type: `Enum['present', 'absent']`
 
@@ -526,7 +527,7 @@ Specifies whether the configuration file should exist. Valid options: 'present' 
 
 Default value: `present`
 
-##### <a name="priority"></a>`priority`
+##### <a name="-apt--conf--priority"></a>`priority`
 
 Data type: `Variant[String, Integer]`
 
@@ -535,15 +536,15 @@ Valid options: a string containing an integer or an integer.
 
 Default value: `50`
 
-##### <a name="notify_update"></a>`notify_update`
+##### <a name="-apt--conf--notify_update"></a>`notify_update`
 
 Data type: `Optional[Boolean]`
 
 Specifies whether to trigger an `apt-get update` run.
 
-Default value: ``undef``
+Default value: `undef`
 
-### <a name="aptkey"></a>`apt::key`
+### <a name="apt--key"></a>`apt::key`
 
 Manages the GPG keys that Apt uses to authenticate packages.
 
@@ -565,15 +566,15 @@ apt::key { 'puppetlabs':
 
 The following parameters are available in the `apt::key` defined type:
 
-* [`id`](#id)
-* [`ensure`](#ensure)
-* [`content`](#content)
-* [`source`](#source)
-* [`server`](#server)
-* [`weak_ssl`](#weak_ssl)
-* [`options`](#options)
+* [`id`](#-apt--key--id)
+* [`ensure`](#-apt--key--ensure)
+* [`content`](#-apt--key--content)
+* [`source`](#-apt--key--source)
+* [`server`](#-apt--key--server)
+* [`weak_ssl`](#-apt--key--weak_ssl)
+* [`options`](#-apt--key--options)
 
-##### <a name="id"></a>`id`
+##### <a name="-apt--key--id"></a>`id`
 
 Data type: `Pattern[/\A(0x)?[0-9a-fA-F]{8}\Z/, /\A(0x)?[0-9a-fA-F]{16}\Z/, /\A(0x)?[0-9a-fA-F]{40}\Z/]`
 
@@ -582,7 +583,7 @@ characters, optionally prefixed with "0x") or a full key fingerprint (40 hexadec
 
 Default value: `$title`
 
-##### <a name="ensure"></a>`ensure`
+##### <a name="-apt--key--ensure"></a>`ensure`
 
 Data type: `Enum['present', 'absent', 'refreshed']`
 
@@ -591,24 +592,24 @@ update when they have expired (assuming a new key exists on the key server).
 
 Default value: `present`
 
-##### <a name="content"></a>`content`
+##### <a name="-apt--key--content"></a>`content`
 
 Data type: `Optional[String]`
 
 Supplies the entire GPG key. Useful in case the key can't be fetched from a remote location and using a file resource is inconvenient.
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="source"></a>`source`
+##### <a name="-apt--key--source"></a>`source`
 
 Data type: `Optional[Pattern[/\Ahttps?:\/\//, /\Aftp:\/\//, /\A\/\w+/]]`
 
 Specifies the location of an existing GPG key file to copy. Valid options: a string containing a URL (ftp://, http://, or https://) or
 an absolute path.
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="server"></a>`server`
+##### <a name="-apt--key--server"></a>`server`
 
 Data type: `Pattern[/\A((hkp|hkps|http|https):\/\/)?([a-z\d])([a-z\d-]{0,61}\.)+[a-z\d]+(:\d{2,5})?(\/[a-zA-Z\d\-_.]+)*\/?$/]`
 
@@ -617,15 +618,15 @@ hkp:// or hkps://). The hkps:// protocol is currently only supported on Ubuntu 1
 
 Default value: `$apt::keyserver`
 
-##### <a name="weak_ssl"></a>`weak_ssl`
+##### <a name="-apt--key--weak_ssl"></a>`weak_ssl`
 
 Data type: `Boolean`
 
 Specifies whether strict SSL verification on a https URL should be disabled. Valid options: true or false.
 
-Default value: ``false``
+Default value: `false`
 
-##### <a name="options"></a>`options`
+##### <a name="-apt--key--options"></a>`options`
 
 Data type: `Optional[String]`
 
@@ -633,22 +634,30 @@ Passes additional options to `apt-key adv --keyserver-options`.
 
 Default value: `$apt::key_options`
 
-### <a name="aptkeyring"></a>`apt::keyring`
+### <a name="apt--keyring"></a>`apt::keyring`
 
 Manage GPG keyrings for apt repositories
 
 #### Examples
 
-##### Install the puppetlabs apt source with keyring.
+##### Download the puppetlabs apt keyring
 
 ```puppet
-apt::source { 'puppet7-release':
-  location => 'http://apt.puppetlabs.com',
-  repos    => 'main',
-  keyring  => '/etc/apt/keyrings/puppetlabs-keyring.gpg',
-}
-apt::keyring {'puppetlabs-keyring.gpg':
+apt::keyring { 'puppetlabs-keyring.gpg':
   source => 'https://apt.puppetlabs.com/keyring.gpg',
+}
+```
+
+##### Deploy the apt source and associated keyring file
+
+```puppet
+apt::source { 'puppet8-release':
+  location => 'http://apt.puppetlabs.com',
+  repos    => 'puppet8',
+  key      => {
+    name   => 'puppetlabs-keyring.gpg',
+    source => 'https://apt.puppetlabs.com/keyring.gpg'
+  }
 }
 ```
 
@@ -656,15 +665,15 @@ apt::keyring {'puppetlabs-keyring.gpg':
 
 The following parameters are available in the `apt::keyring` defined type:
 
-* [`keyring_dir`](#keyring_dir)
-* [`keyring_filename`](#keyring_filename)
-* [`keyring_file`](#keyring_file)
-* [`keyring_file_mode`](#keyring_file_mode)
-* [`source`](#source)
-* [`content`](#content)
-* [`ensure`](#ensure)
+* [`keyring_dir`](#-apt--keyring--keyring_dir)
+* [`keyring_filename`](#-apt--keyring--keyring_filename)
+* [`keyring_file`](#-apt--keyring--keyring_file)
+* [`keyring_file_mode`](#-apt--keyring--keyring_file_mode)
+* [`source`](#-apt--keyring--source)
+* [`content`](#-apt--keyring--content)
+* [`ensure`](#-apt--keyring--ensure)
 
-##### <a name="keyring_dir"></a>`keyring_dir`
+##### <a name="-apt--keyring--keyring_dir"></a>`keyring_dir`
 
 Data type: `Stdlib::Absolutepath`
 
@@ -672,15 +681,15 @@ Path to the directory where the keyring will be stored.
 
 Default value: `'/etc/apt/keyrings'`
 
-##### <a name="keyring_filename"></a>`keyring_filename`
+##### <a name="-apt--keyring--keyring_filename"></a>`keyring_filename`
 
-Data type: `Optional[String]`
+Data type: `String[1]`
 
-Optional filename for the keyring.
+Optional filename for the keyring. It should also contain extension along with the filename.
 
 Default value: `$name`
 
-##### <a name="keyring_file"></a>`keyring_file`
+##### <a name="-apt--keyring--keyring_file"></a>`keyring_file`
 
 Data type: `Stdlib::Absolutepath`
 
@@ -688,31 +697,31 @@ File path of the keyring.
 
 Default value: `"${keyring_dir}/${keyring_filename}"`
 
-##### <a name="keyring_file_mode"></a>`keyring_file_mode`
+##### <a name="-apt--keyring--keyring_file_mode"></a>`keyring_file_mode`
 
-Data type: `String`
+Data type: `Stdlib::Filemode`
 
 File permissions of the keyring.
 
 Default value: `'0644'`
 
-##### <a name="source"></a>`source`
+##### <a name="-apt--keyring--source"></a>`source`
 
 Data type: `Optional[Stdlib::Filesource]`
 
 Source of the keyring file. Mutually exclusive with 'content'.
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="content"></a>`content`
+##### <a name="-apt--keyring--content"></a>`content`
 
-Data type: `Optional[String]`
+Data type: `Optional[String[1]]`
 
 Content of the keyring file. Mutually exclusive with 'source'.
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="ensure"></a>`ensure`
+##### <a name="-apt--keyring--ensure"></a>`ensure`
 
 Data type: `Enum['present','absent']`
 
@@ -720,7 +729,7 @@ Ensure presence or absence of the resource.
 
 Default value: `'present'`
 
-### <a name="aptmark"></a>`apt::mark`
+### <a name="apt--mark"></a>`apt::mark`
 
 Manages apt-mark settings
 
@@ -728,9 +737,9 @@ Manages apt-mark settings
 
 The following parameters are available in the `apt::mark` defined type:
 
-* [`setting`](#setting)
+* [`setting`](#-apt--mark--setting)
 
-##### <a name="setting"></a>`setting`
+##### <a name="-apt--mark--setting"></a>`setting`
 
 Data type: `Enum['auto','manual','hold','unhold']`
 
@@ -738,7 +747,7 @@ auto, manual, hold, unhold
 specifies the behavior of apt in case of no more dependencies installed
 https://manpages.debian.org/stable/apt/apt-mark.8.en.html
 
-### <a name="aptpin"></a>`apt::pin`
+### <a name="apt--pin"></a>`apt::pin`
 
 Manages Apt pins. Does not trigger an apt-get update run.
 
@@ -750,21 +759,21 @@ Manages Apt pins. Does not trigger an apt-get update run.
 
 The following parameters are available in the `apt::pin` defined type:
 
-* [`ensure`](#ensure)
-* [`explanation`](#explanation)
-* [`order`](#order)
-* [`packages`](#packages)
-* [`priority`](#priority)
-* [`release`](#release)
-* [`release_version`](#release_version)
-* [`component`](#component)
-* [`originator`](#originator)
-* [`label`](#label)
-* [`origin`](#origin)
-* [`version`](#version)
-* [`codename`](#codename)
+* [`ensure`](#-apt--pin--ensure)
+* [`explanation`](#-apt--pin--explanation)
+* [`order`](#-apt--pin--order)
+* [`packages`](#-apt--pin--packages)
+* [`priority`](#-apt--pin--priority)
+* [`release`](#-apt--pin--release)
+* [`release_version`](#-apt--pin--release_version)
+* [`component`](#-apt--pin--component)
+* [`originator`](#-apt--pin--originator)
+* [`label`](#-apt--pin--label)
+* [`origin`](#-apt--pin--origin)
+* [`version`](#-apt--pin--version)
+* [`codename`](#-apt--pin--codename)
 
-##### <a name="ensure"></a>`ensure`
+##### <a name="-apt--pin--ensure"></a>`ensure`
 
 Data type: `Enum['file', 'present', 'absent']`
 
@@ -772,15 +781,15 @@ Specifies whether the pin should exist. Valid options: 'file', 'present', and 'a
 
 Default value: `present`
 
-##### <a name="explanation"></a>`explanation`
+##### <a name="-apt--pin--explanation"></a>`explanation`
 
 Data type: `Optional[String]`
 
 Supplies a comment to explain the pin. Default: "${caller_module_name}: ${name}".
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="order"></a>`order`
+##### <a name="-apt--pin--order"></a>`order`
 
 Data type: `Variant[Integer]`
 
@@ -788,7 +797,7 @@ Determines the order in which Apt processes the pin file. Files with lower order
 
 Default value: `50`
 
-##### <a name="packages"></a>`packages`
+##### <a name="-apt--pin--packages"></a>`packages`
 
 Data type: `Variant[String, Array]`
 
@@ -796,7 +805,7 @@ Specifies which package(s) to pin.
 
 Default value: `'*'`
 
-##### <a name="priority"></a>`priority`
+##### <a name="-apt--pin--priority"></a>`priority`
 
 Data type: `Variant[Numeric, String]`
 
@@ -805,71 +814,71 @@ priority number (subject to dependency constraints). Valid options: an integer.
 
 Default value: `0`
 
-##### <a name="release"></a>`release`
+##### <a name="-apt--pin--release"></a>`release`
 
 Data type: `Optional[String]`
 
 Tells APT to prefer packages that support the specified release. Typical values include 'stable', 'testing', and 'unstable'.
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="release_version"></a>`release_version`
+##### <a name="-apt--pin--release_version"></a>`release_version`
 
 Data type: `Optional[String]`
 
 Tells APT to prefer packages that support the specified operating system release version (such as Debian release version 7).
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="component"></a>`component`
+##### <a name="-apt--pin--component"></a>`component`
 
 Data type: `Optional[String]`
 
 Names the licensing component associated with the packages in the directory tree of the Release file.
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="originator"></a>`originator`
+##### <a name="-apt--pin--originator"></a>`originator`
 
 Data type: `Optional[String]`
 
 Names the originator of the packages in the directory tree of the Release file.
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="label"></a>`label`
+##### <a name="-apt--pin--label"></a>`label`
 
 Data type: `Optional[String]`
 
 Names the label of the packages in the directory tree of the Release file.
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="origin"></a>`origin`
+##### <a name="-apt--pin--origin"></a>`origin`
 
 Data type: `Optional[String]`
 
 The package origin
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="version"></a>`version`
+##### <a name="-apt--pin--version"></a>`version`
 
 Data type: `Optional[String]`
 
 The version of the package
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="codename"></a>`codename`
+##### <a name="-apt--pin--codename"></a>`codename`
 
 Data type: `Optional[String]`
 
 The codename of the package
 
-Default value: ``undef``
+Default value: `undef`
 
-### <a name="aptppa"></a>`apt::ppa`
+### <a name="apt--ppa"></a>`apt::ppa`
 
 Manages PPA repositories using `add-apt-repository`. Not supported on Debian.
 
@@ -885,14 +894,14 @@ apt::ppa{ 'ppa:openstack-ppa/bleeding-edge': }
 
 The following parameters are available in the `apt::ppa` defined type:
 
-* [`ensure`](#ensure)
-* [`options`](#options)
-* [`release`](#release)
-* [`dist`](#dist)
-* [`package_name`](#package_name)
-* [`package_manage`](#package_manage)
+* [`ensure`](#-apt--ppa--ensure)
+* [`options`](#-apt--ppa--options)
+* [`release`](#-apt--ppa--release)
+* [`dist`](#-apt--ppa--dist)
+* [`package_name`](#-apt--ppa--package_name)
+* [`package_manage`](#-apt--ppa--package_manage)
 
-##### <a name="ensure"></a>`ensure`
+##### <a name="-apt--ppa--ensure"></a>`ensure`
 
 Data type: `String`
 
@@ -900,7 +909,7 @@ Specifies whether the PPA should exist. Valid options: 'present' and 'absent'.
 
 Default value: `'present'`
 
-##### <a name="options"></a>`options`
+##### <a name="-apt--ppa--options"></a>`options`
 
 Data type: `Optional[Array[String]]`
 
@@ -908,7 +917,7 @@ Supplies options to be passed to the `add-apt-repository` command. Default: '-y'
 
 Default value: `$apt::ppa_options`
 
-##### <a name="release"></a>`release`
+##### <a name="-apt--ppa--release"></a>`release`
 
 Data type: `Optional[String]`
 
@@ -917,7 +926,7 @@ Optional if `puppet facts show os.distro.codename` returns your correct distribu
 
 Default value: `fact('os.distro.codename')`
 
-##### <a name="dist"></a>`dist`
+##### <a name="-apt--ppa--dist"></a>`dist`
 
 Data type: `Optional[String]`
 
@@ -926,7 +935,7 @@ Optional if `puppet facts show os.name` returns your correct distribution name.
 
 Default value: `$facts['os']['name']`
 
-##### <a name="package_name"></a>`package_name`
+##### <a name="-apt--ppa--package_name"></a>`package_name`
 
 Data type: `Optional[String]`
 
@@ -934,15 +943,15 @@ Names the package that provides the `apt-add-repository` command. Default: 'soft
 
 Default value: `$apt::ppa_package`
 
-##### <a name="package_manage"></a>`package_manage`
+##### <a name="-apt--ppa--package_manage"></a>`package_manage`
 
 Data type: `Boolean`
 
 Specifies whether Puppet should manage the package that provides `apt-add-repository`.
 
-Default value: ``false``
+Default value: `false`
 
-### <a name="aptsetting"></a>`apt::setting`
+### <a name="apt--setting"></a>`apt::setting`
 
 Manages Apt configuration files.
 
@@ -954,13 +963,13 @@ Manages Apt configuration files.
 
 The following parameters are available in the `apt::setting` defined type:
 
-* [`priority`](#priority)
-* [`ensure`](#ensure)
-* [`source`](#source)
-* [`content`](#content)
-* [`notify_update`](#notify_update)
+* [`priority`](#-apt--setting--priority)
+* [`ensure`](#-apt--setting--ensure)
+* [`source`](#-apt--setting--source)
+* [`content`](#-apt--setting--content)
+* [`notify_update`](#-apt--setting--notify_update)
 
-##### <a name="priority"></a>`priority`
+##### <a name="-apt--setting--priority"></a>`priority`
 
 Data type: `Variant[String, Integer, Array]`
 
@@ -968,7 +977,7 @@ Determines the order in which Apt processes the configuration file. Files with h
 
 Default value: `50`
 
-##### <a name="ensure"></a>`ensure`
+##### <a name="-apt--setting--ensure"></a>`ensure`
 
 Data type: `Enum['file', 'present', 'absent']`
 
@@ -976,33 +985,33 @@ Specifies whether the file should exist. Valid options: 'present', 'absent', and
 
 Default value: `file`
 
-##### <a name="source"></a>`source`
+##### <a name="-apt--setting--source"></a>`source`
 
 Data type: `Optional[String]`
 
 Required, unless `content` is set. Specifies a source file to supply the content of the configuration file. Cannot be used in combination
 with `content`. Valid options: see link above for Puppet's native file type source attribute.
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="content"></a>`content`
+##### <a name="-apt--setting--content"></a>`content`
 
 Data type: `Optional[String]`
 
 Required, unless `source` is set. Directly supplies content for the configuration file. Cannot be used in combination with `source`. Valid
 options: see link above for Puppet's native file type content attribute.
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="notify_update"></a>`notify_update`
+##### <a name="-apt--setting--notify_update"></a>`notify_update`
 
 Data type: `Boolean`
 
 Specifies whether to trigger an `apt-get update` run.
 
-Default value: ``true``
+Default value: `true`
 
-### <a name="aptsource"></a>`apt::source`
+### <a name="apt--source"></a>`apt::source`
 
 Manages the Apt sources in /etc/apt/sources.list.d/.
 
@@ -1021,34 +1030,48 @@ apt::source { 'puppetlabs':
 }
 ```
 
+##### Download key behaviour to handle modern apt gpg keyrings. The `name` parameter in the key hash should be given with
+
+```puppet
+extension. Absence of extension will result in file formation with just name and no extension.
+apt::source { 'puppetlabs':
+  location => 'http://apt.puppetlabs.com',
+  comment  => 'Puppet8',
+  key      => {
+    'name'   => 'puppetlabs.gpg',
+    'source' => 'https://apt.puppetlabs.com/keyring.gpg',
+  },
+}
+```
+
 #### Parameters
 
 The following parameters are available in the `apt::source` defined type:
 
-* [`location`](#location)
-* [`comment`](#comment)
-* [`ensure`](#ensure)
-* [`release`](#release)
-* [`repos`](#repos)
-* [`include`](#include)
-* [`key`](#key)
-* [`keyring`](#keyring)
-* [`pin`](#pin)
-* [`architecture`](#architecture)
-* [`allow_unsigned`](#allow_unsigned)
-* [`allow_insecure`](#allow_insecure)
-* [`notify_update`](#notify_update)
-* [`check_valid_until`](#check_valid_until)
+* [`location`](#-apt--source--location)
+* [`comment`](#-apt--source--comment)
+* [`ensure`](#-apt--source--ensure)
+* [`release`](#-apt--source--release)
+* [`repos`](#-apt--source--repos)
+* [`include`](#-apt--source--include)
+* [`key`](#-apt--source--key)
+* [`keyring`](#-apt--source--keyring)
+* [`pin`](#-apt--source--pin)
+* [`architecture`](#-apt--source--architecture)
+* [`allow_unsigned`](#-apt--source--allow_unsigned)
+* [`allow_insecure`](#-apt--source--allow_insecure)
+* [`notify_update`](#-apt--source--notify_update)
+* [`check_valid_until`](#-apt--source--check_valid_until)
 
-##### <a name="location"></a>`location`
+##### <a name="-apt--source--location"></a>`location`
 
 Data type: `Optional[String]`
 
 Required, unless ensure is set to 'absent'. Specifies an Apt repository. Valid options: a string containing a repository URL.
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="comment"></a>`comment`
+##### <a name="-apt--source--comment"></a>`comment`
 
 Data type: `String`
 
@@ -1056,7 +1079,7 @@ Supplies a comment for adding to the Apt source file.
 
 Default value: `$name`
 
-##### <a name="ensure"></a>`ensure`
+##### <a name="-apt--source--ensure"></a>`ensure`
 
 Data type: `String`
 
@@ -1064,15 +1087,15 @@ Specifies whether the Apt source file should exist. Valid options: 'present' and
 
 Default value: `present`
 
-##### <a name="release"></a>`release`
+##### <a name="-apt--source--release"></a>`release`
 
 Data type: `Optional[String]`
 
 Specifies a distribution of the Apt repository.
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="repos"></a>`repos`
+##### <a name="-apt--source--repos"></a>`repos`
 
 Data type: `String`
 
@@ -1080,7 +1103,7 @@ Specifies a component of the Apt repository.
 
 Default value: `'main'`
 
-##### <a name="include"></a>`include`
+##### <a name="-apt--source--include"></a>`include`
 
 Data type: `Variant[Hash]`
 
@@ -1093,85 +1116,83 @@ Options:
 
 Default value: `{}`
 
-##### <a name="key"></a>`key`
+##### <a name="-apt--source--key"></a>`key`
 
 Data type: `Optional[Variant[String, Hash]]`
 
-Creates an apt::keyring in /etc/apt/keyrings (or anywhere on disk given `filename`) Valid options:
+Creates an `apt::keyring` in `/etc/apt/keyrings` (or anywhere on disk given `filename`) Valid options:
   * a hash of `parameter => value` pairs to be passed to `file`: `name` (title), `content`, `source`, `filename`
 
-The following inputs are valid for the (deprecated) apt::key defined type. Valid options:
+The following inputs are valid for the (deprecated) `apt::key` defined type. Valid options:
   * a string to be passed to the `id` parameter of the `apt::key` defined type
   * a hash of `parameter => value` pairs to be passed to `apt::key`: `id`, `server`, `content`, `source`, `weak_ssl`, `options`
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="keyring"></a>`keyring`
+##### <a name="-apt--source--keyring"></a>`keyring`
 
 Data type: `Optional[Stdlib::AbsolutePath]`
 
 Absolute path to a file containing the PGP keyring used to sign this repository. Value is used to set signed-by on the source entry.
-This is not necessary if the key is installed with key param above.
+This is not necessary if the key is installed with `key` param above.
 See https://wiki.debian.org/DebianRepository/UseThirdParty for details.
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="pin"></a>`pin`
+##### <a name="-apt--source--pin"></a>`pin`
 
 Data type: `Optional[Variant[Hash, Numeric, String]]`
 
 Creates a declaration of the apt::pin defined type. Valid options: a number or string to be passed to the `id` parameter of the
 `apt::pin` defined type, or a hash of `parameter => value` pairs to be passed to `apt::pin`'s corresponding parameters.
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="architecture"></a>`architecture`
+##### <a name="-apt--source--architecture"></a>`architecture`
 
 Data type: `Optional[String]`
 
 Tells Apt to only download information for specified architectures. Valid options: a string containing one or more architecture names,
-separated by commas (e.g., 'i386' or 'i386,alpha,powerpc'). Default: undef
+separated by commas (e.g., 'i386' or 'i386,alpha,powerpc').
 (if unspecified, Apt downloads information for all architectures defined in the Apt::Architectures option)
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="allow_unsigned"></a>`allow_unsigned`
+##### <a name="-apt--source--allow_unsigned"></a>`allow_unsigned`
 
 Data type: `Boolean`
 
 Specifies whether to authenticate packages from this release, even if the Release file is not signed or the signature can't be checked.
 
-Default value: ``false``
+Default value: `false`
 
-##### <a name="allow_insecure"></a>`allow_insecure`
+##### <a name="-apt--source--allow_insecure"></a>`allow_insecure`
 
 Data type: `Boolean`
 
 Specifies whether to allow downloads from insecure repositories.
 
-Default value: ``false``
+Default value: `false`
 
-##### <a name="notify_update"></a>`notify_update`
+##### <a name="-apt--source--notify_update"></a>`notify_update`
 
 Data type: `Boolean`
 
 Specifies whether to trigger an `apt-get update` run.
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="check_valid_until"></a>`check_valid_until`
+##### <a name="-apt--source--check_valid_until"></a>`check_valid_until`
 
 Data type: `Boolean`
 
 Specifies whether to check if the package release date is valid. Defaults to `True`.
 
-Default value: ``true``
-
-## Resource types
+Default value: `true`
 
 ## Data types
 
-### <a name="aptauth_conf_entry"></a>`Apt::Auth_conf_entry`
+### <a name="Apt--Auth_conf_entry"></a>`Apt::Auth_conf_entry`
 
 Login configuration settings that are recorded in the file `/etc/apt/auth.conf`.
 
@@ -1193,23 +1214,23 @@ Struct[{
 
 The following parameters are available in the `Apt::Auth_conf_entry` data type:
 
-* [`machine`](#machine)
-* [`login`](#login)
-* [`password`](#password)
+* [`machine`](#-Apt--Auth_conf_entry--machine)
+* [`login`](#-Apt--Auth_conf_entry--login)
+* [`password`](#-Apt--Auth_conf_entry--password)
 
-##### <a name="machine"></a>`machine`
+##### <a name="-Apt--Auth_conf_entry--machine"></a>`machine`
 
 Hostname of machine to connect to.
 
-##### <a name="login"></a>`login`
+##### <a name="-Apt--Auth_conf_entry--login"></a>`login`
 
 Specifies the username to connect with.
 
-##### <a name="password"></a>`password`
+##### <a name="-Apt--Auth_conf_entry--password"></a>`password`
 
 Specifies the password to connect with.
 
-### <a name="aptproxy"></a>`Apt::Proxy`
+### <a name="Apt--Proxy"></a>`Apt::Proxy`
 
 Configures Apt to connect to a proxy server.
 
@@ -1231,33 +1252,33 @@ Struct[{
 
 The following parameters are available in the `Apt::Proxy` data type:
 
-* [`ensure`](#ensure)
-* [`host`](#host)
-* [`port`](#port)
-* [`https`](#https)
-* [`direct`](#direct)
+* [`ensure`](#-Apt--Proxy--ensure)
+* [`host`](#-Apt--Proxy--host)
+* [`port`](#-Apt--Proxy--port)
+* [`https`](#-Apt--Proxy--https)
+* [`direct`](#-Apt--Proxy--direct)
 
-##### <a name="ensure"></a>`ensure`
+##### <a name="-Apt--Proxy--ensure"></a>`ensure`
 
 Specifies whether the proxy should exist. Valid options: 'file', 'present', and 'absent'. Prefer 'file' over 'present'.
 
-##### <a name="host"></a>`host`
+##### <a name="-Apt--Proxy--host"></a>`host`
 
 Specifies a proxy host to be stored in `/etc/apt/apt.conf.d/01proxy`. Valid options: a string containing a hostname.
 
-##### <a name="port"></a>`port`
+##### <a name="-Apt--Proxy--port"></a>`port`
 
 Specifies a proxy port to be stored in `/etc/apt/apt.conf.d/01proxy`. Valid options: an integer containing a port number.
 
-##### <a name="https"></a>`https`
+##### <a name="-Apt--Proxy--https"></a>`https`
 
 Specifies whether to enable https proxies.
 
-##### <a name="direct"></a>`direct`
+##### <a name="-Apt--Proxy--direct"></a>`direct`
 
 Specifies whether or not to use a `DIRECT` https proxy if http proxy is used but https is not.
 
-### <a name="aptproxy_per_host"></a>`Apt::Proxy_Per_Host`
+### <a name="Apt--Proxy_Per_Host"></a>`Apt::Proxy_Per_Host`
 
 Adds per-host overrides to the system default APT proxy configuration
 
@@ -1277,29 +1298,29 @@ Struct[{
 
 The following parameters are available in the `Apt::Proxy_Per_Host` data type:
 
-* [`scope`](#scope)
-* [`host`](#host)
-* [`port`](#port)
-* [`https`](#https)
-* [`direct`](#direct)
+* [`scope`](#-Apt--Proxy_Per_Host--scope)
+* [`host`](#-Apt--Proxy_Per_Host--host)
+* [`port`](#-Apt--Proxy_Per_Host--port)
+* [`https`](#-Apt--Proxy_Per_Host--https)
+* [`direct`](#-Apt--Proxy_Per_Host--direct)
 
-##### <a name="scope"></a>`scope`
+##### <a name="-Apt--Proxy_Per_Host--scope"></a>`scope`
 
 Specifies the scope of the override.  Valid options: a string containing a hostname.
 
-##### <a name="host"></a>`host`
+##### <a name="-Apt--Proxy_Per_Host--host"></a>`host`
 
 Specifies a proxy host to be stored in `/etc/apt/apt.conf.d/01proxy`. Valid options: a string containing a hostname.
 
-##### <a name="port"></a>`port`
+##### <a name="-Apt--Proxy_Per_Host--port"></a>`port`
 
 Specifies a proxy port to be stored in `/etc/apt/apt.conf.d/01proxy`. Valid options: an integer containing a port number.
 
-##### <a name="https"></a>`https`
+##### <a name="-Apt--Proxy_Per_Host--https"></a>`https`
 
 Specifies whether to enable https for this override.
 
-##### <a name="direct"></a>`direct`
+##### <a name="-Apt--Proxy_Per_Host--direct"></a>`direct`
 
 Specifies whether or not to use a `DIRECT` target to bypass the system default proxy.
 
@@ -1318,3 +1339,4 @@ Allows you to perform apt-get functions
 Data type: `Enum[update, upgrade, dist-upgrade, autoremove]`
 
 Action to perform with apt-get
+

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -9,7 +9,7 @@
 #### Public Classes
 
 * [`apt`](#apt): Main class, includes all other classes.
-* [`apt::backports`](#apt--backports): Manages backports.
+* [`apt::backports`](#aptbackports): Manages backports.
 
 #### Private Classes
 
@@ -18,15 +18,19 @@
 
 ### Defined types
 
-* [`apt::conf`](#apt--conf): Specifies a custom Apt configuration file.
-* [`apt::key`](#apt--key): Manages the GPG keys that Apt uses to authenticate packages.
-* [`apt::mark`](#apt--mark): Manages apt-mark settings
-* [`apt::pin`](#apt--pin): Manages Apt pins. Does not trigger an apt-get update run.
-* [`apt::ppa`](#apt--ppa): Manages PPA repositories using `add-apt-repository`. Not supported on Debian.
-* [`apt::setting`](#apt--setting): Manages Apt configuration files.
-* [`apt::source`](#apt--source): Manages the Apt sources in /etc/apt/sources.list.d/.
+* [`apt::conf`](#aptconf): Specifies a custom Apt configuration file.
+* [`apt::key`](#aptkey): Manages the GPG keys that Apt uses to authenticate packages.
+* [`apt::keyring`](#aptkeyring): Manage GPG keyrings for apt repositories
+* [`apt::mark`](#aptmark): Manages apt-mark settings
+* [`apt::pin`](#aptpin): Manages Apt pins. Does not trigger an apt-get update run.
+* [`apt::ppa`](#aptppa): Manages PPA repositories using `add-apt-repository`. Not supported on Debian.
+* [`apt::setting`](#aptsetting): Manages Apt configuration files.
+* [`apt::source`](#aptsource): Manages the Apt sources in /etc/apt/sources.list.d/.
 
 ### Resource types
+
+#### Public Resource types
+
 
 #### Private Resource types
 
@@ -36,9 +40,9 @@ be manipulated through the `apt-key` command.
 
 ### Data types
 
-* [`Apt::Auth_conf_entry`](#Apt--Auth_conf_entry): Login configuration settings that are recorded in the file `/etc/apt/auth.conf`.
-* [`Apt::Proxy`](#Apt--Proxy): Configures Apt to connect to a proxy server.
-* [`Apt::Proxy_Per_Host`](#Apt--Proxy_Per_Host): Adds per-host overrides to the system default APT proxy configuration
+* [`Apt::Auth_conf_entry`](#aptauth_conf_entry): Login configuration settings that are recorded in the file `/etc/apt/auth.conf`.
+* [`Apt::Proxy`](#aptproxy): Configures Apt to connect to a proxy server.
+* [`Apt::Proxy_Per_Host`](#aptproxy_per_host): Adds per-host overrides to the system default APT proxy configuration
 
 ### Tasks
 
@@ -58,40 +62,41 @@ Main class, includes all other classes.
 
 The following parameters are available in the `apt` class:
 
-* [`provider`](#-apt--provider)
-* [`keyserver`](#-apt--keyserver)
-* [`key_options`](#-apt--key_options)
-* [`ppa_options`](#-apt--ppa_options)
-* [`ppa_package`](#-apt--ppa_package)
-* [`backports`](#-apt--backports)
-* [`confs`](#-apt--confs)
-* [`update`](#-apt--update)
-* [`update_defaults`](#-apt--update_defaults)
-* [`purge`](#-apt--purge)
-* [`purge_defaults`](#-apt--purge_defaults)
-* [`proxy`](#-apt--proxy)
-* [`proxy_defaults`](#-apt--proxy_defaults)
-* [`sources`](#-apt--sources)
-* [`keys`](#-apt--keys)
-* [`ppas`](#-apt--ppas)
-* [`pins`](#-apt--pins)
-* [`settings`](#-apt--settings)
-* [`manage_auth_conf`](#-apt--manage_auth_conf)
-* [`auth_conf_entries`](#-apt--auth_conf_entries)
-* [`auth_conf_owner`](#-apt--auth_conf_owner)
-* [`root`](#-apt--root)
-* [`sources_list`](#-apt--sources_list)
-* [`sources_list_d`](#-apt--sources_list_d)
-* [`conf_d`](#-apt--conf_d)
-* [`preferences`](#-apt--preferences)
-* [`preferences_d`](#-apt--preferences_d)
-* [`config_files`](#-apt--config_files)
-* [`sources_list_force`](#-apt--sources_list_force)
-* [`include_defaults`](#-apt--include_defaults)
-* [`apt_conf_d`](#-apt--apt_conf_d)
-* [`source_key_defaults`](#-apt--source_key_defaults)
+* [`provider`](#provider)
+* [`keyserver`](#keyserver)
+* [`key_options`](#key_options)
+* [`ppa_options`](#ppa_options)
+* [`ppa_package`](#ppa_package)
+* [`backports`](#backports)
+* [`confs`](#confs)
+* [`update`](#update)
+* [`update_defaults`](#update_defaults)
+* [`purge`](#purge)
+* [`purge_defaults`](#purge_defaults)
+* [`proxy`](#proxy)
+* [`proxy_defaults`](#proxy_defaults)
+* [`sources`](#sources)
+* [`keys`](#keys)
+* [`keyrings`](#keyrings)
+* [`ppas`](#ppas)
+* [`pins`](#pins)
+* [`settings`](#settings)
+* [`manage_auth_conf`](#manage_auth_conf)
+* [`auth_conf_entries`](#auth_conf_entries)
+* [`auth_conf_owner`](#auth_conf_owner)
+* [`root`](#root)
+* [`sources_list`](#sources_list)
+* [`sources_list_d`](#sources_list_d)
+* [`conf_d`](#conf_d)
+* [`preferences`](#preferences)
+* [`preferences_d`](#preferences_d)
+* [`config_files`](#config_files)
+* [`sources_list_force`](#sources_list_force)
+* [`include_defaults`](#include_defaults)
+* [`apt_conf_d`](#apt_conf_d)
+* [`source_key_defaults`](#source_key_defaults)
 
-##### <a name="-apt--provider"></a>`provider`
+##### <a name="provider"></a>`provider`
 
 Data type: `String`
 
@@ -99,7 +104,7 @@ Specifies the provider that should be used by apt::update.
 
 Default value: `$apt::params::provider`
 
-##### <a name="-apt--keyserver"></a>`keyserver`
+##### <a name="keyserver"></a>`keyserver`
 
 Data type: `String`
 
@@ -108,7 +113,7 @@ hkp://).
 
 Default value: `$apt::params::keyserver`
 
-##### <a name="-apt--key_options"></a>`key_options`
+##### <a name="key_options"></a>`key_options`
 
 Data type: `Optional[String]`
 
@@ -116,7 +121,7 @@ Specifies the default options for apt::key resources.
 
 Default value: `$apt::params::key_options`
 
-##### <a name="-apt--ppa_options"></a>`ppa_options`
+##### <a name="ppa_options"></a>`ppa_options`
 
 Data type: `Optional[Array[String]]`
 
@@ -124,7 +129,7 @@ Supplies options to be passed to the `add-apt-repository` command.
 
 Default value: `$apt::params::ppa_options`
 
-##### <a name="-apt--ppa_package"></a>`ppa_package`
+##### <a name="ppa_package"></a>`ppa_package`
 
 Data type: `Optional[String]`
 
@@ -132,7 +137,7 @@ Names the package that provides the `apt-add-repository` command.
 
 Default value: `$apt::params::ppa_package`
 
-##### <a name="-apt--backports"></a>`backports`
+##### <a name="backports"></a>`backports`
 
 Data type: `Optional[Hash]`
 
@@ -146,7 +151,7 @@ Options:
 
 Default value: `$apt::params::backports`
 
-##### <a name="-apt--confs"></a>`confs`
+##### <a name="confs"></a>`confs`
 
 Data type: `Hash`
 
@@ -154,7 +159,7 @@ Creates new `apt::conf` resources. Valid options: a hash to be passed to the cre
 
 Default value: `$apt::params::confs`
 
-##### <a name="-apt--update"></a>`update`
+##### <a name="update"></a>`update`
 
 Data type: `Hash`
 
@@ -176,7 +181,7 @@ Default: 'reluctantly'.
 
 Default value: `$apt::params::update`
 
-##### <a name="-apt--update_defaults"></a>`update_defaults`
+##### <a name="update_defaults"></a>`update_defaults`
 
 Data type: `Hash`
 
@@ -184,7 +189,7 @@ The default update settings that are combined and merged with the passed `update
 
 Default value: `$apt::params::update_defaults`
 
-##### <a name="-apt--purge"></a>`purge`
+##### <a name="purge"></a>`purge`
 
 Data type: `Hash`
 
@@ -199,7 +204,7 @@ Options:
 
 Default value: `$apt::params::purge`
 
-##### <a name="-apt--purge_defaults"></a>`purge_defaults`
+##### <a name="purge_defaults"></a>`purge_defaults`
 
 Data type: `Hash`
 
@@ -207,7 +212,7 @@ The default purge settings that are combined and merged with the passed `purge` 
 
 Default value: `$apt::params::purge_defaults`
 
-##### <a name="-apt--proxy"></a>`proxy`
+##### <a name="proxy"></a>`proxy`
 
 Data type: `Apt::Proxy`
 
@@ -215,7 +220,7 @@ Configures Apt to connect to a proxy server. Valid options: a hash matching the 
 
 Default value: `$apt::params::proxy`
 
-##### <a name="-apt--proxy_defaults"></a>`proxy_defaults`
+##### <a name="proxy_defaults"></a>`proxy_defaults`
 
 Data type: `Hash`
 
@@ -223,7 +228,7 @@ The default proxy settings that are combined and merged with the passed `proxy` 
 
 Default value: `$apt::params::proxy_defaults`
 
-##### <a name="-apt--sources"></a>`sources`
+##### <a name="sources"></a>`sources`
 
 Data type: `Hash`
 
@@ -231,7 +236,7 @@ Creates new `apt::source` resources. Valid options: a hash to be passed to the c
 
 Default value: `$apt::params::sources`
 
-##### <a name="-apt--keys"></a>`keys`
+##### <a name="keys"></a>`keys`
 
 Data type: `Hash`
 
@@ -239,7 +244,15 @@ Creates new `apt::key` resources. Valid options: a hash to be passed to the crea
 
 Default value: `$apt::params::keys`
 
-##### <a name="-apt--ppas"></a>`ppas`
+##### <a name="keyrings"></a>`keyrings`
+
+Data type: `Hash`
+
+Creates new `apt::keyring` resources. Valid options: a hash to be passed to the create_resources function linked above.
+
+Default value: `{}`
+
+##### <a name="ppas"></a>`ppas`
 
 Data type: `Hash`
 
@@ -247,7 +260,7 @@ Creates new `apt::ppa` resources. Valid options: a hash to be passed to the crea
 
 Default value: `$apt::params::ppas`
 
-##### <a name="-apt--pins"></a>`pins`
+##### <a name="pins"></a>`pins`
 
 Data type: `Hash`
 
@@ -255,7 +268,7 @@ Creates new `apt::pin` resources. Valid options: a hash to be passed to the crea
 
 Default value: `$apt::params::pins`
 
-##### <a name="-apt--settings"></a>`settings`
+##### <a name="settings"></a>`settings`
 
 Data type: `Hash`
 
@@ -263,7 +276,7 @@ Creates new `apt::setting` resources. Valid options: a hash to be passed to the 
 
 Default value: `$apt::params::settings`
 
-##### <a name="-apt--manage_auth_conf"></a>`manage_auth_conf`
+##### <a name="manage_auth_conf"></a>`manage_auth_conf`
 
 Data type: `Boolean`
 
@@ -272,7 +285,7 @@ the auth_conf_entries parameter. When false, the file will be ignored (note that
 
 Default value: `$apt::params::manage_auth_conf`
 
-##### <a name="-apt--auth_conf_entries"></a>`auth_conf_entries`
+##### <a name="auth_conf_entries"></a>`auth_conf_entries`
 
 Data type: `Array[Apt::Auth_conf_entry]`
 
@@ -283,7 +296,7 @@ password and no others. Specifying manage_auth_conf and not specifying this para
 
 Default value: `$apt::params::auth_conf_entries`
 
-##### <a name="-apt--auth_conf_owner"></a>`auth_conf_owner`
+##### <a name="auth_conf_owner"></a>`auth_conf_owner`
 
 Data type: `String`
 
@@ -291,7 +304,7 @@ The owner of the file /etc/apt/auth.conf. Default: '_apt' or 'root' on old relea
 
 Default value: `$apt::params::auth_conf_owner`
 
-##### <a name="-apt--root"></a>`root`
+##### <a name="root"></a>`root`
 
 Data type: `String`
 
@@ -299,7 +312,7 @@ Specifies root directory of Apt executable.
 
 Default value: `$apt::params::root`
 
-##### <a name="-apt--sources_list"></a>`sources_list`
+##### <a name="sources_list"></a>`sources_list`
 
 Data type: `String`
 
@@ -307,7 +320,7 @@ Specifies the path of the sources_list file to use.
 
 Default value: `$apt::params::sources_list`
 
-##### <a name="-apt--sources_list_d"></a>`sources_list_d`
+##### <a name="sources_list_d"></a>`sources_list_d`
 
 Data type: `String`
 
@@ -315,7 +328,7 @@ Specifies the path of the sources_list.d file to use.
 
 Default value: `$apt::params::sources_list_d`
 
-##### <a name="-apt--conf_d"></a>`conf_d`
+##### <a name="conf_d"></a>`conf_d`
 
 Data type: `String`
 
@@ -323,7 +336,7 @@ Specifies the path of the conf.d file to use.
 
 Default value: `$apt::params::conf_d`
 
-##### <a name="-apt--preferences"></a>`preferences`
+##### <a name="preferences"></a>`preferences`
 
 Data type: `String`
 
@@ -331,7 +344,7 @@ Specifies the path of the preferences file to use.
 
 Default value: `$apt::params::preferences`
 
-##### <a name="-apt--preferences_d"></a>`preferences_d`
+##### <a name="preferences_d"></a>`preferences_d`
 
 Data type: `String`
 
@@ -339,7 +352,7 @@ Specifies the path of the preferences.d file to use.
 
 Default value: `$apt::params::preferences_d`
 
-##### <a name="-apt--config_files"></a>`config_files`
+##### <a name="config_files"></a>`config_files`
 
 Data type: `Hash`
 
@@ -347,7 +360,7 @@ A hash made up of the various configuration files used by Apt.
 
 Default value: `$apt::params::config_files`
 
-##### <a name="-apt--sources_list_force"></a>`sources_list_force`
+##### <a name="sources_list_force"></a>`sources_list_force`
 
 Data type: `Boolean`
 
@@ -355,7 +368,7 @@ Specifies whether to perform force purge or delete. Default false.
 
 Default value: `$apt::params::sources_list_force`
 
-##### <a name="-apt--include_defaults"></a>`include_defaults`
+##### <a name="include_defaults"></a>`include_defaults`
 
 Data type: `Hash`
 
@@ -363,7 +376,7 @@ Data type: `Hash`
 
 Default value: `$apt::params::include_defaults`
 
-##### <a name="-apt--apt_conf_d"></a>`apt_conf_d`
+##### <a name="apt_conf_d"></a>`apt_conf_d`
 
 Data type: `String`
 
@@ -371,24 +384,20 @@ The path to the file `apt.conf.d`
 
 Default value: `$apt::params::apt_conf_d`
 
-##### <a name="-apt--source_key_defaults"></a>`source_key_defaults`
+##### <a name="source_key_defaults"></a>`source_key_defaults`
 
 Data type: `Hash`
 
-The fault `source_key` settings
+The default `source_key` settings
 
-Default value:
-
-```puppet
-{
+Default value: `{
     'server'  => $keyserver,
     'options' => undef,
     'content' => undef,
     'source'  => undef,
-  }
-```
+  }`
 
-### <a name="apt--backports"></a>`apt::backports`
+### <a name="aptbackports"></a>`apt::backports`
 
 Manages backports.
 
@@ -412,14 +421,14 @@ class { 'apt::backports':
 
 The following parameters are available in the `apt::backports` class:
 
-* [`location`](#-apt--backports--location)
-* [`release`](#-apt--backports--release)
-* [`repos`](#-apt--backports--repos)
-* [`key`](#-apt--backports--key)
-* [`pin`](#-apt--backports--pin)
-* [`include`](#-apt--backports--include)
+* [`location`](#location)
+* [`release`](#release)
+* [`repos`](#repos)
+* [`key`](#key)
+* [`pin`](#pin)
+* [`include`](#include)
 
-##### <a name="-apt--backports--location"></a>`location`
+##### <a name="location"></a>`location`
 
 Data type: `Optional[String]`
 
@@ -430,9 +439,9 @@ Ubuntu varies:
 
 - Ubuntu: 'http://archive.ubuntu.com/ubuntu'
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-apt--backports--release"></a>`release`
+##### <a name="release"></a>`release`
 
 Data type: `Optional[String]`
 
@@ -440,9 +449,9 @@ Specifies a distribution of the Apt repository containing the backports to manag
 Default: on Debian and Ubuntu, `${fact('os.distro.codename')}-backports`. We recommend keeping this default, except on other operating
 systems.
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-apt--backports--repos"></a>`repos`
+##### <a name="repos"></a>`repos`
 
 Data type: `Optional[String]`
 
@@ -453,9 +462,9 @@ Default value for Debian and Ubuntu varies:
 
 - Ubuntu: 'main universe multiverse restricted'
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-apt--backports--key"></a>`key`
+##### <a name="key"></a>`key`
 
 Data type: `Optional[Variant[String, Hash]]`
 
@@ -467,9 +476,9 @@ for Debian and Ubuntu varies:
 
 - Ubuntu: '630239CC130E1A7FD81A27B140976EAF437D05B5'
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-apt--backports--pin"></a>`pin`
+##### <a name="pin"></a>`pin`
 
 Data type: `Variant[Integer, String, Hash]`
 
@@ -478,7 +487,7 @@ type, or a hash of `parameter => value` pairs to be passed to `apt::pin`'s corre
 
 Default value: `200`
 
-##### <a name="-apt--backports--include"></a>`include`
+##### <a name="include"></a>`include`
 
 Data type: `Variant[Hash]`
 
@@ -488,7 +497,7 @@ Default value: `{}`
 
 ## Defined types
 
-### <a name="apt--conf"></a>`apt::conf`
+### <a name="aptconf"></a>`apt::conf`
 
 Specifies a custom Apt configuration file.
 
@@ -496,20 +505,20 @@ Specifies a custom Apt configuration file.
 
 The following parameters are available in the `apt::conf` defined type:
 
-* [`content`](#-apt--conf--content)
-* [`ensure`](#-apt--conf--ensure)
-* [`priority`](#-apt--conf--priority)
-* [`notify_update`](#-apt--conf--notify_update)
+* [`content`](#content)
+* [`ensure`](#ensure)
+* [`priority`](#priority)
+* [`notify_update`](#notify_update)
 
-##### <a name="-apt--conf--content"></a>`content`
+##### <a name="content"></a>`content`
 
 Data type: `Optional[String]`
 
 Required unless `ensure` is set to 'absent'. Directly supplies content for the configuration file.
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-apt--conf--ensure"></a>`ensure`
+##### <a name="ensure"></a>`ensure`
 
 Data type: `Enum['present', 'absent']`
 
@@ -517,7 +526,7 @@ Specifies whether the configuration file should exist. Valid options: 'present' 
 
 Default value: `present`
 
-##### <a name="-apt--conf--priority"></a>`priority`
+##### <a name="priority"></a>`priority`
 
 Data type: `Variant[String, Integer]`
 
@@ -526,15 +535,15 @@ Valid options: a string containing an integer or an integer.
 
 Default value: `50`
 
-##### <a name="-apt--conf--notify_update"></a>`notify_update`
+##### <a name="notify_update"></a>`notify_update`
 
 Data type: `Optional[Boolean]`
 
 Specifies whether to trigger an `apt-get update` run.
 
-Default value: `undef`
+Default value: ``undef``
 
-### <a name="apt--key"></a>`apt::key`
+### <a name="aptkey"></a>`apt::key`
 
 Manages the GPG keys that Apt uses to authenticate packages.
 
@@ -556,15 +565,15 @@ apt::key { 'puppetlabs':
 
 The following parameters are available in the `apt::key` defined type:
 
-* [`id`](#-apt--key--id)
-* [`ensure`](#-apt--key--ensure)
-* [`content`](#-apt--key--content)
-* [`source`](#-apt--key--source)
-* [`server`](#-apt--key--server)
-* [`weak_ssl`](#-apt--key--weak_ssl)
-* [`options`](#-apt--key--options)
+* [`id`](#id)
+* [`ensure`](#ensure)
+* [`content`](#content)
+* [`source`](#source)
+* [`server`](#server)
+* [`weak_ssl`](#weak_ssl)
+* [`options`](#options)
 
-##### <a name="-apt--key--id"></a>`id`
+##### <a name="id"></a>`id`
 
 Data type: `Pattern[/\A(0x)?[0-9a-fA-F]{8}\Z/, /\A(0x)?[0-9a-fA-F]{16}\Z/, /\A(0x)?[0-9a-fA-F]{40}\Z/]`
 
@@ -573,7 +582,7 @@ characters, optionally prefixed with "0x") or a full key fingerprint (40 hexadec
 
 Default value: `$title`
 
-##### <a name="-apt--key--ensure"></a>`ensure`
+##### <a name="ensure"></a>`ensure`
 
 Data type: `Enum['present', 'absent', 'refreshed']`
 
@@ -582,24 +591,24 @@ update when they have expired (assuming a new key exists on the key server).
 
 Default value: `present`
 
-##### <a name="-apt--key--content"></a>`content`
+##### <a name="content"></a>`content`
 
 Data type: `Optional[String]`
 
 Supplies the entire GPG key. Useful in case the key can't be fetched from a remote location and using a file resource is inconvenient.
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-apt--key--source"></a>`source`
+##### <a name="source"></a>`source`
 
 Data type: `Optional[Pattern[/\Ahttps?:\/\//, /\Aftp:\/\//, /\A\/\w+/]]`
 
 Specifies the location of an existing GPG key file to copy. Valid options: a string containing a URL (ftp://, http://, or https://) or
 an absolute path.
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-apt--key--server"></a>`server`
+##### <a name="server"></a>`server`
 
 Data type: `Pattern[/\A((hkp|hkps|http|https):\/\/)?([a-z\d])([a-z\d-]{0,61}\.)+[a-z\d]+(:\d{2,5})?(\/[a-zA-Z\d\-_.]+)*\/?$/]`
 
@@ -608,15 +617,15 @@ hkp:// or hkps://). The hkps:// protocol is currently only supported on Ubuntu 1
 
 Default value: `$apt::keyserver`
 
-##### <a name="-apt--key--weak_ssl"></a>`weak_ssl`
+##### <a name="weak_ssl"></a>`weak_ssl`
 
 Data type: `Boolean`
 
 Specifies whether strict SSL verification on a https URL should be disabled. Valid options: true or false.
 
-Default value: `false`
+Default value: ``false``
 
-##### <a name="-apt--key--options"></a>`options`
+##### <a name="options"></a>`options`
 
 Data type: `Optional[String]`
 
@@ -624,7 +633,94 @@ Passes additional options to `apt-key adv --keyserver-options`.
 
 Default value: `$apt::key_options`
 
-### <a name="apt--mark"></a>`apt::mark`
+### <a name="aptkeyring"></a>`apt::keyring`
+
+Manage GPG keyrings for apt repositories
+
+#### Examples
+
+##### Install the puppetlabs apt source with keyring.
+
+```puppet
+apt::source { 'puppet7-release':
+  location => 'http://apt.puppetlabs.com',
+  repos    => 'main',
+  keyring  => '/etc/apt/keyrings/puppetlabs-keyring.gpg',
+}
+apt::keyring {'puppetlabs-keyring.gpg':
+  source => 'https://apt.puppetlabs.com/keyring.gpg',
+}
+```
+
+#### Parameters
+
+The following parameters are available in the `apt::keyring` defined type:
+
+* [`keyring_dir`](#keyring_dir)
+* [`keyring_filename`](#keyring_filename)
+* [`keyring_file`](#keyring_file)
+* [`keyring_file_mode`](#keyring_file_mode)
+* [`source`](#source)
+* [`content`](#content)
+* [`ensure`](#ensure)
+
+##### <a name="keyring_dir"></a>`keyring_dir`
+
+Data type: `Stdlib::Absolutepath`
+
+Path to the directory where the keyring will be stored.
+
+Default value: `'/etc/apt/keyrings'`
+
+##### <a name="keyring_filename"></a>`keyring_filename`
+
+Data type: `Optional[String]`
+
+Optional filename for the keyring.
+
+Default value: `$name`
+
+##### <a name="keyring_file"></a>`keyring_file`
+
+Data type: `Stdlib::Absolutepath`
+
+File path of the keyring.
+
+Default value: `"${keyring_dir}/${keyring_filename}"`
+
+##### <a name="keyring_file_mode"></a>`keyring_file_mode`
+
+Data type: `String`
+
+File permissions of the keyring.
+
+Default value: `'0644'`
+
+##### <a name="source"></a>`source`
+
+Data type: `Optional[Stdlib::Filesource]`
+
+Source of the keyring file. Mutually exclusive with 'content'.
+
+Default value: ``undef``
+
+##### <a name="content"></a>`content`
+
+Data type: `Optional[String]`
+
+Content of the keyring file. Mutually exclusive with 'source'.
+
+Default value: ``undef``
+
+##### <a name="ensure"></a>`ensure`
+
+Data type: `Enum['present','absent']`
+
+Ensure presence or absence of the resource.
+
+Default value: `'present'`
+
+### <a name="aptmark"></a>`apt::mark`
 
 Manages apt-mark settings
 
@@ -632,9 +728,9 @@ Manages apt-mark settings
 
 The following parameters are available in the `apt::mark` defined type:
 
-* [`setting`](#-apt--mark--setting)
+* [`setting`](#setting)
 
-##### <a name="-apt--mark--setting"></a>`setting`
+##### <a name="setting"></a>`setting`
 
 Data type: `Enum['auto','manual','hold','unhold']`
 
@@ -642,7 +738,7 @@ auto, manual, hold, unhold
 specifies the behavior of apt in case of no more dependencies installed
 https://manpages.debian.org/stable/apt/apt-mark.8.en.html
 
-### <a name="apt--pin"></a>`apt::pin`
+### <a name="aptpin"></a>`apt::pin`
 
 Manages Apt pins. Does not trigger an apt-get update run.
 
@@ -654,21 +750,21 @@ Manages Apt pins. Does not trigger an apt-get update run.
 
 The following parameters are available in the `apt::pin` defined type:
 
-* [`ensure`](#-apt--pin--ensure)
-* [`explanation`](#-apt--pin--explanation)
-* [`order`](#-apt--pin--order)
-* [`packages`](#-apt--pin--packages)
-* [`priority`](#-apt--pin--priority)
-* [`release`](#-apt--pin--release)
-* [`release_version`](#-apt--pin--release_version)
-* [`component`](#-apt--pin--component)
-* [`originator`](#-apt--pin--originator)
-* [`label`](#-apt--pin--label)
-* [`origin`](#-apt--pin--origin)
-* [`version`](#-apt--pin--version)
-* [`codename`](#-apt--pin--codename)
+* [`ensure`](#ensure)
+* [`explanation`](#explanation)
+* [`order`](#order)
+* [`packages`](#packages)
+* [`priority`](#priority)
+* [`release`](#release)
+* [`release_version`](#release_version)
+* [`component`](#component)
+* [`originator`](#originator)
+* [`label`](#label)
+* [`origin`](#origin)
+* [`version`](#version)
+* [`codename`](#codename)
 
-##### <a name="-apt--pin--ensure"></a>`ensure`
+##### <a name="ensure"></a>`ensure`
 
 Data type: `Enum['file', 'present', 'absent']`
 
@@ -676,15 +772,15 @@ Specifies whether the pin should exist. Valid options: 'file', 'present', and 'a
 
 Default value: `present`
 
-##### <a name="-apt--pin--explanation"></a>`explanation`
+##### <a name="explanation"></a>`explanation`
 
 Data type: `Optional[String]`
 
 Supplies a comment to explain the pin. Default: "${caller_module_name}: ${name}".
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-apt--pin--order"></a>`order`
+##### <a name="order"></a>`order`
 
 Data type: `Variant[Integer]`
 
@@ -692,7 +788,7 @@ Determines the order in which Apt processes the pin file. Files with lower order
 
 Default value: `50`
 
-##### <a name="-apt--pin--packages"></a>`packages`
+##### <a name="packages"></a>`packages`
 
 Data type: `Variant[String, Array]`
 
@@ -700,7 +796,7 @@ Specifies which package(s) to pin.
 
 Default value: `'*'`
 
-##### <a name="-apt--pin--priority"></a>`priority`
+##### <a name="priority"></a>`priority`
 
 Data type: `Variant[Numeric, String]`
 
@@ -709,71 +805,71 @@ priority number (subject to dependency constraints). Valid options: an integer.
 
 Default value: `0`
 
-##### <a name="-apt--pin--release"></a>`release`
+##### <a name="release"></a>`release`
 
 Data type: `Optional[String]`
 
 Tells APT to prefer packages that support the specified release. Typical values include 'stable', 'testing', and 'unstable'.
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-apt--pin--release_version"></a>`release_version`
+##### <a name="release_version"></a>`release_version`
 
 Data type: `Optional[String]`
 
 Tells APT to prefer packages that support the specified operating system release version (such as Debian release version 7).
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-apt--pin--component"></a>`component`
+##### <a name="component"></a>`component`
 
 Data type: `Optional[String]`
 
 Names the licensing component associated with the packages in the directory tree of the Release file.
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-apt--pin--originator"></a>`originator`
+##### <a name="originator"></a>`originator`
 
 Data type: `Optional[String]`
 
 Names the originator of the packages in the directory tree of the Release file.
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-apt--pin--label"></a>`label`
+##### <a name="label"></a>`label`
 
 Data type: `Optional[String]`
 
 Names the label of the packages in the directory tree of the Release file.
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-apt--pin--origin"></a>`origin`
+##### <a name="origin"></a>`origin`
 
 Data type: `Optional[String]`
 
 The package origin
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-apt--pin--version"></a>`version`
+##### <a name="version"></a>`version`
 
 Data type: `Optional[String]`
 
 The version of the package
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-apt--pin--codename"></a>`codename`
+##### <a name="codename"></a>`codename`
 
 Data type: `Optional[String]`
 
 The codename of the package
 
-Default value: `undef`
+Default value: ``undef``
 
-### <a name="apt--ppa"></a>`apt::ppa`
+### <a name="aptppa"></a>`apt::ppa`
 
 Manages PPA repositories using `add-apt-repository`. Not supported on Debian.
 
@@ -789,14 +885,14 @@ apt::ppa{ 'ppa:openstack-ppa/bleeding-edge': }
 
 The following parameters are available in the `apt::ppa` defined type:
 
-* [`ensure`](#-apt--ppa--ensure)
-* [`options`](#-apt--ppa--options)
-* [`release`](#-apt--ppa--release)
-* [`dist`](#-apt--ppa--dist)
-* [`package_name`](#-apt--ppa--package_name)
-* [`package_manage`](#-apt--ppa--package_manage)
+* [`ensure`](#ensure)
+* [`options`](#options)
+* [`release`](#release)
+* [`dist`](#dist)
+* [`package_name`](#package_name)
+* [`package_manage`](#package_manage)
 
-##### <a name="-apt--ppa--ensure"></a>`ensure`
+##### <a name="ensure"></a>`ensure`
 
 Data type: `String`
 
@@ -804,7 +900,7 @@ Specifies whether the PPA should exist. Valid options: 'present' and 'absent'.
 
 Default value: `'present'`
 
-##### <a name="-apt--ppa--options"></a>`options`
+##### <a name="options"></a>`options`
 
 Data type: `Optional[Array[String]]`
 
@@ -812,7 +908,7 @@ Supplies options to be passed to the `add-apt-repository` command. Default: '-y'
 
 Default value: `$apt::ppa_options`
 
-##### <a name="-apt--ppa--release"></a>`release`
+##### <a name="release"></a>`release`
 
 Data type: `Optional[String]`
 
@@ -821,7 +917,7 @@ Optional if `puppet facts show os.distro.codename` returns your correct distribu
 
 Default value: `fact('os.distro.codename')`
 
-##### <a name="-apt--ppa--dist"></a>`dist`
+##### <a name="dist"></a>`dist`
 
 Data type: `Optional[String]`
 
@@ -830,7 +926,7 @@ Optional if `puppet facts show os.name` returns your correct distribution name.
 
 Default value: `$facts['os']['name']`
 
-##### <a name="-apt--ppa--package_name"></a>`package_name`
+##### <a name="package_name"></a>`package_name`
 
 Data type: `Optional[String]`
 
@@ -838,15 +934,15 @@ Names the package that provides the `apt-add-repository` command. Default: 'soft
 
 Default value: `$apt::ppa_package`
 
-##### <a name="-apt--ppa--package_manage"></a>`package_manage`
+##### <a name="package_manage"></a>`package_manage`
 
 Data type: `Boolean`
 
 Specifies whether Puppet should manage the package that provides `apt-add-repository`.
 
-Default value: `false`
+Default value: ``false``
 
-### <a name="apt--setting"></a>`apt::setting`
+### <a name="aptsetting"></a>`apt::setting`
 
 Manages Apt configuration files.
 
@@ -858,13 +954,13 @@ Manages Apt configuration files.
 
 The following parameters are available in the `apt::setting` defined type:
 
-* [`priority`](#-apt--setting--priority)
-* [`ensure`](#-apt--setting--ensure)
-* [`source`](#-apt--setting--source)
-* [`content`](#-apt--setting--content)
-* [`notify_update`](#-apt--setting--notify_update)
+* [`priority`](#priority)
+* [`ensure`](#ensure)
+* [`source`](#source)
+* [`content`](#content)
+* [`notify_update`](#notify_update)
 
-##### <a name="-apt--setting--priority"></a>`priority`
+##### <a name="priority"></a>`priority`
 
 Data type: `Variant[String, Integer, Array]`
 
@@ -872,7 +968,7 @@ Determines the order in which Apt processes the configuration file. Files with h
 
 Default value: `50`
 
-##### <a name="-apt--setting--ensure"></a>`ensure`
+##### <a name="ensure"></a>`ensure`
 
 Data type: `Enum['file', 'present', 'absent']`
 
@@ -880,33 +976,33 @@ Specifies whether the file should exist. Valid options: 'present', 'absent', and
 
 Default value: `file`
 
-##### <a name="-apt--setting--source"></a>`source`
+##### <a name="source"></a>`source`
 
 Data type: `Optional[String]`
 
 Required, unless `content` is set. Specifies a source file to supply the content of the configuration file. Cannot be used in combination
 with `content`. Valid options: see link above for Puppet's native file type source attribute.
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-apt--setting--content"></a>`content`
+##### <a name="content"></a>`content`
 
 Data type: `Optional[String]`
 
 Required, unless `source` is set. Directly supplies content for the configuration file. Cannot be used in combination with `source`. Valid
 options: see link above for Puppet's native file type content attribute.
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-apt--setting--notify_update"></a>`notify_update`
+##### <a name="notify_update"></a>`notify_update`
 
 Data type: `Boolean`
 
 Specifies whether to trigger an `apt-get update` run.
 
-Default value: `true`
+Default value: ``true``
 
-### <a name="apt--source"></a>`apt::source`
+### <a name="aptsource"></a>`apt::source`
 
 Manages the Apt sources in /etc/apt/sources.list.d/.
 
@@ -929,30 +1025,30 @@ apt::source { 'puppetlabs':
 
 The following parameters are available in the `apt::source` defined type:
 
-* [`location`](#-apt--source--location)
-* [`comment`](#-apt--source--comment)
-* [`ensure`](#-apt--source--ensure)
-* [`release`](#-apt--source--release)
-* [`repos`](#-apt--source--repos)
-* [`include`](#-apt--source--include)
-* [`key`](#-apt--source--key)
-* [`keyring`](#-apt--source--keyring)
-* [`pin`](#-apt--source--pin)
-* [`architecture`](#-apt--source--architecture)
-* [`allow_unsigned`](#-apt--source--allow_unsigned)
-* [`allow_insecure`](#-apt--source--allow_insecure)
-* [`notify_update`](#-apt--source--notify_update)
-* [`check_valid_until`](#-apt--source--check_valid_until)
+* [`location`](#location)
+* [`comment`](#comment)
+* [`ensure`](#ensure)
+* [`release`](#release)
+* [`repos`](#repos)
+* [`include`](#include)
+* [`key`](#key)
+* [`keyring`](#keyring)
+* [`pin`](#pin)
+* [`architecture`](#architecture)
+* [`allow_unsigned`](#allow_unsigned)
+* [`allow_insecure`](#allow_insecure)
+* [`notify_update`](#notify_update)
+* [`check_valid_until`](#check_valid_until)
 
-##### <a name="-apt--source--location"></a>`location`
+##### <a name="location"></a>`location`
 
 Data type: `Optional[String]`
 
 Required, unless ensure is set to 'absent'. Specifies an Apt repository. Valid options: a string containing a repository URL.
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-apt--source--comment"></a>`comment`
+##### <a name="comment"></a>`comment`
 
 Data type: `String`
 
@@ -960,7 +1056,7 @@ Supplies a comment for adding to the Apt source file.
 
 Default value: `$name`
 
-##### <a name="-apt--source--ensure"></a>`ensure`
+##### <a name="ensure"></a>`ensure`
 
 Data type: `String`
 
@@ -968,15 +1064,15 @@ Specifies whether the Apt source file should exist. Valid options: 'present' and
 
 Default value: `present`
 
-##### <a name="-apt--source--release"></a>`release`
+##### <a name="release"></a>`release`
 
 Data type: `Optional[String]`
 
 Specifies a distribution of the Apt repository.
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-apt--source--repos"></a>`repos`
+##### <a name="repos"></a>`repos`
 
 Data type: `String`
 
@@ -984,7 +1080,7 @@ Specifies a component of the Apt repository.
 
 Default value: `'main'`
 
-##### <a name="-apt--source--include"></a>`include`
+##### <a name="include"></a>`include`
 
 Data type: `Variant[Hash]`
 
@@ -997,79 +1093,85 @@ Options:
 
 Default value: `{}`
 
-##### <a name="-apt--source--key"></a>`key`
+##### <a name="key"></a>`key`
 
 Data type: `Optional[Variant[String, Hash]]`
 
-Creates a declaration of the apt::key defined type. Valid options: a string to be passed to the `id` parameter of the `apt::key`
-defined type, or a hash of `parameter => value` pairs to be passed to `apt::key`'s `id`, `server`, `content`, `source`, `weak_ssl`,
-and/or `options` parameters.
+Creates an apt::keyring in /etc/apt/keyrings (or anywhere on disk given `filename`) Valid options:
+  * a hash of `parameter => value` pairs to be passed to `file`: `name` (title), `content`, `source`, `filename`
 
-Default value: `undef`
+The following inputs are valid for the (deprecated) apt::key defined type. Valid options:
+  * a string to be passed to the `id` parameter of the `apt::key` defined type
+  * a hash of `parameter => value` pairs to be passed to `apt::key`: `id`, `server`, `content`, `source`, `weak_ssl`, `options`
 
-##### <a name="-apt--source--keyring"></a>`keyring`
+Default value: ``undef``
+
+##### <a name="keyring"></a>`keyring`
 
 Data type: `Optional[Stdlib::AbsolutePath]`
 
 Absolute path to a file containing the PGP keyring used to sign this repository. Value is used to set signed-by on the source entry.
+This is not necessary if the key is installed with key param above.
 See https://wiki.debian.org/DebianRepository/UseThirdParty for details.
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-apt--source--pin"></a>`pin`
+##### <a name="pin"></a>`pin`
 
 Data type: `Optional[Variant[Hash, Numeric, String]]`
 
 Creates a declaration of the apt::pin defined type. Valid options: a number or string to be passed to the `id` parameter of the
 `apt::pin` defined type, or a hash of `parameter => value` pairs to be passed to `apt::pin`'s corresponding parameters.
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-apt--source--architecture"></a>`architecture`
+##### <a name="architecture"></a>`architecture`
 
 Data type: `Optional[String]`
 
 Tells Apt to only download information for specified architectures. Valid options: a string containing one or more architecture names,
-separated by commas (e.g., 'i386' or 'i386,alpha,powerpc'). Default: undef (if unspecified, Apt downloads information for all architectures
-defined in the Apt::Architectures option).
+separated by commas (e.g., 'i386' or 'i386,alpha,powerpc'). Default: undef
+(if unspecified, Apt downloads information for all architectures defined in the Apt::Architectures option)
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-apt--source--allow_unsigned"></a>`allow_unsigned`
+##### <a name="allow_unsigned"></a>`allow_unsigned`
 
 Data type: `Boolean`
 
 Specifies whether to authenticate packages from this release, even if the Release file is not signed or the signature can't be checked.
 
-Default value: `false`
+Default value: ``false``
 
-##### <a name="-apt--source--allow_insecure"></a>`allow_insecure`
+##### <a name="allow_insecure"></a>`allow_insecure`
 
 Data type: `Boolean`
 
 Specifies whether to allow downloads from insecure repositories.
 
-Default value: `false`
+Default value: ``false``
 
-##### <a name="-apt--source--notify_update"></a>`notify_update`
+##### <a name="notify_update"></a>`notify_update`
 
 Data type: `Boolean`
 
 Specifies whether to trigger an `apt-get update` run.
 
-Default value: `true`
+Default value: ``true``
 
-##### <a name="-apt--source--check_valid_until"></a>`check_valid_until`
+##### <a name="check_valid_until"></a>`check_valid_until`
 
 Data type: `Boolean`
 
 Specifies whether to check if the package release date is valid. Defaults to `True`.
 
-Default value: `true`
+Default value: ``true``
+
+## Resource types
 
 ## Data types
 
-### <a name="Apt--Auth_conf_entry"></a>`Apt::Auth_conf_entry`
+### <a name="aptauth_conf_entry"></a>`Apt::Auth_conf_entry`
 
 Login configuration settings that are recorded in the file `/etc/apt/auth.conf`.
 
@@ -1091,23 +1193,23 @@ Struct[{
 
 The following parameters are available in the `Apt::Auth_conf_entry` data type:
 
-* [`machine`](#-Apt--Auth_conf_entry--machine)
-* [`login`](#-Apt--Auth_conf_entry--login)
-* [`password`](#-Apt--Auth_conf_entry--password)
+* [`machine`](#machine)
+* [`login`](#login)
+* [`password`](#password)
 
-##### <a name="-Apt--Auth_conf_entry--machine"></a>`machine`
+##### <a name="machine"></a>`machine`
 
 Hostname of machine to connect to.
 
-##### <a name="-Apt--Auth_conf_entry--login"></a>`login`
+##### <a name="login"></a>`login`
 
 Specifies the username to connect with.
 
-##### <a name="-Apt--Auth_conf_entry--password"></a>`password`
+##### <a name="password"></a>`password`
 
 Specifies the password to connect with.
 
-### <a name="Apt--Proxy"></a>`Apt::Proxy`
+### <a name="aptproxy"></a>`Apt::Proxy`
 
 Configures Apt to connect to a proxy server.
 
@@ -1129,33 +1231,33 @@ Struct[{
 
 The following parameters are available in the `Apt::Proxy` data type:
 
-* [`ensure`](#-Apt--Proxy--ensure)
-* [`host`](#-Apt--Proxy--host)
-* [`port`](#-Apt--Proxy--port)
-* [`https`](#-Apt--Proxy--https)
-* [`direct`](#-Apt--Proxy--direct)
+* [`ensure`](#ensure)
+* [`host`](#host)
+* [`port`](#port)
+* [`https`](#https)
+* [`direct`](#direct)
 
-##### <a name="-Apt--Proxy--ensure"></a>`ensure`
+##### <a name="ensure"></a>`ensure`
 
 Specifies whether the proxy should exist. Valid options: 'file', 'present', and 'absent'. Prefer 'file' over 'present'.
 
-##### <a name="-Apt--Proxy--host"></a>`host`
+##### <a name="host"></a>`host`
 
 Specifies a proxy host to be stored in `/etc/apt/apt.conf.d/01proxy`. Valid options: a string containing a hostname.
 
-##### <a name="-Apt--Proxy--port"></a>`port`
+##### <a name="port"></a>`port`
 
 Specifies a proxy port to be stored in `/etc/apt/apt.conf.d/01proxy`. Valid options: an integer containing a port number.
 
-##### <a name="-Apt--Proxy--https"></a>`https`
+##### <a name="https"></a>`https`
 
 Specifies whether to enable https proxies.
 
-##### <a name="-Apt--Proxy--direct"></a>`direct`
+##### <a name="direct"></a>`direct`
 
 Specifies whether or not to use a `DIRECT` https proxy if http proxy is used but https is not.
 
-### <a name="Apt--Proxy_Per_Host"></a>`Apt::Proxy_Per_Host`
+### <a name="aptproxy_per_host"></a>`Apt::Proxy_Per_Host`
 
 Adds per-host overrides to the system default APT proxy configuration
 
@@ -1175,29 +1277,29 @@ Struct[{
 
 The following parameters are available in the `Apt::Proxy_Per_Host` data type:
 
-* [`scope`](#-Apt--Proxy_Per_Host--scope)
-* [`host`](#-Apt--Proxy_Per_Host--host)
-* [`port`](#-Apt--Proxy_Per_Host--port)
-* [`https`](#-Apt--Proxy_Per_Host--https)
-* [`direct`](#-Apt--Proxy_Per_Host--direct)
+* [`scope`](#scope)
+* [`host`](#host)
+* [`port`](#port)
+* [`https`](#https)
+* [`direct`](#direct)
 
-##### <a name="-Apt--Proxy_Per_Host--scope"></a>`scope`
+##### <a name="scope"></a>`scope`
 
 Specifies the scope of the override.  Valid options: a string containing a hostname.
 
-##### <a name="-Apt--Proxy_Per_Host--host"></a>`host`
+##### <a name="host"></a>`host`
 
 Specifies a proxy host to be stored in `/etc/apt/apt.conf.d/01proxy`. Valid options: a string containing a hostname.
 
-##### <a name="-Apt--Proxy_Per_Host--port"></a>`port`
+##### <a name="port"></a>`port`
 
 Specifies a proxy port to be stored in `/etc/apt/apt.conf.d/01proxy`. Valid options: an integer containing a port number.
 
-##### <a name="-Apt--Proxy_Per_Host--https"></a>`https`
+##### <a name="https"></a>`https`
 
 Specifies whether to enable https for this override.
 
-##### <a name="-Apt--Proxy_Per_Host--direct"></a>`direct`
+##### <a name="direct"></a>`direct`
 
 Specifies whether or not to use a `DIRECT` target to bypass the system default proxy.
 
@@ -1216,4 +1318,3 @@ Allows you to perform apt-get functions
 Data type: `Enum[update, upgrade, dist-upgrade, autoremove]`
 
 Action to perform with apt-get
-

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -89,7 +89,7 @@
 #   Creates new `apt::key` resources. Valid options: a hash to be passed to the create_resources function linked above.
 #
 # @param keyrings
-#   Creates new `apt::keyring` resources. Valid options: a hash to be passed to the create_resources function linked above.
+#   Hash of `apt::keyring` resources.
 #
 # @param ppas
 #   Creates new `apt::ppa` resources. Valid options: a hash to be passed to the create_resources function linked above.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -88,6 +88,9 @@
 # @param keys
 #   Creates new `apt::key` resources. Valid options: a hash to be passed to the create_resources function linked above.
 #
+# @param keyrings
+#   Creates new `apt::keyring` resources. Valid options: a hash to be passed to the create_resources function linked above.
+#
 # @param ppas
 #   Creates new `apt::ppa` resources. Valid options: a hash to be passed to the create_resources function linked above.
 #
@@ -159,6 +162,7 @@ class apt (
   Apt::Proxy $proxy                               = $apt::params::proxy,
   Hash $sources                                   = $apt::params::sources,
   Hash $keys                                      = $apt::params::keys,
+  Hash $keyrings                                  = {},
   Hash $ppas                                      = $apt::params::ppas,
   Hash $pins                                      = $apt::params::pins,
   Hash $settings                                  = $apt::params::settings,
@@ -346,6 +350,12 @@ class apt (
   # manage keys if present
   if $keys {
     create_resources('apt::key', $keys)
+  }
+  # manage keyrings if present
+  $keyrings.each |$key, $data| {
+    apt::keyring { $key:
+      * => $data,
+    }
   }
   # manage ppas if present
   if $ppas {

--- a/manifests/keyring.pp
+++ b/manifests/keyring.pp
@@ -41,7 +41,7 @@ define apt::keyring (
   Stdlib::Absolutepath $keyring_file = "${keyring_dir}/${keyring_filename}",
   Stdlib::Filemode $keyring_file_mode = '0644',
   Optional[Stdlib::Filesource] $source = undef,
-  Optional[String] $content = undef,
+  Optional[String[1]] $content = undef,
   Enum['present','absent'] $ensure = 'present',
 ) {
   ensure_resource('file', $keyring_dir, { ensure => 'directory', mode => '0755', })

--- a/manifests/keyring.pp
+++ b/manifests/keyring.pp
@@ -1,0 +1,72 @@
+# @summary Manage GPG keyrings for apt repositories
+#
+# @example Download the puppetlabs apt keyring
+#   apt::keyring {'puppetlabs-keyring.gpg':
+#     source => 'https://apt.puppetlabs.com/keyring.gpg',
+#   }
+# @example Deploy the apt source and associated keyring file
+#   apt::source { 'puppet8-release':
+#     location => 'http://apt.puppetlabs.com',
+#     repos    => 'puppet8',
+#     key      => {
+#       name   => 'puppetlabs-keyring.gpg',
+#       source => 'https://apt.puppetlabs.com/keyring.gpg'
+#     }
+#   }
+#
+# @param keyring_dir
+#   Path to the directory where the keyring will be stored.
+#
+# @param keyring_filename
+#   Optional filename for the keyring. It should also contain extension along with the filename.
+#
+# @param keyring_file
+#   File path of the keyring.
+#
+# @param keyring_file_mode
+#   File permissions of the keyring.
+#
+# @param source
+#   Source of the keyring file. Mutually exclusive with 'content'.
+#
+# @param content
+#   Content of the keyring file. Mutually exclusive with 'source'.
+#
+# @param ensure
+#   Ensure presence or absence of the resource.
+#
+define apt::keyring (
+  Stdlib::Absolutepath $keyring_dir = '/etc/apt/keyrings',
+  Optional[String] $keyring_filename = $name,
+  Stdlib::Absolutepath $keyring_file = "${keyring_dir}/${keyring_filename}",
+  String  $keyring_file_mode = '0644',
+  Optional[Stdlib::Filesource] $source = undef,
+  Optional[String] $content = undef,
+  Enum['present','absent'] $ensure = 'present',
+) {
+  ensure_resource('file', $keyring_dir, { ensure => 'directory', mode => '0755', })
+  if $source and $content {
+    fail("Parameters 'source' and 'content' are mutually exclusive")
+  } elsif ! $source and ! $content {
+    fail("One of 'source' or 'content' parameters are required")
+  }
+
+  case $ensure {
+    'present': {
+      file { $keyring_file:
+        ensure  => 'file',
+        mode    => $keyring_file_mode,
+        source  => $source,
+        content => $content,
+      }
+    }
+    'absent': {
+      file { $keyring_file:
+        ensure => $ensure,
+      }
+    }
+    default: {
+      fail("Invalid 'ensure' value '${ensure}' for apt::keyring")
+    }
+  }
+}

--- a/manifests/keyring.pp
+++ b/manifests/keyring.pp
@@ -37,7 +37,7 @@
 #
 define apt::keyring (
   Stdlib::Absolutepath $keyring_dir = '/etc/apt/keyrings',
-  Optional[String] $keyring_filename = $name,
+  String[1] $keyring_filename = $name,
   Stdlib::Absolutepath $keyring_file = "${keyring_dir}/${keyring_filename}",
   String  $keyring_file_mode = '0644',
   Optional[Stdlib::Filesource] $source = undef,

--- a/manifests/keyring.pp
+++ b/manifests/keyring.pp
@@ -56,6 +56,8 @@ define apt::keyring (
       file { $keyring_file:
         ensure  => 'file',
         mode    => $keyring_file_mode,
+        owner   => 'root',
+        group   => 'root',
         source  => $source,
         content => $content,
       }

--- a/manifests/keyring.pp
+++ b/manifests/keyring.pp
@@ -1,7 +1,7 @@
 # @summary Manage GPG keyrings for apt repositories
 #
 # @example Download the puppetlabs apt keyring
-#   apt::keyring {'puppetlabs-keyring.gpg':
+#   apt::keyring { 'puppetlabs-keyring.gpg':
 #     source => 'https://apt.puppetlabs.com/keyring.gpg',
 #   }
 # @example Deploy the apt source and associated keyring file

--- a/manifests/keyring.pp
+++ b/manifests/keyring.pp
@@ -39,7 +39,7 @@ define apt::keyring (
   Stdlib::Absolutepath $keyring_dir = '/etc/apt/keyrings',
   String[1] $keyring_filename = $name,
   Stdlib::Absolutepath $keyring_file = "${keyring_dir}/${keyring_filename}",
-  String  $keyring_file_mode = '0644',
+  Stdlib::Filemode $keyring_file_mode = '0644',
   Optional[Stdlib::Filesource] $source = undef,
   Optional[String] $content = undef,
   Enum['present','absent'] $ensure = 'present',

--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -64,7 +64,7 @@
 #
 # @param architecture
 #   Tells Apt to only download information for specified architectures. Valid options: a string containing one or more architecture names,
-#   separated by commas (e.g., 'i386' or 'i386,alpha,powerpc'). Default: undef
+#   separated by commas (e.g., 'i386' or 'i386,alpha,powerpc').
 #   (if unspecified, Apt downloads information for all architectures defined in the Apt::Architectures option)
 #
 # @param allow_unsigned

--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -10,6 +10,17 @@
 #     },
 #   }
 #
+#@example Download key behaviour to handle modern apt gpg keyrings. The name parameter in the key hash should be given with
+# extension. Absence of extension will result in file formation with just name and no extension.
+# apt::source { 'puppetlabs':
+#   location => 'http://apt.puppetlabs.com',
+#   comment  => 'Puppet8',
+#   key      => {
+#     'name'   => 'puppetlabs.gpg',
+#     'source' => 'https://apt.puppetlabs.com/keyring.gpg',
+#   },
+# }
+#
 # @param location
 #   Required, unless ensure is set to 'absent'. Specifies an Apt repository. Valid options: a string containing a repository URL.
 #
@@ -35,12 +46,16 @@
 #   Specifies whether to request the distribution's uncompiled source code. Default false.
 #
 # @param key
-#   Creates a declaration of the apt::key defined type. Valid options: a string to be passed to the `id` parameter of the `apt::key`
-#   defined type, or a hash of `parameter => value` pairs to be passed to `apt::key`'s `id`, `server`, `content`, `source`, `weak_ssl`,
-#   and/or `options` parameters.
+#   Creates an apt::keyring in /etc/apt/keyrings (or anywhere on disk given `filename`) Valid options:
+#     * a hash of `parameter => value` pairs to be passed to `file`: `name` (title), `content`, `source`, `filename`
+#
+#   The following inputs are valid for the (deprecated) apt::key defined type. Valid options:
+#     * a string to be passed to the `id` parameter of the `apt::key` defined type
+#     * a hash of `parameter => value` pairs to be passed to `apt::key`: `id`, `server`, `content`, `source`, `weak_ssl`, `options`
 #
 # @param keyring
 #   Absolute path to a file containing the PGP keyring used to sign this repository. Value is used to set signed-by on the source entry.
+#   This is not necessary if the key is installed with key param above.
 #   See https://wiki.debian.org/DebianRepository/UseThirdParty for details.
 #
 # @param pin
@@ -49,8 +64,8 @@
 #
 # @param architecture
 #   Tells Apt to only download information for specified architectures. Valid options: a string containing one or more architecture names,
-#   separated by commas (e.g., 'i386' or 'i386,alpha,powerpc'). Default: undef (if unspecified, Apt downloads information for all architectures
-#   defined in the Apt::Architectures option).
+#   separated by commas (e.g., 'i386' or 'i386,alpha,powerpc'). Default: undef
+#   (if unspecified, Apt downloads information for all architectures defined in the Apt::Architectures option)
 #
 # @param allow_unsigned
 #   Specifies whether to authenticate packages from this release, even if the Release file is not signed or the signature can't be checked.
@@ -122,19 +137,68 @@ define apt::source (
 
   $includes = $apt::include_defaults + $include
 
-  if $key and $keyring {
-    fail('parameters key and keyring are mutualy exclusive')
-  }
-
-  if $key {
+  if $keyring {
+    if $key {
+      fail('parameters key and keyring are mutually exclusive')
+    } else {
+      $_list_keyring = $keyring
+    }
+  } elsif $key {
     if $key =~ Hash {
-      unless $key['id'] {
-        fail('key hash must contain at least an id entry')
+      unless $key['name'] or $key['id'] {
+        fail('key hash must contain a key name (for apt::keyring) or an id (for apt::key)')
       }
-      $_key = $apt::source_key_defaults + $key
+      if $key['id'] {
+        # defaults like keyserver are only relevant to apt::key
+        $_key = merge($apt::source_key_defaults, $key)
+      } else {
+        $_key = $key
+      }
     } else {
       $_key = { 'id' => assert_type(String[1], $key) }
     }
+    if $_key['ensure'] {
+      $_key_ensure = $_key['ensure']
+    } else {
+      $_key_ensure = $ensure
+    }
+
+    # Old keyserver keys handled by apt-key
+    if ($_key =~ Hash and $_key['id']) {
+      # We do not want to remove keys when the source is absent.
+      if ($ensure == 'present') {
+        apt::key { "Add key: ${$_key['id']} from Apt::Source ${title}":
+          ensure   => $_key_ensure,
+          id       => $_key['id'],
+          server   => $_key['server'],
+          content  => $_key['content'],
+          source   => $_key['source'],
+          options  => $_key['options'],
+          weak_ssl => $_key['weak_ssl'],
+          before   => $_before,
+        }
+      }
+      $_list_keyring = undef
+    }
+    # Modern apt keyrings
+    elsif $_key =~ Hash and $_key['name'] {
+      apt::keyring { $_key['name']:
+        ensure           => $_key_ensure,
+        content          => $_key['content'],
+        source           => $_key['source'],
+        keyring_filename => $_key['filename'],
+        before           => $_before,
+      }
+      # TODO replace this block with a reference to the apt::keyring's final filename/full_path
+      if $_key['filename'] {
+        $_list_keyring = $_key['filename']
+      } else {
+        $_list_keyring = "/etc/apt/keyrings/${_key['name']}"
+      }
+    }
+  } else {
+    # No `key` nor `keyring` provided
+    $_list_keyring = undef
   }
 
   $header = epp('apt/_header.epp')
@@ -152,7 +216,7 @@ define apt::source (
           'arch'              => $_architecture,
           'trusted'           => $allow_unsigned ? { true => 'yes', false => undef },
           'allow-insecure'    => $allow_insecure ? { true => 'yes', false => undef },
-          'signed-by'         => $keyring,
+          'signed-by'         => $_list_keyring,
           'check-valid-until' => $check_valid_until? { true => undef, false => 'false' },
         },
       ),
@@ -183,27 +247,5 @@ define apt::source (
       fail('Received invalid value for pin parameter')
     }
     create_resources('apt::pin', { "${name}" => $_pin })
-  }
-
-  # We do not want to remove keys when the source is absent.
-  if $key and ($ensure == 'present') {
-    if $_key =~ Hash {
-      if $_key['ensure'] != undef {
-        $_ensure = $_key['ensure']
-      } else {
-        $_ensure = $ensure
-      }
-
-      apt::key { "Add key: ${$_key['id']} from Apt::Source ${title}":
-        ensure   => $_ensure,
-        id       => $_key['id'],
-        server   => $_key['server'],
-        content  => $_key['content'],
-        source   => $_key['source'],
-        options  => $_key['options'],
-        weak_ssl => $_key['weak_ssl'],
-        before   => $_before,
-      }
-    }
   }
 }

--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -166,7 +166,7 @@ define apt::source (
     # Old keyserver keys handled by apt-key
     if $_key =~ Hash and $_key['id'] {
       # We do not want to remove keys when the source is absent.
-      if ($ensure == 'present') {
+      if $ensure == 'present' {
         apt::key { "Add key: ${$_key['id']} from Apt::Source ${title}":
           ensure   => $_key_ensure,
           id       => $_key['id'],

--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -49,7 +49,7 @@
 #   Creates an apt::keyring in /etc/apt/keyrings (or anywhere on disk given `filename`) Valid options:
 #     * a hash of `parameter => value` pairs to be passed to `file`: `name` (title), `content`, `source`, `filename`
 #
-#   The following inputs are valid for the (deprecated) apt::key defined type. Valid options:
+#   The following inputs are valid for the (deprecated) `apt::key` defined type. Valid options:
 #     * a string to be passed to the `id` parameter of the `apt::key` defined type
 #     * a hash of `parameter => value` pairs to be passed to `apt::key`: `id`, `server`, `content`, `source`, `weak_ssl`, `options`
 #

--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -46,7 +46,7 @@
 #   Specifies whether to request the distribution's uncompiled source code. Default false.
 #
 # @param key
-#   Creates an apt::keyring in /etc/apt/keyrings (or anywhere on disk given `filename`) Valid options:
+#   Creates an `apt::keyring` in `/etc/apt/keyrings` (or anywhere on disk given `filename`) Valid options:
 #     * a hash of `parameter => value` pairs to be passed to `file`: `name` (title), `content`, `source`, `filename`
 #
 #   The following inputs are valid for the (deprecated) `apt::key` defined type. Valid options:

--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -55,7 +55,7 @@
 #
 # @param keyring
 #   Absolute path to a file containing the PGP keyring used to sign this repository. Value is used to set signed-by on the source entry.
-#   This is not necessary if the key is installed with key param above.
+#   This is not necessary if the key is installed with `key` param above.
 #   See https://wiki.debian.org/DebianRepository/UseThirdParty for details.
 #
 # @param pin

--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -164,7 +164,7 @@ define apt::source (
     }
 
     # Old keyserver keys handled by apt-key
-    if ($_key =~ Hash and $_key['id']) {
+    if $_key =~ Hash and $_key['id'] {
       # We do not want to remove keys when the source is absent.
       if ($ensure == 'present') {
         apt::key { "Add key: ${$_key['id']} from Apt::Source ${title}":

--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -10,16 +10,16 @@
 #     },
 #   }
 #
-#@example Download key behaviour to handle modern apt gpg keyrings. The name parameter in the key hash should be given with
-# extension. Absence of extension will result in file formation with just name and no extension.
-# apt::source { 'puppetlabs':
-#   location => 'http://apt.puppetlabs.com',
-#   comment  => 'Puppet8',
-#   key      => {
-#     'name'   => 'puppetlabs.gpg',
-#     'source' => 'https://apt.puppetlabs.com/keyring.gpg',
-#   },
-# }
+# @example Download key behaviour to handle modern apt gpg keyrings. The `name` parameter in the key hash should be given with
+#   extension. Absence of extension will result in file formation with just name and no extension.
+#   apt::source { 'puppetlabs':
+#     location => 'http://apt.puppetlabs.com',
+#     comment  => 'Puppet8',
+#     key      => {
+#       'name'   => 'puppetlabs.gpg',
+#       'source' => 'https://apt.puppetlabs.com/keyring.gpg',
+#     },
+#   }
 #
 # @param location
 #   Required, unless ensure is set to 'absent'. Specifies an Apt repository. Valid options: a string containing a repository URL.

--- a/spec/acceptance/apt_keyring_spec.rb
+++ b/spec/acceptance/apt_keyring_spec.rb
@@ -2,6 +2,8 @@
 
 require 'spec_helper_acceptance'
 
+PUPPETLABS_KEYRING_CHECK_COMMAND = 'gpg --show-keys /etc/apt/keyrings/puppetlabs-keyring.gpg | grep -F -A 1 \'pub   rsa4096 2019-04-08 [SC] [expires: 2025-04-06]\' | grep \'D6811ED3ADEEB8441AF5AA8F4528B6CD9E61EF26\''
+
 describe 'apt::keyring' do
   context 'when using default values and source specified explicitly' do
     keyring_pp = <<-MANIFEST
@@ -16,8 +18,8 @@ describe 'apt::keyring' do
       end
     end
 
-    it 'expects file to be present at default location' do
-      run_shell('rm /etc/apt/keyrings/puppetlabs-keyring.gpg')
+    it 'expects file content to be present and correct' do
+      run_shell(PUPPETLABS_KEYRING_CHECK_COMMAND.to_s)
     end
   end
 end

--- a/spec/acceptance/apt_keyring_spec.rb
+++ b/spec/acceptance/apt_keyring_spec.rb
@@ -2,15 +2,15 @@
 
 require 'spec_helper_acceptance'
 
-PUPPETLABS_KEYRING_CHECK_COMMAND = 'gpg --import /etc/apt/keyrings/puppetlabs-keyring.gpg | gpg --list-keys | grep -F -A 1 \'pub   rsa4096 2019-04-08 [SC] [expires: 2025-04-06]\'' \
+PUPPETLABS_KEYRING_CHECK_COMMAND = 'gpg --import /etc/apt/keyrings/puppetlabs-keyring.gpg && gpg --list-keys | grep -F -A 1 \'pub   rsa4096 2019-04-08 [SC] [expires: 2025-04-06]\'' \
 '| grep \'D6811ED3ADEEB8441AF5AA8F4528B6CD9E61EF26\''
 
 describe 'apt::keyring' do
   context 'when using default values and source specified explicitly' do
     keyring_pp = <<-MANIFEST
-     apt::keyring { 'puppetlabs-keyring.gpg':
-  	  source => 'https://apt.puppetlabs.com/keyring.gpg',
-     }
+      apt::keyring { 'puppetlabs-keyring.gpg':
+        source => 'https://apt.puppetlabs.com/keyring.gpg',
+      }
     MANIFEST
 
     it 'applies idempotently' do

--- a/spec/acceptance/apt_keyring_spec.rb
+++ b/spec/acceptance/apt_keyring_spec.rb
@@ -12,7 +12,7 @@ describe 'apt::keyring' do
 
     it 'applies idempotently' do
       retry_on_error_matching do
-        idempotent_apply(pp)
+        idempotent_apply(keyring_pp)
       end
     end
   end

--- a/spec/acceptance/apt_keyring_spec.rb
+++ b/spec/acceptance/apt_keyring_spec.rb
@@ -2,7 +2,8 @@
 
 require 'spec_helper_acceptance'
 
-PUPPETLABS_KEYRING_CHECK_COMMAND = 'gpg --show-keys /etc/apt/keyrings/puppetlabs-keyring.gpg | grep -F -A 1 \'pub   rsa4096 2019-04-08 [SC] [expires: 2025-04-06]\' | grep \'D6811ED3ADEEB8441AF5AA8F4528B6CD9E61EF26\''
+PUPPETLABS_KEYRING_CHECK_COMMAND = 'gpg --show-keys /etc/apt/keyrings/puppetlabs-keyring.gpg | grep -F -A 1 \'pub   rsa4096 2019-04-08 [SC] [expires: 2025-04-06]\'' \
+'| grep \'D6811ED3ADEEB8441AF5AA8F4528B6CD9E61EF26\''
 
 describe 'apt::keyring' do
   context 'when using default values and source specified explicitly' do

--- a/spec/acceptance/apt_keyring_spec.rb
+++ b/spec/acceptance/apt_keyring_spec.rb
@@ -2,6 +2,8 @@
 
 require 'spec_helper_acceptance'
 
+PUPPETLABS_FILE_CHECK_COMMAND = 'ls /etc/apt/keyrings | grep \'puppetlabs-keyring.gpg\''
+
 describe 'apt::keyring' do
   context 'when using default values and source specified explicitly' do
     let(:keyring_pp) do
@@ -16,6 +18,10 @@ describe 'apt::keyring' do
       retry_on_error_matching do
         idempotent_apply(keyring_pp)
       end
+    end
+
+    it 'expects file to be present at default location' do
+      run_shell(PUPPETLABS_FILE_CHECK_COMMAND.to_s)
     end
   end
 end

--- a/spec/acceptance/apt_keyring_spec.rb
+++ b/spec/acceptance/apt_keyring_spec.rb
@@ -7,7 +7,7 @@ describe 'apt::keyring' do
     keyring_pp = <<-MANIFEST
      apt::keyring { 'puppetlabs-keyring.gpg':
   	  source => 'https://apt.puppetlabs.com/keyring.gpg',
-    }
+     }
     MANIFEST
 
     it 'applies idempotently' do

--- a/spec/acceptance/apt_keyring_spec.rb
+++ b/spec/acceptance/apt_keyring_spec.rb
@@ -5,9 +5,9 @@ require 'spec_helper_acceptance'
 describe 'apt::keyring' do
   context 'when using default values and source specified explicitly' do
     keyring_pp = <<-MANIFEST
-    	apt::keyring { 'puppetlabs-keyring.gpg':
-  			source => 'https://apt.puppetlabs.com/keyring.gpg',
-    	}
+     apt::keyring { 'puppetlabs-keyring.gpg':
+  	 source => 'https://apt.puppetlabs.com/keyring.gpg',
+    }
     MANIFEST
 
     it 'applies idempotently' do

--- a/spec/acceptance/apt_keyring_spec.rb
+++ b/spec/acceptance/apt_keyring_spec.rb
@@ -4,13 +4,13 @@ require 'spec_helper_acceptance'
 
 describe 'apt::keyring' do
   context 'when using default values and source specified explicitly' do
-    let (:keyring_pp) do
-			<<-MANIFEST
+    let(:keyring_pp) do
+      <<-MANIFEST
     		apt::keyring { 'puppetlabs-keyring.gpg':
   				source => 'https://apt.puppetlabs.com/keyring.gpg',
     		}
-    	MANIFEST
-		end
+      MANIFEST
+    end
 
     it 'applies idempotently' do
       retry_on_error_matching do

--- a/spec/acceptance/apt_keyring_spec.rb
+++ b/spec/acceptance/apt_keyring_spec.rb
@@ -20,7 +20,9 @@ describe 'apt::keyring' do
     end
 
     it 'expects file content to be present and correct' do
-      run_shell(PUPPETLABS_KEYRING_CHECK_COMMAND.to_s)
+      retry_on_error_matching do
+        run_shell(PUPPETLABS_KEYRING_CHECK_COMMAND.to_s)
+      end
     end
   end
 end

--- a/spec/acceptance/apt_keyring_spec.rb
+++ b/spec/acceptance/apt_keyring_spec.rb
@@ -6,7 +6,7 @@ describe 'apt::keyring' do
   context 'when using default values and source specified explicitly' do
     keyring_pp = <<-MANIFEST
      apt::keyring { 'puppetlabs-keyring.gpg':
-  	 source => 'https://apt.puppetlabs.com/keyring.gpg',
+  	  source => 'https://apt.puppetlabs.com/keyring.gpg',
     }
     MANIFEST
 

--- a/spec/acceptance/apt_keyring_spec.rb
+++ b/spec/acceptance/apt_keyring_spec.rb
@@ -2,17 +2,13 @@
 
 require 'spec_helper_acceptance'
 
-PUPPETLABS_FILE_CHECK_COMMAND = 'ls /etc/apt/keyrings | grep \'puppetlabs-keyring.gpg\''
-
 describe 'apt::keyring' do
   context 'when using default values and source specified explicitly' do
-    let(:keyring_pp) do
-      <<-MANIFEST
-    		apt::keyring { 'puppetlabs-keyring.gpg':
-  				source => 'https://apt.puppetlabs.com/keyring.gpg',
-    		}
-      MANIFEST
-    end
+    keyring_pp = <<-MANIFEST
+    	apt::keyring { 'puppetlabs-keyring.gpg':
+  			source => 'https://apt.puppetlabs.com/keyring.gpg',
+    	}
+    MANIFEST
 
     it 'applies idempotently' do
       retry_on_error_matching do
@@ -21,7 +17,7 @@ describe 'apt::keyring' do
     end
 
     it 'expects file to be present at default location' do
-      run_shell(PUPPETLABS_FILE_CHECK_COMMAND.to_s)
+      run_shell('rm /etc/apt/keyrings/puppetlabs-keyring.gpg')
     end
   end
 end

--- a/spec/acceptance/apt_keyring_spec.rb
+++ b/spec/acceptance/apt_keyring_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper_acceptance'
 
-PUPPETLABS_KEYRING_CHECK_COMMAND = 'gpg --show-keys /etc/apt/keyrings/puppetlabs-keyring.gpg | grep -F -A 1 \'pub   rsa4096 2019-04-08 [SC] [expires: 2025-04-06]\'' \
+PUPPETLABS_KEYRING_CHECK_COMMAND = 'gpg --import /etc/apt/keyrings/puppetlabs-keyring.gpg | gpg --list-keys | grep -F -A 1 \'pub   rsa4096 2019-04-08 [SC] [expires: 2025-04-06]\'' \
 '| grep \'D6811ED3ADEEB8441AF5AA8F4528B6CD9E61EF26\''
 
 describe 'apt::keyring' do

--- a/spec/acceptance/apt_keyring_spec.rb
+++ b/spec/acceptance/apt_keyring_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'spec_helper_acceptance'
+
+describe 'apt::keyring' do
+  context 'when using default values and source specified explicitly' do
+    keyring_pp = <<-MANIFEST
+    apt::keyring { 'puppetlabs-keyring.gpg':
+  		source => 'https://apt.puppetlabs.com/keyring.gpg',
+    }
+    MANIFEST
+
+    it 'applies idempotently' do
+      retry_on_error_matching do
+        idempotent_apply(pp)
+      end
+    end
+  end
+end

--- a/spec/acceptance/apt_keyring_spec.rb
+++ b/spec/acceptance/apt_keyring_spec.rb
@@ -4,11 +4,13 @@ require 'spec_helper_acceptance'
 
 describe 'apt::keyring' do
   context 'when using default values and source specified explicitly' do
-    keyring_pp = <<-MANIFEST
-    apt::keyring { 'puppetlabs-keyring.gpg':
-  		source => 'https://apt.puppetlabs.com/keyring.gpg',
-    }
-    MANIFEST
+    let (:keyring_pp) do
+			<<-MANIFEST
+    		apt::keyring { 'puppetlabs-keyring.gpg':
+  				source => 'https://apt.puppetlabs.com/keyring.gpg',
+    		}
+    	MANIFEST
+		end
 
     it 'applies idempotently' do
       retry_on_error_matching do

--- a/spec/defines/keyring_spec.rb
+++ b/spec/defines/keyring_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'apt::keyring' do
+  let(:title) { 'namevar' }
+  let(:params) do
+    {
+      source: 'http://apt.puppetlabs.com/pubkey.gpg',
+    }
+  end
+
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it { is_expected.to compile }
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Add apt::keyring defined type which creates modern-style keyrings. Just a PR with resolved comments and fixed parallel specs on PR #1105 

## Additional Context

## Related Issues (if any)

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)

## Courtesy Pull Requests (PRs)
We extend our gratitude to the original authors who have paved the way for us in the realm of open-source development. Special thanks to @jorhett for taking the initiative and demonstrating the handling of modern apt GPG keyrings in PR #1105. Additionally, we would like to express our appreciation to @jps-help for their contributions in PR #1120, specifically in the area of keyring management.

Your efforts are highly valued and greatly appreciated. Keep up the great work, and let's continue to drive innovation in the open-source community! Cheers!"
 