### PR TITLE
add auth.conf.d resources

### DIFF
--- a/manifests/auth.pp
+++ b/manifests/auth.pp
@@ -1,0 +1,43 @@
+# @summary Manages the Apt auth conf in /etc/apt/auth.conf.d/.
+#
+# @example Install the puppetlabs apt auth
+#   apt::auth { 'puppetlabs':
+#     machine  => 'apt.puppetlabs.com',
+#     login    => 'apt',
+#     password => 'password',
+#   }
+#
+# @param ensure
+#   Specifies whether the Apt auth file should exist. Valid options: 'present' and 'absent'.
+#
+# @param machine
+#   The machine entry specifies the auth URI.
+#
+# @param login
+#   The username to be used.
+#
+# @param password
+#   The password to be used.
+#
+
+define apt::auth (
+  String $ensure   = 'present',
+  String $machine  = $name,
+  String $login    = undef,
+  String $password = undef,
+) {
+  $content = epp('apt/auth_conf.d.epp',
+    machine  => $machine,
+    login    => $login,
+    password => $password
+  )
+
+  file { "${apt::auth_conf_d}/${name}.conf":
+    ensure  => $ensure,
+    owner   => $apt::auth_conf_owner,
+    group   => 'root',
+    mode    => '0600',
+    content => Sensitive($content),
+    notify  => Class['apt::update'],
+  }
+}

--- a/spec/classes/apt_spec.rb
+++ b/spec/classes/apt_spec.rb
@@ -38,6 +38,14 @@ apt_conf_d = {    ensure: 'directory',
                   recurse: false,
                   notify: 'Class[Apt::Update]' }
 
+auth_conf_d = {   ensure: 'directory',
+                  path: '/etc/apt/auth.conf.d',
+                  owner: 'root',
+                  group: 'root',
+                  purge: false,
+                  recurse: false,
+                  notify: 'Class[Apt::Update]' }
+
 describe 'apt' do
   let(:facts) do
     {
@@ -75,6 +83,10 @@ describe 'apt' do
 
     it {
       expect(subject).to contain_file('apt.conf.d').that_notifies('Class[Apt::Update]').only_with(apt_conf_d)
+    }
+
+    it {
+      is_expected.to contain_file('auth.conf.d').that_notifies('Class[Apt::Update]').only_with(auth_conf_d)
     }
 
     it { is_expected.to contain_file('/etc/apt/auth.conf').with_ensure('absent') }

--- a/templates/auth_conf.d.epp
+++ b/templates/auth_conf.d.epp
@@ -1,0 +1,3 @@
+machine <%= $machine %>
+login <%= $login %>
+password <%= $password %>


### PR DESCRIPTION
## Summary
add auth.conf.d resources

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)