### PR TITLE
Refresh expired GPG key when using keyring

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -772,7 +772,7 @@ Default value: `undef`
 
 ##### <a name="-apt--keyring--ensure"></a>`ensure`
 
-Data type: `Enum['present','absent']`
+Data type: `Enum['present','refreshed','absent']`
 
 Ensure presence or absence of the resource.
 

--- a/manifests/keyring.pp
+++ b/manifests/keyring.pp
@@ -61,7 +61,7 @@ define apt::keyring (
       }
 
       if $ensure == 'refreshed' {
-        exec {"check_keyring_${name}":
+        exec { "check_keyring_${name}":
           command => "rm ${file}",
           onlyif  => "test -f ${file} && gpg --show-keys --list-options show-sig-expire ${file} | grep expired",
           path    => $facts['path'],

--- a/spec/acceptance/apt_keyring_spec.rb
+++ b/spec/acceptance/apt_keyring_spec.rb
@@ -40,6 +40,7 @@ describe 'apt::keyring' do
 
     it 'updates GPG key' do
       retry_on_error_matching do
+        idempotent_apply(keyring_pp)
         res = run_shell('gpg --show-keys --list-options show-sig-expire /etc/apt/keyrings/puppetlabs-keyring.gpg | grep expired')
         expect(res.stdout.strip).to eq('')
       end

--- a/spec/acceptance/apt_keyring_spec.rb
+++ b/spec/acceptance/apt_keyring_spec.rb
@@ -25,4 +25,24 @@ describe 'apt::keyring' do
       end
     end
   end
+
+  context 'when using refreshed GPG' do
+    # add expired GPG key
+    before(:each) do
+      run_shell('curl https://apt.puppetlabs.com/DEB-GPG-KEY-puppet | gpg --dearmor >/etc/apt/keyrings/puppetlabs-keyring.gpg')
+    end
+    keyring_pp = <<-MANIFEST
+      apt::keyring { 'puppetlabs-keyring.gpg':
+        ensure => 'refreshed',
+        source => 'https://apt.puppetlabs.com/keyring.gpg',
+      }
+    MANIFEST
+
+    it 'updates GPG key' do
+      retry_on_error_matching do
+        res = run_shell('gpg --show-keys --list-options show-sig-expire /etc/apt/keyrings/puppetlabs-keyring.gpg | grep expired')
+        expect(res.stdout.strip).to eq('')
+      end
+    end
+  end
 end

--- a/spec/defines/keyring_spec.rb
+++ b/spec/defines/keyring_spec.rb
@@ -17,4 +17,21 @@ describe 'apt::keyring' do
       it { is_expected.to compile }
     end
   end
+
+  describe 'ensure => refreshed' do
+    let :params do
+      {
+        ensure: 'refreshed',
+        name: 'puppetlabs.gpg',
+        source: 'http://apt.puppetlabs.com/pubkey.gpg',
+      }
+    end
+
+    it {
+      is_expected.to contain_exec('check_keyring_puppetlabs.gpg').with(
+      command: 'rm /etc/apt/keyrings/puppetlabs.gpg',
+      onlyif: 'test -f /etc/apt/keyrings/puppetlabs.gpg && gpg --show-keys --list-options show-sig-expire /etc/apt/keyrings/puppetlabs.gpg | grep expired',
+    )
+    }
+  end
 end


### PR DESCRIPTION
## Summary

Refresh (update) expired GPG key when using `apt::keyring`

## Related Issues (if any)
 - #1253

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)