### PR TITLE
Added support for checksum and checksum_value

### DIFF
--- a/manifests/keyring.pp
+++ b/manifests/keyring.pp
@@ -32,6 +32,13 @@
 # @param ensure
 #   Ensure presence or absence of the resource.
 #
+# @param checksum
+#   The checksum type to use when determining whether to replace a file's contents.
+#
+# @param checksum_value
+#   The checksum of the source contents. Only md5, sha256, sha224, sha384 and sha512 are supported when specifying this parameter.
+#   If this parameter is set, source_permissions will be assumed to be false, and ownership and permissions will not be read from source.
+#
 define apt::keyring (
   Stdlib::Absolutepath $dir = '/etc/apt/keyrings',
   String[1] $filename = $name,
@@ -39,6 +46,8 @@ define apt::keyring (
   Optional[Stdlib::Filesource] $source = undef,
   Optional[String[1]] $content = undef,
   Enum['present','absent'] $ensure = 'present',
+  Enum['sha256', 'sha256lite', 'md5', 'md5lite', 'sha1', 'sha1lite', 'sha512', 'sha384', 'sha224', 'mtime', 'ctime', 'none'] $checksum = 'sha256',
+  Optional[String[1]] $checksum_value = undef,
 ) {
   ensure_resource('file', $dir, { ensure => 'directory', mode => '0755', })
   if $source and $content {
@@ -52,12 +61,14 @@ define apt::keyring (
   case $ensure {
     'present': {
       file { $file:
-        ensure  => 'file',
-        mode    => $mode,
-        owner   => 'root',
-        group   => 'root',
-        source  => $source,
-        content => $content,
+        ensure         => 'file',
+        mode           => $mode,
+        owner          => 'root',
+        group          => 'root',
+        source         => $source,
+        content        => $content,
+        checksum       => $checksum,
+        checksum_value => $checksum_value,
       }
     }
     'absent': {


### PR DESCRIPTION
This allows the module to download remote files (http) without triggering a change every time puppet runs

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [x] Root cause and the steps to reproduce. (If applicable)
If you download a key from a keyserver (for example https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xd6811ed3adeeb8441af5aa8f4528b6cd9e61ef26), the keyring is downloaded every time
When providing the checksum of the contents of the expected file, a change is only triggered if the version on disk has changed.
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)