### PR TITLE
fix: allow plus signs in ppa

### DIFF
--- a/manifests/ppa.pp
+++ b/manifests/ppa.pp
@@ -40,7 +40,7 @@ define apt::ppa (
   }
 
   # Validate the resource name
-  if $name !~ /^ppa:([a-zA-Z0-9\-_.]+)\/([a-zA-z0-9\-_\.]+)$/ {
+  if $name !~ /^ppa:([a-zA-Z0-9\-_.+]+)\/([a-zA-z0-9\-_.+]+)$/ {
     fail("Invalid PPA name: ${name}")
   }
 

--- a/spec/defines/ppa_spec.rb
+++ b/spec/defines/ppa_spec.rb
@@ -50,6 +50,8 @@ describe 'apt::ppa' do
     'ppa:foo/bar1.0',
     'ppa:foo10/bar10',
     'ppa:foo-/bar_',
+    'ppa:foo/bar+',
+    'ppa:foo+/bar',
   ].each do |value|
     describe 'valid resource names' do
       let :facts do


### PR DESCRIPTION

## Summary

PPA names can have plus signs

    From Launchpad:

    > At least one lowercase letter or number, followed by letters, numbers,
    > dots, hyphens or pluses. Keep this name short; it is used in URLs.


## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)