### PR TITLE
(CAT-1486) - Removing deprecated --force-yes flag with newly introduced flags

### DIFF
--- a/spec/acceptance/apt_spec.rb
+++ b/spec/acceptance/apt_spec.rb
@@ -48,7 +48,7 @@ describe 'apt class' do
 
     it 'stills work' do
       run_shell('apt-get update')
-      run_shell('apt-get -y --force-yes upgrade')
+      run_shell('apt-get -y --allow-downgrades --allow-remove-essential --allow-change-held-packages upgrade')
     end
   end
 


### PR DESCRIPTION
## Summary
Removing --force-yes flag with new flags.

## Additional Context
This is deprecated and replaced by --allow-unauthenticated , --allow-downgrades , --allow-remove-essential , --allow-change-held-packages.

## Related Issues (if any)
https://github.com/puppetlabs/puppetlabs-apt/issues/1130

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)