### PR TITLE
use nightly build for acceptance module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,4 +14,6 @@ jobs:
   Acceptance:
     needs: Spec
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_acceptance.yml@main"
+    with:
+      flags: '--nightly'
     secrets: "inherit"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,5 +13,7 @@ jobs:
   Acceptance:
     needs: Spec
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_acceptance.yml@main"
+    with:
+      flags: '--nightly'
     secrets: "inherit"
 


### PR DESCRIPTION
## Summary

This pull request updates the GitHub Actions workflows to ensure that the acceptance tests are run with the `--nightly` flag in both the continuous integration and nightly workflows.

**Workflow configuration updates:**

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR17-R18): Added the `flags: '--nightly'` parameter to the Acceptance job to ensure nightly-specific tests or behaviors are triggered during CI runs.
* [`.github/workflows/nightly.yml`](diffhunk://#diff-0d5658b415099a82c11c03a06ca4ec765b4003a1f4b2f3f1943980a882cf8aa6R16-R17): Added the `flags: '--nightly'` parameter to the Acceptance job to ensure nightly-specific tests or behaviors are triggered during nightly runs.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)