### PR TITLE
Allow passing all `keyring` params in `apt::source`

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -662,7 +662,6 @@ The following parameters are available in the `apt::keyring` defined type:
 
 * [`dir`](#-apt--keyring--dir)
 * [`filename`](#-apt--keyring--filename)
-* [`file`](#-apt--keyring--file)
 * [`mode`](#-apt--keyring--mode)
 * [`source`](#-apt--keyring--source)
 * [`content`](#-apt--keyring--content)
@@ -683,14 +682,6 @@ Data type: `String[1]`
 Optional filename for the keyring. It should also contain extension along with the filename.
 
 Default value: `$name`
-
-##### <a name="-apt--keyring--file"></a>`file`
-
-Data type: `Stdlib::Absolutepath`
-
-File path of the keyring.
-
-Default value: `"${dir}/${filename}"`
 
 ##### <a name="-apt--keyring--mode"></a>`mode`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -660,15 +660,15 @@ apt::source { 'puppet8-release':
 
 The following parameters are available in the `apt::keyring` defined type:
 
-* [`keyring_dir`](#-apt--keyring--keyring_dir)
-* [`keyring_filename`](#-apt--keyring--keyring_filename)
-* [`keyring_file`](#-apt--keyring--keyring_file)
-* [`keyring_file_mode`](#-apt--keyring--keyring_file_mode)
+* [`dir`](#-apt--keyring--dir)
+* [`filename`](#-apt--keyring--filename)
+* [`file`](#-apt--keyring--file)
+* [`mode`](#-apt--keyring--mode)
 * [`source`](#-apt--keyring--source)
 * [`content`](#-apt--keyring--content)
 * [`ensure`](#-apt--keyring--ensure)
 
-##### <a name="-apt--keyring--keyring_dir"></a>`keyring_dir`
+##### <a name="-apt--keyring--dir"></a>`dir`
 
 Data type: `Stdlib::Absolutepath`
 
@@ -676,7 +676,7 @@ Path to the directory where the keyring will be stored.
 
 Default value: `'/etc/apt/keyrings'`
 
-##### <a name="-apt--keyring--keyring_filename"></a>`keyring_filename`
+##### <a name="-apt--keyring--filename"></a>`filename`
 
 Data type: `String[1]`
 
@@ -684,15 +684,15 @@ Optional filename for the keyring. It should also contain extension along with t
 
 Default value: `$name`
 
-##### <a name="-apt--keyring--keyring_file"></a>`keyring_file`
+##### <a name="-apt--keyring--file"></a>`file`
 
 Data type: `Stdlib::Absolutepath`
 
 File path of the keyring.
 
-Default value: `"${keyring_dir}/${keyring_filename}"`
+Default value: `"${dir}/${filename}"`
 
-##### <a name="-apt--keyring--keyring_file_mode"></a>`keyring_file_mode`
+##### <a name="-apt--keyring--mode"></a>`mode`
 
 Data type: `Stdlib::Filemode`
 

--- a/manifests/keyring.pp
+++ b/manifests/keyring.pp
@@ -14,16 +14,16 @@
 #     }
 #   }
 #
-# @param keyring_dir
+# @param dir
 #   Path to the directory where the keyring will be stored.
 #
-# @param keyring_filename
+# @param filename
 #   Optional filename for the keyring. It should also contain extension along with the filename.
 #
-# @param keyring_file
+# @param file
 #   File path of the keyring.
 #
-# @param keyring_file_mode
+# @param mode
 #   File permissions of the keyring.
 #
 # @param source
@@ -36,15 +36,15 @@
 #   Ensure presence or absence of the resource.
 #
 define apt::keyring (
-  Stdlib::Absolutepath $keyring_dir = '/etc/apt/keyrings',
-  String[1] $keyring_filename = $name,
-  Stdlib::Absolutepath $keyring_file = "${keyring_dir}/${keyring_filename}",
-  Stdlib::Filemode $keyring_file_mode = '0644',
+  Stdlib::Absolutepath $dir = '/etc/apt/keyrings',
+  String[1] $filename = $name,
+  Stdlib::Absolutepath $file = "${dir}/${filename}",
+  Stdlib::Filemode $mode = '0644',
   Optional[Stdlib::Filesource] $source = undef,
   Optional[String[1]] $content = undef,
   Enum['present','absent'] $ensure = 'present',
 ) {
-  ensure_resource('file', $keyring_dir, { ensure => 'directory', mode => '0755', })
+  ensure_resource('file', $dir, { ensure => 'directory', mode => '0755', })
   if $source and $content {
     fail("Parameters 'source' and 'content' are mutually exclusive")
   } elsif ! $source and ! $content {
@@ -53,9 +53,9 @@ define apt::keyring (
 
   case $ensure {
     'present': {
-      file { $keyring_file:
+      file { $file:
         ensure  => 'file',
-        mode    => $keyring_file_mode,
+        mode    => $mode,
         owner   => 'root',
         group   => 'root',
         source  => $source,
@@ -63,7 +63,7 @@ define apt::keyring (
       }
     }
     'absent': {
-      file { $keyring_file:
+      file { $file:
         ensure => $ensure,
       }
     }

--- a/manifests/keyring.pp
+++ b/manifests/keyring.pp
@@ -20,9 +20,6 @@
 # @param filename
 #   Optional filename for the keyring. It should also contain extension along with the filename.
 #
-# @param file
-#   File path of the keyring.
-#
 # @param mode
 #   File permissions of the keyring.
 #
@@ -38,7 +35,6 @@
 define apt::keyring (
   Stdlib::Absolutepath $dir = '/etc/apt/keyrings',
   String[1] $filename = $name,
-  Stdlib::Absolutepath $file = "${dir}/${filename}",
   Stdlib::Filemode $mode = '0644',
   Optional[Stdlib::Filesource] $source = undef,
   Optional[String[1]] $content = undef,
@@ -50,6 +46,8 @@ define apt::keyring (
   } elsif ! $source and ! $content {
     fail("One of 'source' or 'content' parameters are required")
   }
+
+  $file = "${dir}/${filename}"
 
   case $ensure {
     'present': {

--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -186,14 +186,20 @@ define apt::source (
         ensure   => $_key_ensure,
         content  => $_key['content'],
         source   => $_key['source'],
+        dir      => $_key['dir'],
         filename => $_key['filename'],
+        mode     => $_key['mode'],
         before   => $_before,
       }
-      # TODO replace this block with a reference to the apt::keyring's final filename/full_path
-      if $_key['filename'] {
-        $_list_keyring = $_key['filename']
+
+      $_list_keyring = if $_key['dir'] and $_key['filename'] {
+        "${_key['dir']}${_key['filename']}"
+      } elsif $_key['filename'] {
+        "/etc/apt/keyrings/${_key['filename']}"
+      } elsif $_key['dir'] {
+        "${_key['dir']}${_key['name']}"
       } else {
-        $_list_keyring = "/etc/apt/keyrings/${_key['name']}"
+        "/etc/apt/keyrings/${_key['name']}"
       }
     }
   } else {

--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -183,11 +183,11 @@ define apt::source (
     # Modern apt keyrings
     elsif $_key =~ Hash and $_key['name'] {
       apt::keyring { $_key['name']:
-        ensure           => $_key_ensure,
-        content          => $_key['content'],
-        source           => $_key['source'],
-        keyring_filename => $_key['filename'],
-        before           => $_before,
+        ensure   => $_key_ensure,
+        content  => $_key['content'],
+        source   => $_key['source'],
+        filename => $_key['filename'],
+        before   => $_before,
       }
       # TODO replace this block with a reference to the apt::keyring's final filename/full_path
       if $_key['filename'] {


### PR DESCRIPTION
- keyring: rename parameters to remove redundancy
- keyring: remove the file param
- source: allow passing all `apt::keyring` attributes
