### PR TITLE
Add support for ACNG HTTPS proxy for DEB822 sources

### DIFF
--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -298,6 +298,21 @@ define apt::source (
         $_location = $location
       }
 
+      # Handle the HTTPS to HTTP trick for APT-Cacher-NG
+      if ($ensure == 'present') and ($apt::proxy['https_acng']) {
+        $__location = $_location.reduce([]) | Array $acng_locations, $loc | {
+          if $loc =~ /(?i:^https:\/\/)/ {
+            $patched_location = regsubst($loc, 'https://', 'http://HTTPS///')
+          } else {
+            $patched_location = $loc
+          }
+          $acng_locations + [$patched_location]
+        }
+      }
+      else {
+        $__location = $_location
+      }
+
       if !$release {
         if fact('os.distro.codename') {
           $_release = [fact('os.distro.codename')]
@@ -338,7 +353,7 @@ define apt::source (
         'present': {
           $header = epp('apt/_header.epp')
           $source_content = epp('apt/source_deb822.epp', delete_undef_values({
-                'uris'              => $_location,
+                'uris'              => $__location,
                 'suites'            => $_release,
                 'components'        => $_repos,
                 'types'             => $types,


### PR DESCRIPTION
## Summary

This is a reopen of PR #1242 since no response was given on https://github.com/puppetlabs/puppetlabs-apt/pull/1242#issuecomment-4476464884

This PR aim to provide the same functionality of HTTPS trick for APT Cacher NG that was not ported to the new DEB822 sources format. 

## Additional Context

This permit small and medium infrastructure switch to the new source format and keep the HTTPS caching through APT Cacher NG.

## Related Issues (if any)
None found.

## Checklist
- [x] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)