### PR TITLE
apt::setting: Dont expect source/content when removing settings

### DIFF
--- a/manifests/setting.pp
+++ b/manifests/setting.pp
@@ -30,8 +30,10 @@ define apt::setting (
     fail('apt::setting cannot have both content and source')
   }
 
-  if !$content and !$source {
-    fail('apt::setting needs either of content or source')
+  if $ensure != 'absent' {
+    if !$content and !$source {
+      fail('apt::setting needs either of content or source')
+    }
   }
 
   $title_array = split($title, '-')

--- a/spec/defines/setting_spec.rb
+++ b/spec/defines/setting_spec.rb
@@ -143,8 +143,15 @@ describe 'apt::setting' do
     it { is_expected.to contain_file('/etc/apt/apt.conf.d/100teddybear').that_notifies('Class[Apt::Update]') }
   end
 
-  describe 'with ensure=absent' do
+  describe 'with ensure=absent and default params' do
     let(:params) { default_params.merge(ensure: 'absent') }
+
+    it {
+      expect(subject).to contain_file('/etc/apt/apt.conf.d/50teddybear').that_notifies('Class[Apt::Update]').with(ensure: 'absent')
+    }
+  end
+  describe 'with ensure=absent and without default params' do
+    let(:params) { { ensure: 'absent' } }
 
     it {
       expect(subject).to contain_file('/etc/apt/apt.conf.d/50teddybear').that_notifies('Class[Apt::Update]').with(ensure: 'absent')


### PR DESCRIPTION
## Summary

I think https://github.com/puppetlabs/puppetlabs-apt/commit/1e1baadf8158a878562b8aab1924a3db5b777a0c#diff-792ade83ea45b5c6696875678e6e7cc52f4a105db6ed4d8b6f2933ec5d7d6f3bR25-R26 introduced a regression. I'm not an apt expert, but I think it doesn't make sense to provide content or source when removing something.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)