### PR TITLE
replace deprecated merge() with native puppet code

### DIFF
--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -144,7 +144,7 @@ define apt::source (
       }
       if $key['id'] {
         # defaults like keyserver are only relevant to apt::key
-        $_key = merge($apt::source_key_defaults, $key)
+        $_key = $apt::source_key_defaults + $key
       } else {
         $_key = $key
       }


### PR DESCRIPTION
`merge()` was a function from stdlib. It got namespaced in stdlib 9 to `stdlib::merge()`. To stay compatible with both stdlib versions, we can just replace the code with the puppet-native `+`.