### PR TITLE
fix: add ensure for ppa lock file

### DIFF
--- a/manifests/ppa.pp
+++ b/manifests/ppa.pp
@@ -109,7 +109,9 @@ define apt::ppa (
       }
     }
 
-    file { "${apt::sources_list_d}/${sources_list_d_filename}": }
+    file { "${apt::sources_list_d}/${sources_list_d_filename}":
+      ensure => 'file',
+    }
   }
   else {
     tidy { "remove-apt-repository-script-${name}":


### PR DESCRIPTION
## Summary
The lock file used by the apt::ppa resource miss the `ensure => file` attribute and so never created leading to a constant repository installation.

## Related Issues (if any)
Fix issue #1210 

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)