### PR TITLE
Support PPA in deb822 format

### DIFF
--- a/lib/facter/apt_sources.rb
+++ b/lib/facter/apt_sources.rb
@@ -5,7 +5,7 @@ Facter.add(:apt_sources) do
   confine osfamily: 'Debian'
   setcode do
     sources = ['sources.list']
-    Dir.glob('/etc/apt/sources.list.d/*.list').each do |file|
+    Dir.glob('/etc/apt/sources.list.d/*.{list,sources}').each do |file|
       sources.push(File.basename(file))
     end
     sources

--- a/manifests/ppa.pp
+++ b/manifests/ppa.pp
@@ -53,10 +53,10 @@ define apt::ppa (
   $underscore_filename_no_slashes      = regsubst($underscore_filename, '/', '-', 'G')
   $underscore_filename_no_specialchars = regsubst($underscore_filename_no_slashes, '[\.\+]', '_', 'G')
 
-  if versioncmp($facts['os']['release']['full'], '23.10') < 0 {
-    $sources_list_d_filename  = "${dash_filename_no_specialchars}-${release}.list"
+  $sources_list_d_filename = if versioncmp($facts['os']['release']['full'], '23.10') < 0 {
+    "${dash_filename_no_specialchars}-${release}.list"
   } else {
-    $sources_list_d_filename  = "${dash_filename_no_specialchars}-${release}.sources"
+    $"${dash_filename_no_specialchars}-${release}.sources"
   }
 
   if versioncmp($facts['os']['release']['full'], '21.04') < 0 {

--- a/manifests/ppa.pp
+++ b/manifests/ppa.pp
@@ -56,7 +56,7 @@ define apt::ppa (
   $sources_list_d_filename = if versioncmp($facts['os']['release']['full'], '23.10') < 0 {
     "${dash_filename_no_specialchars}-${release}.list"
   } else {
-    $"${dash_filename_no_specialchars}-${release}.sources"
+    "${dash_filename_no_specialchars}-${release}.sources"
   }
 
   if versioncmp($facts['os']['release']['full'], '21.04') < 0 {

--- a/manifests/ppa.pp
+++ b/manifests/ppa.pp
@@ -53,7 +53,11 @@ define apt::ppa (
   $underscore_filename_no_slashes      = regsubst($underscore_filename, '/', '-', 'G')
   $underscore_filename_no_specialchars = regsubst($underscore_filename_no_slashes, '[\.\+]', '_', 'G')
 
-  $sources_list_d_filename  = "${dash_filename_no_specialchars}-${release}.list"
+  if versioncmp($facts['os']['release']['full'], '23.10') < 0 {
+    $sources_list_d_filename  = "${dash_filename_no_specialchars}-${release}.list"
+  } else {
+    $sources_list_d_filename  = "${dash_filename_no_specialchars}-${release}.sources"
+  }
 
   if versioncmp($facts['os']['release']['full'], '21.04') < 0 {
     $trusted_gpg_d_filename = "${underscore_filename_no_specialchars}.gpg"


### PR DESCRIPTION
## Summary
Since Ubuntu 23.10, `add-apt-repository` no longer creates a `.list` file but a `.sources` file (in deb822 format).

## Additional Context

## Related Issues (if any)

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [X] Manually verified. (For example `puppet apply`)