### PR TITLE
Include components when suite does not end with slash

### DIFF
--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -311,10 +311,15 @@ define apt::source (
         $_release = $release
       }
 
-      # The deb822 format requires that if the Suite ($release) is a path (contains a /) that
-      # the Components field be absent.  Check the original
-      $_releasefilter = $_release.any |$item| { $item.index('/') != undef }
-      if $_releasefilter {
+      # The deb822 format requires that if the Suite ends with a slash (/),
+      # the Components field must be omitted. Otherwise, Components is required.
+      # Mixing path-style (ending with /) and codename-style suites is invalid.
+      $_any_suites_end_with_slash = $_release.any |$item| { $item =~ /\/$/ }
+      $_all_suites_end_with_slash = $_release.all |$item| { $item =~ /\/$/ }
+      if $_any_suites_end_with_slash and !$_all_suites_end_with_slash {
+        fail("apt::source ${name}: Mixing path-style suites (ending with /) and codename-style suites is not valid in deb822 format.")
+      }
+      if $_all_suites_end_with_slash {
         $_repos = undef
       } elsif $repos !~ Array {
         warning("For deb822 sources, 'repos' must be specified as an array. Converting to array.")

--- a/spec/defines/source_spec.rb
+++ b/spec/defines/source_spec.rb
@@ -436,6 +436,68 @@ describe 'apt::source' do
   end
 
   describe 'deb822 sources' do
+    context 'suite contains a slash but does not end with slash (should require Components)' do
+      let :params do
+        super().merge(
+          {
+            location: ['http://repo.mongodb.org/apt/debian'],
+            release: ['bookworm/mongodb-org/6.0'],
+            repos: ['main'],
+            keyring: '/etc/apt/keyrings/mongodb.gpg',
+          },
+        )
+      end
+
+      it { is_expected.to contain_apt__setting("sources-#{title}").with_content(%r{Suites: bookworm/mongodb-org/6.0}) }
+      it { is_expected.to contain_apt__setting("sources-#{title}").with_content(%r{Components: main}) }
+    end
+
+    context 'suite ends with slash (should omit Components)' do
+      let :params do
+        super().merge(
+          {
+            location: ['https://pkg.jenkins.io/debian-stable'],
+            release: ['binary/'],
+            repos: [],
+            keyring: '/etc/apt/keyrings/jenkins-keyring.asc',
+          },
+        )
+      end
+
+      it { is_expected.to contain_apt__setting("sources-#{title}").with_content(%r{Suites: binary/}) }
+      it { is_expected.to contain_apt__setting("sources-#{title}").without_content(%r{Components:}) }
+    end
+
+    context 'multiple suites, all end with slash (should omit Components)' do
+      let :params do
+        super().merge(
+          {
+            location: ['https://example.com/debian'],
+            release: ['foo/', 'bar/'],
+            repos: ['main'],
+            keyring: '/etc/apt/keyrings/example.gpg',
+          },
+        )
+      end
+
+      it { is_expected.to contain_apt__setting("sources-#{title}").with_content(%r{Suites: foo/ bar/}) }
+      it { is_expected.to contain_apt__setting("sources-#{title}").without_content(%r{Components:}) }
+    end
+
+    context 'multiple suites, not all end with slash (should raise error)' do
+      let :params do
+        super().merge(
+          {
+            location: ['https://example.com/debian'],
+            release: ['foo/', 'bar'],
+            repos: ['main'],
+            keyring: '/etc/apt/keyrings/example.gpg',
+          },
+        )
+      end
+
+      it { is_expected.to compile.and_raise_error(%r{Mixing path-style suites}) }
+    end
     let :params do
       {
         source_format: 'sources',


### PR DESCRIPTION
## Summary

Omit `Components` only when Suite ends with a slash.

## Additional Context

https://repolib.readthedocs.io/en/latest/deb822-format.html

## Related Issues (if any)

Fixes https://github.com/puppetlabs/puppetlabs-apt/issues/1252

## Checklist
- [x] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)