### PR TITLE
Support "hourly" and Integer as value for update frequency (fixes #1157)

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ If you raise the priority through the `pin` parameter to 500, normal policy goes
 
 ### Update the list of packages
 
-By default, Puppet runs `apt-get update` on the first Puppet run after you include the `apt` class, and anytime `notify => Exec['apt_update']` occurs; i.e., whenever config files get updated or other relevant changes occur. If you set `update['frequency']` to 'always', the update runs on every Puppet run. You can also set `update['frequency']` to 'daily' or 'weekly':
+By default, Puppet runs `apt-get update` on the first Puppet run after you include the `apt` class, and anytime `notify => Exec['apt_update']` occurs; i.e., whenever config files get updated or other relevant changes occur. If you set `update['frequency']` to 'always', the update runs on every Puppet run. You can also set `update['frequency']` to 'hourly', 'daily', 'weekly' or any integer value >= 60:
 
 ```puppet
 class { 'apt':

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -168,9 +168,11 @@ Options:
 `apt-get update` runs regardless of this value.
 Valid options:
   'always' (at every Puppet run);
-   daily' (if the value of `apt_update_last_success` is less than current epoch time minus 86400);
+  'hourly' (if the value of `apt_update_last_success` is less than current epoch time minus 3600);
+  'daily'  (if the value of `apt_update_last_success` is less than current epoch time minus 86400);
   'weekly' (if the value of `apt_update_last_success` is less than current epoch time minus 604800);
   'reluctantly' (only if the exec resource `apt_update` is notified).
+  Integer  (if the value of `apt_update_last_success` is less than current epoch time minus provided Integer value);
 Default: 'reluctantly'.
 * **:loglevel** `Integer`: Specifies the log level of logs outputted to the console. Default: undef.
 * **:timeout** `Integer`: Specifies how long to wait for the update to complete before canceling it. Valid options: an integer, in seconds. Default: undef.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -41,8 +41,10 @@
 #   `apt-get update` runs regardless of this value.
 #   Valid options:
 #     'always' (at every Puppet run); 
-#      daily' (if the value of `apt_update_last_success` is less than current epoch time minus 86400);
+#     'hourly' (if the value of `apt_update_last_success` is less than current epoch time minus 3600);
+#     'daily'  (if the value of `apt_update_last_success` is less than current epoch time minus 86400);
 #     'weekly' (if the value of `apt_update_last_success` is less than current epoch time minus 604800);
+#     Integer  (if the value of `apt_update_last_success` is less than current epoch time minus provided Integer value);
 #     'reluctantly' (only if the exec resource `apt_update` is notified).
 #   Default: 'reluctantly'.
 #
@@ -193,7 +195,7 @@ class apt (
 
   if $update['frequency'] {
     assert_type(
-      Enum['always','daily','weekly','reluctantly'],
+      Variant[Enum['always','hourly','daily','weekly','reluctantly'],Integer[60]],
       $update['frequency'],
     )
   }

--- a/manifests/update.pp
+++ b/manifests/update.pp
@@ -14,6 +14,36 @@ class apt::update {
     'always': {
       $_kick_apt = true
     }
+    Integer[60]:{
+      #compare current date with the apt_update_last_success fact to determine
+      #if we should kick apt_update.
+      $int_threshold = (Integer(Timestamp().strftime('%s')) - Integer($apt::_update['frequency']))
+      if $facts['apt_update_last_success'] {
+        if $facts['apt_update_last_success'] + 0 < $int_threshold {
+          $_kick_apt = true
+        } else {
+          $_kick_apt = false
+        }
+      } else {
+        #if apt-get update has not successfully run, we should kick apt_update
+        $_kick_apt = true
+      }
+    }
+    'hourly':{
+      #compare current date with the apt_update_last_success fact to determine
+      #if we should kick apt_update.
+      $hourly_threshold = (Integer(Timestamp().strftime('%s')) - 3600)
+      if $facts['apt_update_last_success'] {
+        if $facts['apt_update_last_success'] + 0 < $hourly_threshold {
+          $_kick_apt = true
+        } else {
+          $_kick_apt = false
+        }
+      } else {
+        #if apt-get update has not successfully run, we should kick apt_update
+        $_kick_apt = true
+      }
+    }
     'daily': {
       #compare current date with the apt_update_last_success fact to determine
       #if we should kick apt_update.

--- a/spec/classes/apt_update_spec.rb
+++ b/spec/classes/apt_update_spec.rb
@@ -174,7 +174,7 @@ describe 'apt::update', type: :class do
               apt_update_last_success: factval
             }
           end
-          let(:pre_condition) { "class{ '::apt': update => {'frequency' => '#{update_frequency}',} }" }
+          let(:pre_condition) { "class{ '::apt': update => {'frequency' => #{update_frequency.inspect},} }" }
 
           it 'triggers an apt-get update run' do
             # set the apt_update exec\'s refreshonly attribute to false
@@ -200,7 +200,7 @@ describe 'apt::update', type: :class do
             apt_update_last_success: Time.now.to_i
           }
         end
-        let(:pre_condition) { "class{ '::apt': update => {'frequency' => '#{update_frequency}',} }" }
+        let(:pre_condition) { "class{ '::apt': update => {'frequency' => #{update_frequency.inspect},} }" }
 
         it 'does not trigger an apt-get update run' do
           # don't change the apt_update exec\'s refreshonly attribute. (it should be true)
@@ -226,7 +226,7 @@ describe 'apt::update', type: :class do
             apt_update_last_success: nil
           }
         end
-        let(:pre_condition) { "class{ '::apt': update => {'frequency' => '#{update_frequency}',} }" }
+        let(:pre_condition) { "class{ '::apt': update => {'frequency' => #{update_frequency.inspect},} }" }
 
         it 'triggers an apt-get update run' do
           # set the apt_update exec\'s refreshonly attribute to false

--- a/spec/classes/apt_update_spec.rb
+++ b/spec/classes/apt_update_spec.rb
@@ -152,7 +152,7 @@ describe 'apt::update', type: :class do
     end
   end
 
-  ['daily', 'weekly'].each do |update_frequency|
+  ['hourly', 'daily', 'weekly', 60].each do |update_frequency|
     context "when apt::update['frequency'] has the value of #{update_frequency}" do
       pair = { 'we are due for a run' => 1_406_660_561, 'the update-success-stamp file does not exist' => -1 }
       pair.each_pair do |desc, factval|


### PR DESCRIPTION
## Summary
With these changes the update frequency accepts two more values as described in the linked issue.

## Related Issues
Add more possible values for update frequency (#1157)

## Checklist
- [X] 🟢 Spec tests.
- [X] Manually verified.