### PR TITLE
Backports: add keyring support

### DIFF
--- a/examples/backports.pp
+++ b/examples/backports.pp
@@ -4,8 +4,4 @@ class { 'apt::backports':
   location => 'http://us.archive.ubuntu.com/ubuntu',
   release  => 'trusty-backports',
   repos    => 'main universe multiverse restricted',
-  key      => {
-    id     => '630239CC130E1A7FD81A27B140976EAF437D05B5',
-    server => 'keyserver.ubuntu.com',
-  },
 }

--- a/manifests/backports.pp
+++ b/manifests/backports.pp
@@ -1,15 +1,7 @@
 # @summary Manages backports.
 #
-# @example Set up a backport source for Linux Mint qiana
-#   class { 'apt::backports':
-#     location => 'http://us.archive.ubuntu.com/ubuntu',
-#     release  => 'trusty-backports',
-#     repos    => 'main universe multiverse restricted',
-#     key      => {
-#       id     => '630239CC130E1A7FD81A27B140976EAF437D05B5',
-#       server => 'keyserver.ubuntu.com',
-#     },
-#   }
+# @example Set up a backport source for Ubuntu
+#   include apt::backports
 #
 # @param location
 #   Specifies an Apt repository containing the backports to manage. Valid options: a string containing a URL. Default value for Debian and
@@ -36,6 +28,11 @@
 #   Specifies a key to authenticate the backports. Valid options: a string to be passed to the id parameter of the apt::key defined type, or a
 #   hash of parameter => value pairs to be passed to apt::key's id, server, content, source, and/or options parameters.
 #
+# @param keyring
+#   Absolute path to a file containing the PGP keyring used to sign this
+#   repository. Value is passed to the apt::source and used to set signed-by on
+#   the source entry.
+#
 # @param pin
 #   Specifies a pin priority for the backports. Valid options: a number or string to be passed to the `id` parameter of the `apt::pin` defined
 #   type, or a hash of `parameter => value` pairs to be passed to `apt::pin`'s corresponding parameters.
@@ -48,6 +45,7 @@ class apt::backports (
   Optional[String] $release                     = undef,
   Optional[String] $repos                       = undef,
   Optional[Variant[String, Hash]] $key          = undef,
+  Stdlib::AbsolutePath $keyring                 = "/usr/share/keyrings/${facts['os']['name'].downcase}-archive-keyring.gpg",
   Variant[Integer, String, Hash] $pin           = 200,
   Variant[Hash] $include                        = {},
 ) {
@@ -56,21 +54,25 @@ class apt::backports (
   if $location {
     $_location = $location
   }
+
   if $release {
     $_release = $release
   }
+
   if $repos {
     $_repos = $repos
   }
 
   if (!($facts['os']['name'] == 'Debian' or $facts['os']['name'] == 'Ubuntu')) {
-    unless $location and $release and $repos and $key {
-      fail('If not on Debian or Ubuntu, you must explicitly pass location, release, repos, and key')
+    unless $location and $release and $repos {
+      fail('If not on Debian or Ubuntu, you must explicitly pass location, release, and repos')
     }
   }
+
   unless $location {
     $_location = $apt::backports['location']
   }
+
   unless $release {
     if fact('os.distro.codename') {
       $_release = "${fact('os.distro.codename')}-backports"
@@ -78,8 +80,15 @@ class apt::backports (
       fail('os.distro.codename fact not available: release parameter required')
     }
   }
+
   unless $repos {
     $_repos = $apt::backports['repos']
+  }
+
+  $_keyring = if $key {
+    undef
+  } else {
+    $keyring
   }
 
   if $pin =~ Hash {
@@ -101,6 +110,7 @@ class apt::backports (
     repos    => $_repos,
     include  => $include,
     key      => $key,
+    keyring  => $_keyring,
     pin      => $_pin,
   }
 }

--- a/spec/classes/apt_backports_spec.rb
+++ b/spec/classes/apt_backports_spec.rb
@@ -34,6 +34,7 @@ describe 'apt::backports', type: :class do
             'priority' => 200,
             'release' => 'bullseye-backports'
           },
+          keyring: '/usr/share/keyrings/debian-archive-keyring.gpg',
         )
       }
     end
@@ -65,6 +66,7 @@ describe 'apt::backports', type: :class do
             'priority' => 200,
             'release' => 'jammy-backports'
           },
+          keyring: '/usr/share/keyrings/ubuntu-archive-keyring.gpg',
         )
       }
     end
@@ -144,7 +146,7 @@ describe 'apt::backports', type: :class do
     end
   end
 
