### PR TITLE
Running autoremove in non-interactive mode

### DIFF
--- a/tasks/init.rb
+++ b/tasks/init.rb
@@ -8,7 +8,7 @@ require 'puppet'
 def apt_get(action)
   cmd = ['apt-get', action]
   cmd << '-y' if ['upgrade', 'dist-upgrade', 'autoremove'].include?(action)
-  if ['upgrade', 'dist-upgrade'].include?(action)
+  if ['upgrade', 'dist-upgrade', 'autoremove'].include?(action)
     ENV['DEBIAN_FRONTEND'] = 'noninteractive'
     cmd << '-o'
     cmd << 'Dpkg::Options="--force-confdef"'


### PR DESCRIPTION
## Summary
The pipelines for ubuntu-2204-lts-arm64 platform were failing due to connection timeout issue.

## Additional Context
- Upon investigation it was found that the `apt-get autoremove -y` command is getting stuck.
- To fix this issue, now it has been added to the list of commands which run in an non-interactive mode .

## Related Issues (if any)
NA

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)