### PR TITLE
Suites with a path don't get components

### DIFF
--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -310,7 +310,12 @@ define apt::source (
         $_release = $release
       }
 
-      if $repos !~ Array {
+      # The deb822 format requires that if the Suite ($release) is a path (contains a /) that
+      # the Components field be absent.  Check the original
+      $_releasefilter = $_release.any |$item| { $item.index('/') != undef }
+      if $_releasefilter {
+        $_repos = undef
+      } elsif $repos !~ Array {
         warning("For deb822 sources, 'repos' must be specified as an array. Converting to array.")
         $_repos = split($repos, /\s+/)
       } else {

--- a/spec/defines/source_spec.rb
+++ b/spec/defines/source_spec.rb
@@ -480,6 +480,24 @@ describe 'apt::source' do
       it { is_expected.to contain_apt__setting("sources-#{title}").with_content(%r{Trusted: yes}) }
     end
 
+    context 'path based deb822 source' do
+      let :params do
+        super().merge(
+          {
+            location: ['http://fr.debian.org/debian', 'http://de.debian.org/debian'],
+            release: ['./'],
+            allow_unsigned: true,
+          },
+        )
+      end
+
+      it { is_expected.to contain_apt__setting("sources-#{title}").with_content(%r{Enabled: yes}) }
+      it { is_expected.to contain_apt__setting("sources-#{title}").with_content(%r{URIs: http://fr.debian.org/debian http://de.debian.org/debian}) }
+      it { is_expected.to contain_apt__setting("sources-#{title}").with_content(%r{Suites: ./}) }
+      it { is_expected.to contain_apt__setting("sources-#{title}").without_content(%r{Components:}) }
+      it { is_expected.to contain_apt__setting("sources-#{title}").with_content(%r{Trusted: yes}) }
+    end
+
     context '.list backwards compatibility' do
       let :params do
         super().merge(

--- a/templates/source_deb822.epp
+++ b/templates/source_deb822.epp
@@ -3,7 +3,7 @@
   Array[String] $types,
   Array[String] $uris,
   Array[String] $suites,
-  Array[String] $components,
+  Optional[Array[String]] $components = undef,
   Optional[Array] $architectures = undef,
   Optional[Enum['yes','no']] $allow_insecure = undef,
   Optional[Enum['yes','no']] $repo_trusted = undef,
@@ -15,7 +15,9 @@ Enabled: <%= $enabled %>
 Types: <% $types.each |String $type| { -%> <%= $type %> <% } %>
 URIs: <% $uris.each | String $uri | { -%> <%= $uri %> <% } %>
 Suites: <% $suites.each | String $suite | { -%> <%= $suite %> <% } %>
+<% if $components { -%>
 Components: <% $components.each | String $component | { -%> <%= $component %> <% } %>
+<%- } -%>
 <% if $architectures { -%>
 Architectures:<% $architectures.each | String $arch | { %> <%= $arch %><% } %>
 <%- } -%>


### PR DESCRIPTION
## Summary
Per https://repolib.readthedocs.io/en/latest/deb822-format.html#suites, if Suites is defined as a path, Components shouldn't be set.  

## Checklist
- [x] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)