### PR TITLE
ppa: include apt

### DIFF
--- a/examples/ppa.pp
+++ b/examples/ppa.pp
@@ -1,4 +1,2 @@
-class { 'apt': }
-
 # Example declaration of an Apt PPA
 apt::ppa { 'ppa:ubuntuhandbook1/apps': }

--- a/manifests/ppa.pp
+++ b/manifests/ppa.pp
@@ -31,6 +31,8 @@ define apt::ppa (
   Optional[String] $package_name        = $apt::ppa_package,
   Boolean $package_manage               = false,
 ) {
+  include apt
+
   unless $release {
     fail('os.distro.codename fact not available: release parameter required')
   }


### PR DESCRIPTION
## Summary

This makes the `apt::ppa` defined type easier to use without having to remember to `include` the `apt` class. The original version of `ppa.pp` did an `include` like this. See https://github.com/puppetlabs/puppetlabs-apt/pull/1152#issuecomment-1854787537

Also, the README doesn't say that you have to `include apt` to use `apt::ppa`: https://github.com/puppetlabs/puppetlabs-apt/blob/e0b3a5db6abb043f106614dffe341f68d88158ab/README.md?plain=1#L171-L175

Fixes #1151