### PR TITLE
Add deb822 format ppa support on Ubuntu 24.04

### DIFF
--- a/lib/facter/apt_sources.rb
+++ b/lib/facter/apt_sources.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
-# This fact lists the .list filenames that are used by apt.
+# This fact lists the .list and .sources filenames that are used by apt.
 Facter.add(:apt_sources) do
   confine osfamily: 'Debian'
   setcode do
     sources = ['sources.list']
     Dir.glob('/etc/apt/sources.list.d/*.list').each do |file|
+      sources.push(File.basename(file))
+    end
+    Dir.glob('/etc/apt/sources.list.d/*.sources').each do |file|
       sources.push(File.basename(file))
     end
     sources

--- a/manifests/ppa.pp
+++ b/manifests/ppa.pp
@@ -53,7 +53,11 @@ define apt::ppa (
   $underscore_filename_no_slashes      = regsubst($underscore_filename, '/', '-', 'G')
   $underscore_filename_no_specialchars = regsubst($underscore_filename_no_slashes, '[\.\+]', '_', 'G')
 
-  $sources_list_d_filename  = "${dash_filename_no_specialchars}-${release}.list"
+  if versioncmp($facts['os']['release']['full'], '24.04') < 0 {
+    $sources_list_d_filename  = "${dash_filename_no_specialchars}-${release}.list"
+  } else {
+    $sources_list_d_filename  = "${dash_filename_no_specialchars}-${release}.sources"
+  }
 
   if versioncmp($facts['os']['release']['full'], '21.04') < 0 {
     $trusted_gpg_d_filename = "${underscore_filename_no_specialchars}.gpg"


### PR DESCRIPTION
## Summary
New repo added using add-apt-repository command have a .sources extension (used to be .list)
Without this update, add-apt-repository keeps being called for ppa repo on each Puppet run because if does not look for .sources files

## Additional Context
This only covers repo adde using add-apt-repository command

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)