### PR TITLE
fixed deb822 template to support trailing / with Suites

### DIFF
--- a/templates/source_deb822.epp
+++ b/templates/source_deb822.epp
@@ -14,8 +14,11 @@
 Enabled: <%= $enabled %>
 Types: <% $types.each |String $type| { -%> <%= $type %> <% } %>
 URIs: <% $uris.each | String $uri | { -%> <%= $uri %> <% } %>
-Suites: <% $suites.each | String $suite | { -%> <%= $suite %> <% } %>
-Components: <% $components.each | String $component | { -%> <%= $component %> <% } %>
+Suites: <% $suites.each |String $suite| { -%> <%= $suite %>
+<% if $suite !~ /\/$/ { -%>
+Components: <% $components.each |String $component| { -%> <%= $component %> <% } -%>
+<% } -%>
+<% } -%>
 <% if $architectures { -%>
 Architectures:<% $architectures.each | String $arch | { %> <%= $arch %><% } %>
 <%- } -%>

--- a/templates/source_deb822.epp
+++ b/templates/source_deb822.epp
@@ -12,11 +12,11 @@
 | -%>
 # <%= $comment %>
 Enabled: <%= $enabled %>
-Types: <% $types.each |String $type| { -%> <%= $type %> <% } %>
+Types: <% $types.each | String $type | { -%> <%= $type %> <% } %>
 URIs: <% $uris.each | String $uri | { -%> <%= $uri %> <% } %>
-Suites: <% $suites.each |String $suite| { -%> <%= $suite %> <% } %>
+Suites: <% $suites.each | String $suite | { -%> <%= $suite %> <% } %>
 <% if $suites[0] !~ /\/$/ { -%>
-Components: <% $components.each |String $component| { -%> <%= $component %> <% } %>
+Components: <% $components.each | String $component | { -%> <%= $component %> <% } %>
 <% } -%>
 <% if $architectures { -%>
 Architectures:<% $architectures.each | String $arch | { %> <%= $arch %><% } %>

--- a/templates/source_deb822.epp
+++ b/templates/source_deb822.epp
@@ -14,10 +14,9 @@
 Enabled: <%= $enabled %>
 Types: <% $types.each |String $type| { -%> <%= $type %> <% } %>
 URIs: <% $uris.each | String $uri | { -%> <%= $uri %> <% } %>
-Suites: <% $suites.each |String $suite| { -%> <%= $suite %>
-<% if $suite !~ /\/$/ { -%>
-Components: <% $components.each |String $component| { -%> <%= $component %> <% } -%>
-<% } -%>
+Suites: <% $suites.each |String $suite| { -%> <%= $suite %> <% } %>
+<% if $suites[0] !~ /\/$/ { -%>
+Components: <% $components.each |String $component| { -%> <%= $component %> <% } %>
 <% } -%>
 <% if $architectures { -%>
 Architectures:<% $architectures.each | String $arch | { %> <%= $arch %><% } %>


### PR DESCRIPTION
## Describe the Bug
`Components` in [deb822 template](https://github.com/puppetlabs/puppetlabs-apt/blob/main/templates/source_deb822.epp) must be optional according to [this documentation](https://repolib.readthedocs.io/en/latest/deb822-format.html#suites) if `Suites ` ends with a `/`.  Otherwise we will get the following error
`E: Malformed entry 1 in sources file /etc/apt/sources.list.d/example.sources (absolute Suite Component)`

## Environment
 - Platform: Ubuntu 24.04