### PR TITLE
(MODULES-11840) Allow puppetlabs/stdlib 10.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 9.0.0 < 10.0.0"
+      "version_requirement": ">= 9.0.0 < 11.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Part of MODULES-11840. Metadata-only change: stdlib dependency cap `< 10.0.0` -> `< 11.0.0` so this module installs alongside stdlib 10.x. No code change.