### PR TITLE
join key dir and key filename/name with slash "/"

### DIFF
--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -217,11 +217,11 @@ define apt::source (
           }
 
           $_list_keyring = if $_key['dir'] and $_key['filename'] {
-            "${_key['dir']}${_key['filename']}"
+            "${_key['dir']}/${_key['filename']}"
           } elsif $_key['filename'] {
             "/etc/apt/keyrings/${_key['filename']}"
           } elsif $_key['dir'] {
-            "${_key['dir']}${_key['name']}"
+            "${_key['dir']}/${_key['name']}"
           } else {
             "/etc/apt/keyrings/${_key['name']}"
           }


### PR DESCRIPTION
## Summary
The `apt-key` definition provides `dir`, `name` and `filename`.

In the `manifest/keyring.pp` (`apt::keyring`) the destination file on the filesystem is generated as `$file = "${dir}/${filename}"`.

In the `manifest/source.pp` (`apt::source`) the destination file is generated with the follwing code
```
$_list_keyring = if $_key['dir'] and $_key['filename'] {
  "${_key['dir']}${_key['filename']}"
} elsif $_key['filename'] {
  "/etc/apt/keyrings/${_key['filename']}"
} elsif $_key['dir'] {
  "${_key['dir']}${_key['name']}"
} else {
  "/etc/apt/keyrings/${_key['name']}"
}
```
If the `$_list_keyring` is generated from `dir` and `filename` or `name`, then there is no `/` separator between `dir` and `filename`. The `key::dir:` of the `apt::source` has to contains the `/` otherwise incorrect filename will be generated. This PR just create final full filename by joining directory name with filename using directory separator slash `/`.

