### PR TITLE
add checksum support to apt::keyring

### DIFF
--- a/manifests/keyring.pp
+++ b/manifests/keyring.pp
@@ -32,6 +32,12 @@
 # @param ensure
 #   Ensure presence or absence of the resource.
 #
+# @param checksum
+#   The checksum type to use when determining whether to replace the keyring file.
+#
+# @param checksum_value
+#   The checksum value to compare against. Only used when a matching checksum type is set.
+#
 define apt::keyring (
   Optional[Stdlib::Absolutepath] $dir = undef,
   String[1] $filename = $name,
@@ -39,6 +45,8 @@ define apt::keyring (
   Optional[Stdlib::Filesource] $source = undef,
   Optional[String[1]] $content = undef,
   Enum['present','absent'] $ensure = 'present',
+  Enum['sha256', 'sha256lite', 'md5', 'md5lite', 'sha1', 'sha1lite', 'sha512', 'sha384', 'sha224', 'mtime', 'ctime', 'none'] $checksum = 'sha256',
+  Optional[String[1]] $checksum_value = undef,
 ) {
   include apt
 
@@ -63,13 +71,15 @@ define apt::keyring (
   case $ensure {
     'present': {
       file { $file:
-        ensure  => 'file',
-        mode    => $mode,
-        owner   => 'root',
-        group   => 'root',
-        source  => $source,
-        content => $content,
-        require => $require_dir,
+        ensure         => 'file',
+        mode           => $mode,
+        owner          => 'root',
+        group          => 'root',
+        source         => $source,
+        content        => $content,
+        checksum       => $checksum,
+        checksum_value => $checksum_value,
+        require        => $require_dir,
       }
     }
     'absent': {

--- a/manifests/keyring.pp
+++ b/manifests/keyring.pp
@@ -68,27 +68,20 @@ define apt::keyring (
 
   $file = "${_dir}/${filename}"
 
-  case $ensure {
-    'present': {
-      file { $file:
-        ensure         => 'file',
-        mode           => $mode,
-        owner          => 'root',
-        group          => 'root',
-        source         => $source,
-        content        => $content,
-        checksum       => $checksum,
-        checksum_value => $checksum_value,
-        require        => $require_dir,
-      }
-    }
-    'absent': {
-      file { $file:
-        ensure => $ensure,
-      }
-    }
-    default: {
-      fail("Invalid 'ensure' value '${ensure}' for apt::keyring")
-    }
+  $file_ensure = $ensure ? {
+    'absent' => 'absent',
+    default  => 'file',
+  }
+
+  file { $file:
+    ensure         => $file_ensure,
+    mode           => $mode,
+    owner          => 'root',
+    group          => 'root',
+    source         => $source,
+    content        => $content,
+    checksum       => $checksum,
+    checksum_value => $checksum_value,
+    require        => $require_dir,
   }
 }

--- a/spec/defines/keyring_spec.rb
+++ b/spec/defines/keyring_spec.rb
@@ -86,6 +86,45 @@ describe 'apt::keyring' do
         }
       end
 
+      context 'with default checksum' do
+        it {
+          is_expected.to contain_file('/etc/apt/keyrings/puppetlabs-keyring.gpg').with(
+            checksum: 'sha256',
+            checksum_value: nil,
+          )
+        }
+      end
+
+      context 'with custom checksum and checksum_value' do
+        let(:params) do
+          {
+            source: 'http://apt.puppetlabs.com/pubkey.gpg',
+            checksum: 'md5',
+            checksum_value: 'd41d8cd98f00b204e9800998ecf8427e',
+          }
+        end
+
+        it {
+          is_expected.to contain_file('/etc/apt/keyrings/puppetlabs-keyring.gpg').with(
+            checksum: 'md5',
+            checksum_value: 'd41d8cd98f00b204e9800998ecf8427e',
+          )
+        }
+      end
+
+      context 'with an invalid checksum type' do
+        let(:params) do
+          {
+            source: 'http://apt.puppetlabs.com/pubkey.gpg',
+            checksum: 'bogus',
+          }
+        end
+
+        it {
+          is_expected.to raise_error(%r{parameter 'checksum'})
+        }
+      end
+
       context 'with ensure absent' do
         let(:params) do
           {


### PR DESCRIPTION
## Summary
This PR adds support for the `checksum` and `checksum_value` parameters to the `apt::keyring` defined type and passes them through to the underlying `file` resource.

The changes include:
- Adding `checksum` and `checksum_value` parameters.
- Documenting the new parameters.
- Passing both parameters to the managed `file` resource.
- Adding unit tests for the default behavior, custom values, and parameter validation.

## Additional Context
This change allows users to specify a checksum when managing keyring files. This is useful in cases where the remote key is republished without any content changes, causing Puppet to replace the file on every run.

- [x] Root cause and the steps to reproduce. (If applicable)
  - Some repositories republish their keyring files without changing the content, but with different metadata. As a result, Puppet continuously detects changes and replaces the file on every run.
- [x] Thought process behind the implementation.
  - Expose Puppet's existing `checksum` and `checksum_value` parameters through `apt::keyring` instead of introducing custom logic, keeping the implementation simple and consistent with the underlying `file` resource.

## Related Issues (if any)
Fixes: https://github.com/puppetlabs/puppetlabs-apt/issues/1196

## Checklist
- [x] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)