### PR TITLE
Update community PR test workflow with CI approach

### DIFF
--- a/.github/workflows/community_pr_test.yml
+++ b/.github/workflows/community_pr_test.yml
@@ -17,27 +17,37 @@ permissions:
   issues: write
 
 jobs:
-  create-test-pr:
+  check-permission:
     if: |
       github.event_name == 'pull_request_target' &&
       contains(github.event.pull_request.labels.*.name, 'ok-to-test') &&
       github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
+    outputs:
+      authorized: ${{ steps.check.outputs.authorized }}
     steps:
       - name: Verify labeler has write access
+        id: check
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LABELER: ${{ github.event.sender.login }}
         run: |
           PERMISSION=$(gh api repos/${{ github.repository }}/collaborators/${LABELER}/permission --jq '.permission')
-          if [[ "$PERMISSION" != "write" && "$PERMISSION" != "admin" && "$PERMISSION" != "maintain" ]]; then
+          if [[ "$PERMISSION" == "write" || "$PERMISSION" == "admin" || "$PERMISSION" == "maintain" ]]; then
+            echo "authorized=true" >> "$GITHUB_OUTPUT"
+          else
             echo "${LABELER} has permission '${PERMISSION}' — removing label and notifying."
+            echo "authorized=false" >> "$GITHUB_OUTPUT"
             gh pr edit ${{ github.event.pull_request.number }} --remove-label "ok-to-test"
             gh pr comment ${{ github.event.pull_request.number }} \
               --body "The \`ok-to-test\` label can only be applied by maintainers. It has been removed."
-            exit 0
           fi
 
+  create-test-pr:
+    needs: check-permission
+    if: needs.check-permission.outputs.authorized == 'true'
+    runs-on: ubuntu-latest
+    steps:
       - name: Checkout community PR head
         uses: actions/checkout@v4
         with:
@@ -58,17 +68,19 @@ jobs:
             echo "failed=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Comment and exit on conflict
+      - name: Remove label and comment on conflict
         if: steps.rebase.outputs.failed == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMMUNITY_PR_NUMBER: ${{ github.event.pull_request.number }}
+          COMMUNITY_PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
+          gh pr edit "${COMMUNITY_PR_NUMBER}" --remove-label "ok-to-test"
           gh pr comment "${COMMUNITY_PR_NUMBER}" \
-            --body "Cannot run tests: this PR has merge conflicts with \`main\`. Please rebase and re-apply the \`ok-to-test\` label."
+            --body "@${COMMUNITY_PR_AUTHOR} Cannot run tests: this PR has merge conflicts with \`main\`. Please rebase."
           exit 1
 
-      - name: Push branch and open or update test PR
+      - name: Push branch, open or update test PR, and trigger CI
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMMUNITY_PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -79,8 +91,9 @@ jobs:
         run: |
           BRANCH="community-pr-test-${COMMUNITY_PR_NUMBER}"
 
-          echo "Community PR #${COMMUNITY_PR_NUMBER} from fork ${COMMUNITY_PR_FORK} — proceeding."
-
+          # Push rebased community PR code to a branch on this repo.
+          # ci.yml triggered via workflow_dispatch on this branch will run
+          # module_ci and module_acceptance against this code, not the fork.
           git push origin "HEAD:refs/heads/${BRANCH}" --force
 
           EXISTING=$(gh pr list --head "${BRANCH}" --state open --json number --jq '.[0].number')
@@ -88,21 +101,22 @@ jobs:
             echo "Updated branch for existing test PR #${EXISTING}."
             gh pr comment "${EXISTING}" \
               --body "Branch updated with latest commits from community PR #${COMMUNITY_PR_NUMBER}."
-            exit 0
+          else
+            PR_BODY=$(printf '%s\n\n%s\n%s\n%s\n\n%s' \
+              "Automated test PR to run CI on behalf of community PR #${COMMUNITY_PR_NUMBER}." \
+              "**Original PR:** ${COMMUNITY_PR_URL}" \
+              "**Author:** @${COMMUNITY_PR_AUTHOR}" \
+              "**Fork:** \`${COMMUNITY_PR_FORK}\`" \
+              "> **Note:** This PR was created automatically when the \`ok-to-test\` label was applied. Do not merge — close it once tests complete and review the original PR instead.")
+
+            gh pr create \
+              --title "[Test] Community PR #${COMMUNITY_PR_NUMBER}: ${COMMUNITY_PR_TITLE}" \
+              --body "${PR_BODY}" \
+              --base main \
+              --head "${BRANCH}"
           fi
 
-          PR_BODY=$(printf '%s\n\n%s\n%s\n%s\n\n%s' \
-            "Automated test PR to run CI on behalf of community PR #${COMMUNITY_PR_NUMBER}." \
-            "**Original PR:** ${COMMUNITY_PR_URL}" \
-            "**Author:** @${COMMUNITY_PR_AUTHOR}" \
-            "**Fork:** \`${COMMUNITY_PR_FORK}\`" \
-            "> **Note:** This PR was created automatically when the \`ok-to-test\` label was applied. Do not merge — close it once tests complete and review the original PR instead.")
-
-          gh pr create \
-            --title "[Test] Community PR #${COMMUNITY_PR_NUMBER}: ${COMMUNITY_PR_TITLE}" \
-            --body "${PR_BODY}" \
-            --base main \
-            --head "${BRANCH}"
+          gh workflow run ci.yml --ref "${BRANCH}"
 
   notify-on-failure:
     if: |
@@ -114,14 +128,13 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: ${{ github.event.workflow_run.head_branch }}
-          TEST_PR_URL: ${{ github.event.workflow_run.pull_requests[0].url }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
         run: |
-          # Extract the original PR number from the branch name (community-pr-test-<N>)
           COMMUNITY_PR_NUMBER="${BRANCH#community-pr-test-}"
 
           COMMENT_BODY=$(printf '%s\n\n%s\n%s' \
             "CI tests failed on the test PR for this community PR. Please review the failures and push a fix." \
-            "**Test PR:** ${TEST_PR_URL}" \
-            "**CI run:** ${{ github.event.workflow_run.html_url }}")
+            "**Test branch:** \`${BRANCH}\`" \
+            "**CI run:** ${RUN_URL}")
 
           gh pr comment "${COMMUNITY_PR_NUMBER}" --body "${COMMENT_BODY}"


### PR DESCRIPTION
- Push rebased code to community-pr-test-<N> branch and trigger ci.yml via workflow_dispatch so module_ci and module_acceptance run against the test branch, not the fork or main
- Split permission check into its own job with authorized output
- Remove ok-to-test label and tag author on rebase conflicts
- Replace workflow_run-based failure notification with direct comment

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)