### PR TITLE
Handle repos passed as an array for list format

### DIFF
--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -139,6 +139,8 @@ define apt::source (
 
       if $release =~ Pattern[/\/$/] {
         $_components = $_release
+      } elsif $repos =~ Array {
+        $_components = join([$_release] + $repos, ' ')
       } else {
         $_components = "${_release} ${repos}"
       }

--- a/spec/defines/source_spec.rb
+++ b/spec/defines/source_spec.rb
@@ -36,6 +36,24 @@ describe 'apt::source' do
       it {
         expect(subject).to contain_apt__setting('list-my_source').with(ensure: 'present').without_content(%r{# my_source\ndeb-src hello.there wheezy main\n})
       }
+
+      context 'with repos' do
+        context 'as empty array' do
+          let(:params) { super().merge(repos: []) }
+
+          it {
+            expect(subject).to contain_apt__setting('list-my_source').with(ensure: 'present').without_content(%r{# my_source\ndeb-src hello.there wheezy\n})
+          }
+        end
+
+        context 'as non-empty array' do
+          let(:params) { super().merge(repos: ['main', 'non-free', 'contrib']) }
+
+          it {
+            expect(subject).to contain_apt__setting('list-my_source').with(ensure: 'present').without_content(%r{# my_source\ndeb-src hello.there wheezy main non-free contrib\n})
+          }
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## Summary

In 9876c31aff7e738c9d533c556192591f991aa4af the parameter repos was changed to no longer allow an empty string. It does allow an array, but that isn't specifically handled for the list format.

I'll admit that I didn't verify if it was an issue before and only determined this by reading the code, but now a test case is added as well to ensure it continues working.

## Additional Context

Add any additional context about the problem here.
- [ ] Root cause and the steps to reproduce. (If applicable)
- [x] Thought process behind the implementation.

## Related Issues (if any)

- https://github.com/puppetlabs/puppetlabs-apt/pull/1167

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)