### PR TITLE
(CAT-1483) - Enhancement of handling of apt::source's repos and release parameters

### DIFF
--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -94,6 +94,12 @@ define apt::source (
     $_release = $release
   }
 
+  if $release =~ Pattern[/\/$/] {
+    $_components = $_release
+  } else {
+    $_components = "${_release} ${repos}"
+  }
+
   if $ensure == 'present' {
     if ! $location {
       fail('cannot create a source entry without specifying a location')
@@ -151,8 +157,7 @@ define apt::source (
         },
       ),
       'location'         => $_location,
-      'release'          => $_release,
-      'repos'            => $repos,
+      'components'       => $_components,
     }
   )
 

--- a/spec/defines/source_spec.rb
+++ b/spec/defines/source_spec.rb
@@ -427,6 +427,24 @@ describe 'apt::source' do
       it { is_expected.to contain_apt__setting('list-my_source').with_content(%r{hello\.there  main}) }
     end
 
+    context 'with release is /' do
+      let(:params) { { location: 'hello.there', release: '/' } }
+
+      it { is_expected.to contain_apt__setting('list-my_source').with_content(%r{hello\.there /}) }
+    end
+
+    context 'with release is test/' do
+      let(:params) { { location: 'hello.there', release: 'test/' } }
+
+      it { is_expected.to contain_apt__setting('list-my_source').with_content(%r{hello\.there test/}) }
+    end
+
+    context 'with release is test/test' do
+      let(:params) { { location: 'hello.there', release: 'test/test' } }
+
+      it { is_expected.to contain_apt__setting('list-my_source').with_content(%r{hello\.there test/test main}) }
+    end
+
     context 'with invalid pin' do
       let :params do
         {

--- a/templates/source.list.epp
+++ b/templates/source.list.epp
@@ -1,8 +1,8 @@
-<%- | String $comment, Hash $includes, Hash $options, $location, $release, String $repos | -%>
+<%- | String $comment, Hash $includes, Hash $options, $location, String $components | -%>
 # <%= $comment %>
 <%- if $includes['deb'] { -%>
-deb <% if !$options.empty() { -%>[<%=  $options.map |$key, $value| { if !$value.empty() { "${key}=${value}" } }.join(" ") %>] <% } -%> <%= $location %> <%= $release %> <%= $repos %>
+deb <% if !$options.empty() { -%>[<%=  $options.map |$key, $value| { if !$value.empty() { "${key}=${value}" } }.join(" ") %>] <% } -%> <%= $location %> <%= $components %>
 <%- } -%>
 <%- if $includes['src'] { -%>
-deb-src <% if !$options.empty() { -%>[<%=  $options.map |$key, $value| { if !$value.empty() { "${key}=${value}" } }.join(" ") %>] <% } -%> <%= $location %> <%= $release %> <%= $repos %>
+deb-src <% if !$options.empty() { -%>[<%=  $options.map |$key, $value| { if !$value.empty() { "${key}=${value}" } }.join(" ") %>] <% } -%> <%= $location %> <%= $components %>
 <%- } -%>


### PR DESCRIPTION
## Summary

Generating the correct source list based on the $release and $repos.

## Related Issues (if any)
https://github.com/puppetlabs/puppetlabs-apt/issues/1132

## Checklist
- [x] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)