-  describe 'mint tests' do
+  describe 'linuxmint tests' do
     let(:facts) do
       {
         os: {
@@ -193,7 +195,7 @@ describe 'apt::backports', type: :class do
       end
 
       it do
-        expect(subject).to raise_error(Puppet::Error, %r{If not on Debian or Ubuntu, you must explicitly pass location, release, repos, and key})
+        expect(subject).to raise_error(Puppet::Error, %r{If not on Debian or Ubuntu, you must explicitly pass location, release, and repos})
       end
     end
 
@@ -207,7 +209,7 @@ describe 'apt::backports', type: :class do
       end
 
       it do
-        expect(subject).to raise_error(Puppet::Error, %r{If not on Debian or Ubuntu, you must explicitly pass location, release, repos, and key})
+        expect(subject).to raise_error(Puppet::Error, %r{If not on Debian or Ubuntu, you must explicitly pass location, release, and repos})
       end
     end
 
@@ -221,21 +223,7 @@ describe 'apt::backports', type: :class do
       end
 
       it do
-        expect(subject).to raise_error(Puppet::Error, %r{If not on Debian or Ubuntu, you must explicitly pass location, release, repos, and key})
-      end
-    end
-
-    context 'with missing key' do
-      let(:params) do
-        {
-          location: 'http://archive.ubuntu.com/ubuntu',
-          release: 'trusty-backports',
-          repos: 'main universe multiverse restricted'
-        }
-      end
-
-      it do
-        expect(subject).to raise_error(Puppet::Error, %r{If not on Debian or Ubuntu, you must explicitly pass location, release, repos, and key})
+        expect(subject).to raise_error(Puppet::Error, %r{If not on Debian or Ubuntu, you must explicitly pass location, release, and repos})
       end
     end
   end

--- a/spec/classes/apt_backports_spec.rb
+++ b/spec/classes/apt_backports_spec.rb
@@ -3,21 +3,22 @@
 require 'spec_helper'
 
 describe 'apt::backports', type: :class do
-  let(:pre_condition) { "class{ '::apt': }" }
+  let(:pre_condition) { 'include apt' }
 
   describe 'debian/ubuntu tests' do
-    context 'with defaults on deb' do
+    context 'with defaults on debian' do
       let(:facts) do
         {
           os: {
             family: 'Debian',
             name: 'Debian',
             release: {
-              major: '9',
-              full: '9.0'
+              full: '11.8',
+              major: '11',
+              minor: '8'
             },
             distro: {
-              codename: 'stretch',
+              codename: 'bullseye',
               id: 'Debian'
             }
           }
@@ -27,8 +28,8 @@ describe 'apt::backports', type: :class do
       it {
         expect(subject).to contain_apt__source('backports').with(location: 'http://deb.debian.org/debian',
                                                                  repos: 'main contrib non-free',
-                                                                 release: 'stretch-backports',
-                                                                 pin: { 'priority' => 200, 'release' => 'stretch-backports' })
+                                                                 release: 'bullseye-backports',
+                                                                 pin: { 'priority' => 200, 'release' => 'bullseye-backports' })
       }
     end
 
@@ -39,11 +40,11 @@ describe 'apt::backports', type: :class do
             family: 'Debian',
             name: 'Ubuntu',
             release: {
-              major: '18',
-              full: '18.04'
+              major: '22.04',
+              full: '22.04'
             },
             distro: {
-              codename: 'bionic',
+              codename: 'jammy',
               id: 'Ubuntu'
             }
           }
@@ -53,8 +54,8 @@ describe 'apt::backports', type: :class do
       it {
         expect(subject).to contain_apt__source('backports').with(location: 'http://archive.ubuntu.com/ubuntu',
                                                                  repos: 'main universe multiverse restricted',
-                                                                 release: 'bionic-backports',
-                                                                 pin: { 'priority' => 200, 'release' => 'bionic-backports' })
+                                                                 release: 'jammy-backports',
+                                                                 pin: { 'priority' => 200, 'release' => 'jammy-backports' })
       }
     end
 
@@ -65,11 +66,11 @@ describe 'apt::backports', type: :class do
             family: 'Debian',
             name: 'Ubuntu',
             release: {
-              major: '18',
-              full: '18.04'
+              major: '22.04',
+              full: '22.04'
             },
             distro: {
-              codename: 'bionic',
+              codename: 'jammy',
               id: 'Ubuntu'
             }
           }
@@ -101,11 +102,11 @@ describe 'apt::backports', type: :class do
             family: 'Debian',
             name: 'Ubuntu',
             release: {
-              major: '18',
-              full: '18.04'
+              major: '22.04',
+              full: '22.04'
             },
             distro: {
-              codename: 'bionic',
+              codename: 'jammy',
               id: 'Ubuntu'
             }
           }
@@ -230,11 +231,11 @@ describe 'apt::backports', type: :class do
           family: 'Debian',
           name: 'Ubuntu',
           release: {
-            major: '18',
-            full: '18.04'
+            major: '22.04',
+            full: '22.04'
           },
           distro: {
-            codename: 'bionic',
+            codename: 'jammy',
             id: 'Ubuntu'
           }
         }

--- a/spec/classes/apt_backports_spec.rb
+++ b/spec/classes/apt_backports_spec.rb
@@ -26,10 +26,15 @@ describe 'apt::backports', type: :class do
       end
 
       it {
-        expect(subject).to contain_apt__source('backports').with(location: 'http://deb.debian.org/debian',
-                                                                 repos: 'main contrib non-free',
-                                                                 release: 'bullseye-backports',
-                                                                 pin: { 'priority' => 200, 'release' => 'bullseye-backports' })
+        expect(subject).to contain_apt__source('backports').with(
+          location: 'http://deb.debian.org/debian',
+          repos: 'main contrib non-free',
+          release: 'bullseye-backports',
+          pin: {
+            'priority' => 200,
+            'release' => 'bullseye-backports'
+          },
+        )
       }
     end
 
