### PR TITLE
(CAT-1442)-Fix pipeline for apt module

### DIFF
--- a/spec/acceptance/apt_backports_spec.rb
+++ b/spec/acceptance/apt_backports_spec.rb
@@ -11,7 +11,9 @@ describe 'apt::backports' do
     end
 
     it 'applies idempotently' do
-      idempotent_apply(pp)
+      retry_on_error_matching do
+        idempotent_apply(pp)
+      end
     end
 
     it 'provides backports apt sources' do

--- a/spec/acceptance/apt_key_provider_spec.rb
+++ b/spec/acceptance/apt_key_provider_spec.rb
@@ -902,9 +902,11 @@ describe 'apt_key' do
 
     context 'when refresh => true' do
       it 'updates an expired key' do
-        apply_manifest(refresh_true_pp)
-        # Check key has been updated to new version
-        run_shell(PUPPETLABS_EXP_CHECK_COMMAND.to_s)
+        retry_on_error_matching do
+          apply_manifest(refresh_true_pp)
+          # Check key has been updated to new version
+          run_shell(PUPPETLABS_EXP_CHECK_COMMAND.to_s)
+        end
       end
     end
 

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -2,7 +2,7 @@
 
 UNSUPPORTED_PLATFORMS = ['RedHat', 'Suse', 'windows', 'AIX', 'Solaris'].freeze
 RETRY_WAIT            = 3
-ERROR_MATCHER         = %r{(no valid OpenPGP data found|keyserver timed out|keyserver receive failed)}.freeze
+ERROR_MATCHER         = %r{(no valid OpenPGP data found|keyserver timed out|keyserver receive failed|shell failed|apply manifest failed)}.freeze
 MAX_RETRY_COUNT       = 10
 
 RSpec.configure do |c|


### PR DESCRIPTION
## Summary
Fixing pipeline for apt module. 

## Additional Context
The specs which checks whether the expired key is updated or not usually pings keyserver to receive keys which intermittently generates error. Therefore implementing retries to receive atleast keys once.

## Related Issues (if any)

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)