### PR TITLE
feat: allow disabling non DEB822 repos

### DIFF
--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -40,7 +40,7 @@
 #   DEB822: The package types this source manages.
 #
 # @param enabled
-#   DEB822: Enable or Disable the APT source.
+#   Enable or Disable the APT source.
 #
 # @param comment
 #   Supplies a comment for adding to the Apt source file.
@@ -105,7 +105,7 @@ define apt::source (
   Array[Enum['deb','deb-src'], 1, 2] $types = ['deb'],
   Optional[Variant[String[1], Array[String[1]]]] $location = undef,
   String[1] $comment = $name,
-  Boolean $enabled = true, # deb822
+  Boolean $enabled = true,
   Enum['present', 'absent'] $ensure = present,
   Optional[Variant[String[0], Array[String[0]]]] $release = undef,
   Variant[String[1], Array[String[1]]] $repos = 'main',
@@ -241,6 +241,7 @@ define apt::source (
 
       $source_content = epp('apt/source.list.epp', {
           'comment'          => $comment,
+          'enabled'          => $enabled,
           'includes'         => $includes,
           'options'          => delete_undef_values({
               'arch'              => $_architecture,

--- a/templates/source.list.epp
+++ b/templates/source.list.epp
@@ -1,8 +1,10 @@
-<%- | String $comment, Hash $includes, Hash $options, $location, String $components | -%>
+<%- | String $comment, Boolean $enabled, Hash $includes, Hash $options, $location, String $components | -%>
 # <%= $comment %>
 <%- if $includes['deb'] { -%>
+<%- unless $enabled { -%># <% } -%>
 deb <% if !$options.empty() { -%>[<%=  $options.map |$key, $value| { if !$value.empty() { "${key}=${value}" } }.join(" ") %>] <% } -%> <%= $location %> <%= $components %>
 <%- } -%>
 <%- if $includes['src'] { -%>
+<%- unless $enabled { -%># <% } -%>
 deb-src <% if !$options.empty() { -%>[<%=  $options.map |$key, $value| { if !$value.empty() { "${key}=${value}" } }.join(" ") %>] <% } -%> <%= $location %> <%= $components %>
 <%- } -%>


### PR DESCRIPTION
## Summary

The DEB822 apt repos have the feature built-in allowing to be enabled and disabled. With the non-DEB822 apt repos – by convention – the equivalent action is to comment out the line. This PR adds that capability to the `apt::source` class for the non-DEB822 repos.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)