### PR TITLE
Bugfix - sources format and ensure => absent fails

### DIFF
--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -254,6 +254,7 @@ define apt::source (
           'components'       => $_components,
         }
       )
+      $_content = "${header}${source_content}"
 
       if $pin {
         if $pin =~ Hash {
@@ -346,10 +347,10 @@ define apt::source (
               }
             )
           )
+          $_content = "${header}${source_content}"
         }
         'absent': {
-          $header = undef
-          $source_content = undef
+          $_content = undef
         }
         default: {
           fail('Unexpected value for $ensure parameter.')
@@ -362,7 +363,7 @@ define apt::source (
   }
   apt::setting { "${_file_suffix}-${name}":
     ensure        => $ensure,
-    content       => "${header}${source_content}",
+    content       => $_content,
     notify_update => $notify_update,
   }
 }

--- a/spec/defines/source_spec.rb
+++ b/spec/defines/source_spec.rb
@@ -516,5 +516,36 @@ describe 'apt::source' do
 
       it { is_expected.to contain_apt__setting("sources-#{title}").with_notify_update(true) }
     end
+
+    context 'absent deb822 source' do
+      let :params do
+        super().merge(
+          {
+            ensure: 'absent',
+          },
+        )
+      end
+
+      it { is_expected.to contain_apt__setting("sources-#{title}").with_ensure('absent') }
+    end
+
+    context 'absent complex deb822 source' do
+      let :params do
+        super().merge(
+          {
+            ensure: 'absent',
+            types: ['deb', 'deb-src'],
+            location: ['http://fr.debian.org/debian', 'http://de.debian.org/debian'],
+            release: ['stable', 'stable-updates', 'stable-backports'],
+            repos: ['main', 'contrib', 'non-free'],
+            architecture: ['amd64', 'i386'],
+            allow_unsigned: true,
+            notify_update: false
+          },
+        )
+      end
+
+      it { is_expected.to contain_apt__setting("sources-#{title}").with_ensure('absent') }
+    end
   end
 end


### PR DESCRIPTION
## Summary

```puppet
apt::source{
  ensure        => absent,
  source_format => sources,
}
```

produces a compile error every time.

```
    Puppet::PreformattedError:
       Evaluation Error: Error while evaluating a Resource Statement, Apt::Setting[sources-my_source]: parameter 'content' expects a value of type Undef or String[1], got String (file: /home/steve/GIT/puppetlabs-apt/spec/fixtures/modules/apt/manifests/source.pp, line: 363) on node legion.lan
```