@@ -52,10 +57,15 @@ describe 'apt::backports', type: :class do
       end
 
       it {
-        expect(subject).to contain_apt__source('backports').with(location: 'http://archive.ubuntu.com/ubuntu',
-                                                                 repos: 'main universe multiverse restricted',
-                                                                 release: 'jammy-backports',
-                                                                 pin: { 'priority' => 200, 'release' => 'jammy-backports' })
+        expect(subject).to contain_apt__source('backports').with(
+          location: 'http://archive.ubuntu.com/ubuntu',
+          repos: 'main universe multiverse restricted',
+          release: 'jammy-backports',
+          pin: {
+            'priority' => 200,
+            'release' => 'jammy-backports'
+          },
+        )
       }
     end
 
@@ -87,11 +97,13 @@ describe 'apt::backports', type: :class do
       end
 
       it {
-        expect(subject).to contain_apt__source('backports').with(location: 'http://archive.ubuntu.com/ubuntu-test',
-                                                                 key: 'A1BD8E9D78F7FE5C3E65D8AF8B48AD6246925553',
-                                                                 repos: 'main',
-                                                                 release: 'vivid',
-                                                                 pin: { 'priority' => 90, 'release' => 'vivid' })
+        expect(subject).to contain_apt__source('backports').with(
+          location: 'http://archive.ubuntu.com/ubuntu-test',
+          key: 'A1BD8E9D78F7FE5C3E65D8AF8B48AD6246925553',
+          repos: 'main',
+          release: 'vivid',
+          pin: { 'priority' => 90, 'release' => 'vivid' },
+        )
       }
     end
 
@@ -124,8 +136,10 @@ describe 'apt::backports', type: :class do
       end
 
       it {
-        expect(subject).to contain_apt__source('backports').with(key: { 'id' => 'A1BD8E9D78F7FE5C3E65D8AF8B48AD6246925553' },
-                                                                 pin: { 'priority' => '90' })
+        expect(subject).to contain_apt__source('backports').with(
+          key: { 'id' => 'A1BD8E9D78F7FE5C3E65D8AF8B48AD6246925553' },
+          pin: { 'priority' => '90' },
+        )
       }
     end
   end
@@ -159,11 +173,13 @@ describe 'apt::backports', type: :class do
       end
 
       it {
-        expect(subject).to contain_apt__source('backports').with(location: 'http://archive.ubuntu.com/ubuntu',
-                                                                 key: '630239CC130E1A7FD81A27B140976EAF437D05B5',
-                                                                 repos: 'main universe multiverse restricted',
-                                                                 release: 'trusty-backports',
-                                                                 pin: { 'priority' => 200, 'release' => 'trusty-backports' })
+        expect(subject).to contain_apt__source('backports').with(
+          location: 'http://archive.ubuntu.com/ubuntu',
+          key: '630239CC130E1A7FD81A27B140976EAF437D05B5',
+          repos: 'main universe multiverse restricted',
+          release: 'trusty-backports',
+          pin: { 'priority' => 200, 'release' => 'trusty-backports' },
+        )
       }
     end
 


### PR DESCRIPTION
This adds support for the `keyring` parameter of `apt::source` (https://github.com/puppetlabs/puppetlabs-apt/blob/0871cadcdcbc5f0e6540298fa11e9a3ebe884735/manifests/source.pp#L90) to the `apt::backports` class. This is needed to allow for adding `signed-by=…` to the backports `sources.list.d` entry created by this class. The default is to use the Debian or Ubuntu archive keyring installed by the [debian-archive-keyring](https://tracker.debian.org/pkg/debian-archive-keyring) or [ubuntu-keyring](https://launchpad.net/ubuntu/+source/ubuntu-keyring) packages. If `$key` is specified, then that parameter takes precedence to avoid breaking existing setups that specify `$key`, since otherwise we would be providing both `$key` and `$keyring` to `apt::source`, which is an error (https://github.com/puppetlabs/puppetlabs-apt/blob/0871cadcdcbc5f0e6540298fa11e9a3ebe884735/manifests/source.pp#L136).

I didn't make an effort to support linuxmint or other OSes besides Debian and Ubuntu, since we only declare support for Debian and Ubuntu: https://github.com/puppetlabs/puppetlabs-apt/blob/0871cadcdcbc5f0e6540298fa11e9a3ebe884735/metadata.json#L16-L32 But, the best way to support other OSes would be to eliminate `params.pp` and use hiera data, since the default value for `$keyring` would be different ([linuxmint](http://packages.linuxmint.com/pool/main/l/linuxmint-keyring/) would use `/usr/share/keyrings/linuxmint-keyring.gpg`, for example).

Easiest to review the individual commits.