### PR TITLE
Shorten the conditionals in apt::source

### DIFF
--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -288,11 +288,10 @@ define apt::source (
           fail('cannot create a source entry without specifying a location')
         }
       }
-      if (type($location, 'generalized') !~ Type[Array]) {
+      if $location !~ Array {
         warning('For deb822 sources, location must be specified as an array.')
         $_location = [$location]
-      }
-      else {
+      } else {
         $_location = $location
       }
 
@@ -302,30 +301,23 @@ define apt::source (
         } else {
           fail('os.distro.codename fact not available: release parameter required')
         }
+      } elsif $release !~ Array {
+        warning("For deb822 sources, 'release' must be specified as an array. Converting to array.")
+        $_release = [$release]
       } else {
-        if (type($release, 'generalized') !~ Type[Array]) {
-          warning("For deb822 sources, 'release' must be specified as an array. Converting to array.")
-          $_release = [$release]
-        } else {
-          $_release = $release
-        }
+        $_release = $release
       }
 
-      if (type($repos, 'generalized') !~ Type[Array]) {
+      if $repos !~ Array {
         warning("For deb822 sources, 'repos' must be specified as an array. Converting to array.")
         $_repos = split($repos, /\s+/)
       } else {
         $_repos = $repos
       }
 
-      if $architecture != undef {
-        if (type($architecture, 'generalized') !~ Type[Array]) {
-          warning("For deb822 sources, 'architecture' must be specified as an array. Converting to array.")
-          $_architecture = split($architecture, '[,]')
-        }
-        else {
-          $_architecture = $architecture
-        }
+      if $architecture and $architecture !~ Array {
+        warning("For deb822 sources, 'architecture' must be specified as an array. Converting to array.")
+        $_architecture = split($architecture, '[,]')
       } else {
         $_architecture = $architecture
       }


### PR DESCRIPTION
## Summary

Rather than writing:

```puppet
type($release, 'generalized') !~ Type[Array]
```

This uses:

```puppet
$release !~ Array
```

Which is equal, but shorter.

It also refactors some conditionals merge some branches which results in shorter code and arguably easier to read.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [x] Thought process behind the implementation.

## Related Issues (if any)

Initially introduced in https://github.com/puppetlabs/puppetlabs-apt/pull/1167.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)